### PR TITLE
Fix Issue #171:

### DIFF
--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -1552,7 +1552,7 @@ void StartBattleMode()
     PGE_Delay(500);
     ClearLevel();
 
-    if(NumSelectWorld <= 1)
+    if(NumSelectBattle <= 1)
     {
         MessageText = "Can't start battle because of no levels available";
         PauseGame(1);
@@ -1561,13 +1561,13 @@ void StartBattleMode()
     else
     {
         if(selWorld == 1)
-            selWorld = (iRand(NumSelectWorld - 1)) + 2;
+            selWorld = (iRand(NumSelectBattle - 1)) + 2;
     }
 
-    std::string levelPath = SelectWorld[selWorld].WorldPath + SelectWorld[selWorld].WorldFile;
+    std::string levelPath = SelectBattle[selWorld].WorldPath + SelectBattle[selWorld].WorldFile;
     if(!OpenLevel(levelPath))
     {
-        MessageText = fmt::format_ne("ERROR: Can't open \"{0}\": file doesn't exist or corrupted.", SelectWorld[selWorld].WorldFile);
+        MessageText = fmt::format_ne("ERROR: Can't open \"{0}\": file doesn't exist or corrupted.", SelectBattle[selWorld].WorldFile);
         PauseGame(1);
         ErrorQuit = true;
     }

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -309,7 +309,7 @@ void FindLevels()
                 w.WorldName = head.LevelName;
                 if(w.WorldName.empty())
                     w.WorldName = fName;
-                SelectWorld.push_back(w);
+                SelectBattle.push_back(w);
             }
 #ifndef PGE_NO_THREADING
             SDL_AtomicAdd(&loadingProgrss, 1);
@@ -929,7 +929,8 @@ bool mainMenuUpdate()
                     }
                     else
                     {
-                        FindSaves();
+                        if(MenuMode != MENU_BATTLE_MODE)
+                            FindSaves();
 
                         For(A, 1, numCharacters)
                         {


### PR DESCRIPTION
- Use proper SelectBattle vectors to load battle levels from (game_main.cpp and menu_main.cpp) 
- DONT call FindSaves() if the MenuMode is MENU_BATTLE_MODE to prevent segmentation fault when selecting a level.

I have confirmed that these fixes allow me load and play Battle Mode levels on Linux. I have not yet tested on Vita. These changes were relatively minor so I have no reason to believe that this should not work on Vita. However, I am going to test anyway.

![image](https://user-images.githubusercontent.com/861492/131267836-9e5e5a26-13f3-4cd3-a34f-15b3cf1b6301.png)
