### PR TITLE
[FIX] Fix issue where newer BGOs crash the game.

### DIFF
--- a/src/main/level_file.cpp
+++ b/src/main/level_file.cpp
@@ -297,6 +297,13 @@ bool OpenLevelData(LevelData &lvl, const std::string FilePath)
         bgo.Location.X = double(b.x);
         bgo.Location.Y = double(b.y);
         bgo.Type = int(b.id);
+
+        if(IF_OUTRANGE(bgo.Type, 1, maxBackgroundType)) // Drop ID to 1 for BGOs of out of range IDs
+        {
+            pLogWarning("BGO-%d ID is out of range (max types %d), reset to BGO-1", bgo.Type, maxBackgroundType);
+            bgo.Type = 1;
+        }
+
         bgo.Layer = b.layer;
         bgo.Location.Width = GFXBackgroundWidth[bgo.Type];
         bgo.Location.Height = BackgroundHeight[bgo.Type];
@@ -307,12 +314,6 @@ bool OpenLevelData(LevelData &lvl, const std::string FilePath)
         bgo.zOffset = b.z_offset;
 
         bgoApplyZMode(&bgo, int(b.smbx64_sp));
-
-        if(IF_OUTRANGE(bgo.Type, 1, maxBackgroundType)) // Drop ID to 1 for BGOs of out of range IDs
-        {
-            pLogWarning("BGO-%d ID is out of range (max types %d), reset to BGO-1", bgo.Type, maxBackgroundType);
-            bgo.Type = 1;
-        }
     }
 
 


### PR DESCRIPTION
Fix unreported issue where loading SMBX2 episodes (Specifically Super Mario Flash Remake) would cause an assertion failure. This was due to newer BGOs being used in a level and the game trying to access GFXBackgroundWidth for out of range BGO. Solution involved shifting the block of IF_OUTRANGE to right after bgo.Type is set.