### PR TITLE
Devel mixer fixes

### DIFF
--- a/src/3ds/mixer_platform.cpp
+++ b/src/3ds/mixer_platform.cpp
@@ -60,7 +60,7 @@ bool MixPlatform_NoPreload(const char* path)
         return false;
 }
 
-void MixPlatform_PlayStream(int channel, const char* path, int loops)
+int MixPlatform_PlayStream(int channel, const char* path, int loops)
 {
     if(!cur_sound || channel < 0)
     {
@@ -71,6 +71,7 @@ void MixPlatform_PlayStream(int channel, const char* path, int loops)
         killSound(cur_sound[channel]);
         cur_sound[channel] = playSoundAuto(path, loops);
     }
+    return 0;
 }
 
 Mix_Chunk* MixPlatform_LoadWAV(const char* path)
@@ -83,8 +84,9 @@ const char* MixPlatform_GetError()
     return "";
 }
 
-void MixPlatform_PlayChannel(int channel, Mix_Chunk* chunk, int loops)
+int MixPlatform_PlayChannelTimed(int channel, Mix_Chunk *chunk, int loops, int ticks)
 {
+    (void)ticks;
     if(!cur_sound || channel < 0)
     {
         playSoundMem((WaveObject*)chunk, loops);
@@ -94,15 +96,23 @@ void MixPlatform_PlayChannel(int channel, Mix_Chunk* chunk, int loops)
     cur_sound[channel] = playSoundMem((WaveObject*)chunk, loops);
 }
 
+int MixPlatform_PlayChannelTimedVolume(int channel, Mix_Chunk *chunk, int loops, int ticks, int volume)
+{
+    (void)volume;
+    return MixPlatform_PlayChannelTimed(channel, chunk, loops, ticks);
+}
+
+
 extern "C" {
 
-void Mix_ReserveChannels(int channels)
+int Mix_ReserveChannels(int channels)
 {
     cur_sound = (SoundId*)malloc(sizeof(SoundId)*channels);
     for(int i = 0; i < channels; i++)
     {
         cur_sound[i] = INVALID_ID;
     }
+    return 0;
 }
 
 void Mix_PauseAudio(int pause)
@@ -125,14 +135,16 @@ int Mix_VolumeMusicStream(Mix_Music* music, int volume)
     return 0;
 }
 
-void Mix_HaltMusicStream(Mix_Music* music)
+int Mix_HaltMusicStream(Mix_Music* music)
 {
     killSound((SoundId)music);
+    return 0;
 }
-void Mix_FadeOutMusicStream(Mix_Music* music, int ms)
+int Mix_FadeOutMusicStream(Mix_Music* music, int ms)
 {
     (void)ms;
     killSound((SoundId)music);
+    return 0;
 }
 int Mix_HaltChannel(int channel)
 {
@@ -145,19 +157,21 @@ int Mix_PlayingMusicStream(Mix_Music* music)
 {
     (void)music;
     // no problem on 3DS
-    return false;
+    return 0;
 }
 
-void Mix_PlayMusic(Mix_Music* music, int loops)
+int Mix_PlayMusic(Mix_Music* music, int loops)
 {
     (void)music;
     (void)loops;
+    return 0;
 }
-void Mix_FadeInMusic(Mix_Music* music, int loops, int fadeInMs)
+int Mix_FadeInMusic(Mix_Music* music, int loops, int fadeInMs)
 {
     (void)music;
     (void)loops;
     (void)fadeInMs;
+    return 0;
 }
 
 int Mix_GetMusicTracks(Mix_Music* music)
@@ -166,11 +180,12 @@ int Mix_GetMusicTracks(Mix_Music* music)
     return 1;
 }
 
-void Mix_SetMusicTrackMute(Mix_Music* music, int track, int mute)
+int Mix_SetMusicTrackMute(Mix_Music* music, int track, int mute)
 {
     (void)music;
     (void)track;
     (void)mute;
+    return 0;
 }
 
 void Mix_FreeMusic(Mix_Music* music)

--- a/src/mixer_imports.h
+++ b/src/mixer_imports.h
@@ -28,34 +28,44 @@ bool MixPlatform_NoPreload(const char* path);
 void MixPlatform_PlayStream(int channel, const char* path, int loops);
 
 // need to do this because LoadWAV is not properly declared in MixerX.
+#define Mix_LoadWAV(file)   MixPlatform_LoadWAV(file);
 Mix_Chunk* MixPlatform_LoadWAV(const char* path);
+
+#define Mix_GetError MixPlatform_GetError
 const char* MixPlatform_GetError();
-void MixPlatform_PlayChannel(int channel, Mix_Chunk* chunk, int loops);
+
+#define Mix_PlayChannel(channel,chunk,loops) MixPlatform_PlayChannelTimed(channel,chunk,loops,-1)
+int MixPlatform_PlayChannelTimed(int channel, Mix_Chunk *chunk, int loops, int ticks);
+
+#define Mix_PlayChannelVol(channel,chunk,loops,vol) MixPlatform_PlayChannelTimedVolume(channel,chunk,loops,-1,vol)
+int MixPlatform_PlayChannelTimedVolume(int which, Mix_Chunk *chunk, int loops, int ticks, int volume);
 
 extern "C" {
 
-void Mix_ReserveChannels(int channels);
-void Mix_PauseAudio(int pause);
+extern int Mix_ReserveChannels(int channels);
+extern void Mix_PauseAudio(int pause);
 
 
-Mix_Music* Mix_LoadMUS(const char* path);
+extern Mix_Music* Mix_LoadMUS(const char* path);
 
-int Mix_VolumeMusicStream(Mix_Music* music, int volume);
-void Mix_HaltMusicStream(Mix_Music* music);
-void Mix_FadeOutMusicStream(Mix_Music* music, int ms);
-int Mix_HaltChannel(int channel);
+extern int Mix_VolumeMusicStream(Mix_Music* music, int volume);
+extern int Mix_HaltMusicStream(Mix_Music* music);
+extern int Mix_FadeOutMusicStream(Mix_Music* music, int ms);
+extern int Mix_HaltChannel(int channel);
 
-int Mix_PlayingMusicStream(Mix_Music* music);
+extern int Mix_PlayingMusicStream(Mix_Music* music);
 
-void Mix_PlayMusic(Mix_Music* music, int loops);
-void Mix_FadeInMusic(Mix_Music* music, int loops, int fadeInMs);
+extern int Mix_PlayMusic(Mix_Music *music, int loops);
+extern int Mix_FadeInMusic(Mix_Music* music, int loops, int fadeInMs);
+extern int Mix_SetFreeOnStop(Mix_Music *music, int free_on_stop);
 
-int Mix_GetMusicTracks(Mix_Music* music);
+extern int Mix_PlayMusicStream(Mix_Music *music, int loops);
 
-void Mix_SetMusicTrackMute(Mix_Music* music, int track, int mute);
+extern int Mix_GetMusicTracks(Mix_Music* music);
 
-void Mix_FreeMusic(Mix_Music* music);
-void Mix_FreeChunk(Mix_Chunk* chunk);
+extern int Mix_SetMusicTrackMute(Mix_Music* music, int track, int mute);
 
+extern void Mix_FreeMusic(Mix_Music* music);
+extern void Mix_FreeChunk(Mix_Chunk* chunk);
 
 } // extern "C"

--- a/src/mixer_platform.cpp
+++ b/src/mixer_platform.cpp
@@ -93,15 +93,24 @@ bool MixPlatform_NoPreload(const char *path)
     return false;
 }
 
-void MixPlatform_PlayStream(int channel, const char *path, int loops)
+int MixPlatform_PlayStream(int channel, const char *path, int loops)
 {
+    int ret;
     (void)channel;
+
     Mix_Music *mus = Mix_LoadMUS(path);
+
     if(!mus)
-        return;
-    Mix_PlayMusicStream(mus, loops);
-    Mix_SetFreeOnStop(mus, 1);
-    return;
+        return -1;
+
+    ret = Mix_PlayMusicStream(mus, loops);
+
+    if(ret < 0)
+        Mix_FreeMusic(mus);
+    else
+        Mix_SetFreeOnStop(mus, 1);
+
+    return ret;
 }
 
 Mix_Chunk *MixPlatform_LoadWAV(const char *path)
@@ -114,7 +123,12 @@ const char *MixPlatform_GetError()
     return Mix_GetError();
 }
 
-void MixPlatform_PlayChannel(int channel, Mix_Chunk *chunk, int loops)
+int MixPlatform_PlayChannelTimed(int channel, Mix_Chunk *chunk, int loops, int ticks)
 {
-    Mix_PlayChannel(channel, chunk, loops);
+    return Mix_PlayChannelTimed(channel, chunk, loops, ticks);
+}
+
+int MixPlatform_PlayChannelTimedVolume(int channel, Mix_Chunk *chunk, int loops, int ticks, int volume)
+{
+    return Mix_PlayChannelTimedVolume(channel, chunk, loops, ticks, volume);
 }

--- a/src/mixer_platform.cpp
+++ b/src/mixer_platform.cpp
@@ -40,81 +40,81 @@ static const int maxSfxChannels = 91;
 
 bool MixPlatform_Init()
 {
-	int ret;
-	const int initFlags = MIX_INIT_MID|MIX_INIT_MOD|MIX_INIT_FLAC|MIX_INIT_OGG|MIX_INIT_OPUS|MIX_INIT_MP3;
-	pLogDebug("Opening sound...");
-	ret = Mix_Init(initFlags);
+    int ret;
+    const int initFlags = MIX_INIT_MID | MIX_INIT_MOD | MIX_INIT_FLAC | MIX_INIT_OGG | MIX_INIT_OPUS | MIX_INIT_MP3;
+    pLogDebug("Opening sound...");
+    ret = Mix_Init(initFlags);
 
-	if(ret != initFlags)
-	{
-	    pLogWarning("MixerX: Some modules aren't properly initialized");
-	    if((initFlags & MIX_INIT_MID) != MIX_INIT_MID)
-	        pLogWarning("MixerX: Failed to initialize MIDI module");
-	    if((initFlags & MIX_INIT_MOD) != MIX_INIT_MOD)
-	        pLogWarning("MixerX: Failed to initialize Tracker music module");
-	    if((initFlags & MIX_INIT_FLAC) != MIX_INIT_FLAC)
-	        pLogWarning("MixerX: Failed to initialize FLAC module");
-	    if((initFlags & MIX_INIT_OGG) != MIX_INIT_OGG)
-	        pLogWarning("MixerX: Failed to initialize OGG Vorbis module");
-	    if((initFlags & MIX_INIT_OPUS) != MIX_INIT_OPUS)
-	        pLogWarning("MixerX: Failed to initialize Opus module");
-	    if((initFlags & MIX_INIT_MP3) != MIX_INIT_MP3)
-	        pLogWarning("MixerX: Failed to initialize MP3 module");
-	}
+    if(ret != initFlags)
+    {
+        pLogWarning("MixerX: Some modules aren't properly initialized");
+        if((initFlags & MIX_INIT_MID) != MIX_INIT_MID)
+            pLogWarning("MixerX: Failed to initialize MIDI module");
+        if((initFlags & MIX_INIT_MOD) != MIX_INIT_MOD)
+            pLogWarning("MixerX: Failed to initialize Tracker music module");
+        if((initFlags & MIX_INIT_FLAC) != MIX_INIT_FLAC)
+            pLogWarning("MixerX: Failed to initialize FLAC module");
+        if((initFlags & MIX_INIT_OGG) != MIX_INIT_OGG)
+            pLogWarning("MixerX: Failed to initialize OGG Vorbis module");
+        if((initFlags & MIX_INIT_OPUS) != MIX_INIT_OPUS)
+            pLogWarning("MixerX: Failed to initialize Opus module");
+        if((initFlags & MIX_INIT_MP3) != MIX_INIT_MP3)
+            pLogWarning("MixerX: Failed to initialize MP3 module");
+    }
 
-	ret = Mix_OpenAudio(g_audioSetup.sampleRate,
-	                    g_audioSetup.format,
-	                    g_audioSetup.channels,
-	                    g_audioSetup.bufferSize);
+    ret = Mix_OpenAudio(g_audioSetup.sampleRate,
+                        g_audioSetup.format,
+                        g_audioSetup.channels,
+                        g_audioSetup.bufferSize);
 
-	if(ret < 0)
-	{
-	    std::string msg = fmt::format_ne("Can't open audio stream, continuing without audio: ({0})", Mix_GetError());
-	    pLogCritical(msg.c_str());
-	    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Sound opening error", msg.c_str(), nullptr);
-	    return false;
-	}
+    if(ret < 0)
+    {
+        std::string msg = fmt::format_ne("Can't open audio stream, continuing without audio: ({0})", Mix_GetError());
+        pLogCritical(msg.c_str());
+        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Sound opening error", msg.c_str(), nullptr);
+        return false;
+    }
 
-	Mix_VolumeMusic(MIX_MAX_VOLUME);
-	Mix_AllocateChannels(maxSfxChannels);
+    Mix_VolumeMusic(MIX_MAX_VOLUME);
+    Mix_AllocateChannels(maxSfxChannels);
 
-	return true;
+    return true;
 }
 
 void MixPlatform_Quit()
 {
-	Mix_CloseAudio();
-	Mix_Quit();
+    Mix_CloseAudio();
+    Mix_Quit();
 }
 
-bool MixPlatform_NoPreload(const char* path)
+bool MixPlatform_NoPreload(const char *path)
 {
-	(void)path;
-	return false;
+    (void)path;
+    return false;
 }
 
-void MixPlatform_PlayStream(int channel, const char* path, int loops)
+void MixPlatform_PlayStream(int channel, const char *path, int loops)
 {
-	(void)channel;
-	Mix_Music* mus = Mix_LoadMUS(path);
-	if(!mus)
-		return;
-	Mix_PlayMusicStream(mus, loops);
-	Mix_SetFreeOnStop(mus, 1);
-	return;
+    (void)channel;
+    Mix_Music *mus = Mix_LoadMUS(path);
+    if(!mus)
+        return;
+    Mix_PlayMusicStream(mus, loops);
+    Mix_SetFreeOnStop(mus, 1);
+    return;
 }
 
-Mix_Chunk* MixPlatform_LoadWAV(const char* path)
+Mix_Chunk *MixPlatform_LoadWAV(const char *path)
 {
-	return Mix_LoadWAV(path);
+    return Mix_LoadWAV(path);
 }
 
-const char* MixPlatform_GetError()
+const char *MixPlatform_GetError()
 {
-	return Mix_GetError();
+    return Mix_GetError();
 }
 
-void MixPlatform_PlayChannel(int channel, Mix_Chunk* chunk, int loops)
+void MixPlatform_PlayChannel(int channel, Mix_Chunk *chunk, int loops)
 {
-	Mix_PlayChannel(channel, chunk, loops);
+    Mix_PlayChannel(channel, chunk, loops);
 }

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -226,7 +226,7 @@ static void AddSfx(const std::string &root,
                 m.customPath = newPath;
                 bool no_preload = MixPlatform_NoPreload((root + f).c_str());
                 if(!no_preload && !isSilent)
-                    m.chunk = MixPlatform_LoadWAV((root + f).c_str());
+                    m.chunk = Mix_LoadWAV((root + f).c_str());
                 if(no_preload || m.chunk || isSilent)
                 {
                     if(!m.isCustom && !m.chunkOrig)
@@ -243,7 +243,7 @@ static void AddSfx(const std::string &root,
                 {
                     m.chunk = backup;
                     m.isSilent = backup_isSilent;
-                    pLogWarning("ERROR: SFX '%s' loading error: %s", m.path.c_str(), MixPlatform_GetError());
+                    pLogWarning("ERROR: SFX '%s' loading error: %s", m.path.c_str(), Mix_GetError());
                 }
             }
         }
@@ -256,7 +256,7 @@ static void AddSfx(const std::string &root,
             pLogDebug("Adding SFX [%s] '%s'", alias.c_str(), isSilent ? "<silence>" : m.path.c_str());
             bool no_preload = MixPlatform_NoPreload(m.path.c_str());
             if(!isSilent && !no_preload)
-                m.chunk = MixPlatform_LoadWAV(m.path.c_str());
+                m.chunk = Mix_LoadWAV(m.path.c_str());
             m.channel = -1;
             if(no_preload || m.chunk || isSilent)
             {
@@ -268,7 +268,7 @@ static void AddSfx(const std::string &root,
             }
             else
             {
-                pLogWarning("ERROR: SFX '%s' loading error: %s", m.path.c_str(), MixPlatform_GetError());
+                pLogWarning("ERROR: SFX '%s' loading error: %s", m.path.c_str(), Mix_GetError());
                 if(!isCustom)
                     g_errorsSfx++;
             }
@@ -359,7 +359,7 @@ void PlayMusic(std::string Alias, int fadeInMs)
         processPathArgs(p, FileNamePath, FileName + "/");
         g_curMusic = Mix_LoadMUS(p.c_str());
         if(!g_curMusic)
-            pLogWarning("Music '%s' opening error: %s", m.path.c_str(), MixPlatform_GetError());
+            pLogWarning("Music '%s' opening error: %s", m.path.c_str(), Mix_GetError());
         else
         {
             Mix_VolumeMusicStream(g_curMusic, m.volume);
@@ -382,7 +382,7 @@ void PlaySfx(std::string Alias, int loops)
         auto &s = sfx->second;
         if(!s.isSilent && s.chunk)
         {
-            MixPlatform_PlayChannel(s.channel, s.chunk, loops);
+            Mix_PlayChannel(s.channel, s.chunk, loops);
         }
         else if(!s.isSilent && s.isCustom)
         {


### PR DESCRIPTION
I made some check out and I made my own fixes on this:
- Please keep the code with 4 spaces than tabs
- Keep call sigantures same (they should return int to indicate the possible error: 0 the fne, and -1 an error)
- If call "didn't properly declared", use the same macro as in original header, but instead of Mixer'x call, pass any your equivalent call