### PR TITLE
Bullet bill fix (EditorNPCFrame -> pass direction by reference)

### DIFF
--- a/lib/CrashHandler/crash_handler.cpp
+++ b/lib/CrashHandler/crash_handler.cpp
@@ -22,6 +22,7 @@
 #include <SDL2/SDL_version.h>
 #include <SDL2/SDL_mixer_ext.h>
 
+#include <exception>
 #include <cstdlib>
 #include <signal.h>
 

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -55,6 +55,7 @@ static void compatInit(Compatibility_t &c)
     c.enable_multipoints = true;
     c.fix_autoscroll_speed = false;
     c.fix_blooper_stomp_effect = true;
+    c.keep_bullet_bill_dir = true;
 
     if(g_speedRunnerMode >= SPEEDRUN_MODE_2) // Make sure that bugs were same as on SMBX2 Beta 4 on this moment
     {
@@ -74,6 +75,7 @@ static void compatInit(Compatibility_t &c)
         c.enable_multipoints = false;
         c.fix_autoscroll_speed = false;
         c.fix_blooper_stomp_effect = false;
+        c.keep_bullet_bill_dir = false;
     }
 
     if(g_speedRunnerMode >= SPEEDRUN_MODE_3) // Strict vanilla SMBX
@@ -120,6 +122,7 @@ static void loadCompatIni(Compatibility_t &c, const std::string &fileName)
         compat.read("enable-multipoints", c.enable_multipoints, c.enable_multipoints);
         compat.read("fix-autoscroll-speed", c.fix_autoscroll_speed, c.fix_autoscroll_speed);
         compat.read("fix-blooper-stomp-effect", c.fix_blooper_stomp_effect, c.fix_blooper_stomp_effect);
+        compat.read("keep-bullet-bill-direction", c.keep_bullet_bill_dir, c.keep_bullet_bill_dir);
     }
     compat.read("fix-player-filter-bounce", c.fix_player_filter_bounce, c.fix_player_filter_bounce);
     compat.read("fix-player-downward-clip", c.fix_player_downward_clip, c.fix_player_downward_clip);

--- a/src/compat.h
+++ b/src/compat.h
@@ -47,6 +47,7 @@ struct Compatibility_t
     bool enable_multipoints;
     bool fix_autoscroll_speed;
     bool fix_blooper_stomp_effect;
+    bool keep_bullet_bill_dir;
 };
 
 extern Compatibility_t g_compatibility;

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1893,7 +1893,7 @@ void UpdateInterprocess()
     IntProc::cmdUnLock();
 }
 
-int EditorNPCFrame(int A, float C, int N)
+int EditorNPCFrame(int A, float& C, int N)
 {
     int ret = 0;
 // find the default left/right frames for NPCs

--- a/src/editor.h
+++ b/src/editor.h
@@ -65,7 +65,7 @@ extern void UpdateEditor();
 
 extern void UpdateInterprocess();
 
-extern int EditorNPCFrame(int A, float C, int N = 0);
+extern int EditorNPCFrame(int A, float& C, int N = 0);
 
 extern void GetEditorControls();
 

--- a/src/npc/npc_update.cpp
+++ b/src/npc/npc_update.cpp
@@ -4442,6 +4442,8 @@ void UpdateNPCs()
                                 NPC[numNPCs].Inert = NPC[A].Inert;
                                 tempBool = false;
                                 NPC[numNPCs].Direction = NPC[A].Direction;
+                                if(g_compatibility.keep_bullet_bill_dir)
+                                    NPC[numNPCs].DefaultDirection = NPC[A].Direction;
                                 if(NPC[A].HoldingPlayer > 0 || NPC[A].standingOnPlayer > 0 || (NPC[A].Type == 22 && NPC[A].Projectile))
                                 {
                                     NPC[numNPCs].Projectile = true;


### PR DESCRIPTION
This fixes the bullet bill unfreezing issue #72 by bringing `EditorNPCFrame` in line with its vanilla behavior, which is to pass the NPC's direction by reference. This is a significant change, but it is how the original game functions.
Additionally, it adds a compat option to get the expected behavior, which is for cannon-fired bullet bills to keep their original direction after being frozen and thawed.