### PR TITLE
[VITA] Fix for Mangled Render Rects, Add Support for Drawing Unfilled Rects.

### DIFF
--- a/src/vita/frm_main.cpp
+++ b/src/vita/frm_main.cpp
@@ -822,13 +822,13 @@ void FrmMain::renderRect(int x, int y, int w, int h, float red, float green, flo
 {
     (void)filled;
     // TODO: Filled or not?
-    PGE_RectF rect = __NormalizeToGL(x + viewport_offset_x, y + viewport_offset_y, w, h, viewport_w, viewport_h);
+    PGE_RectF rect = __NormalizeToGL(x + viewport_offset_x, y + viewport_offset_y, w, h, ScreenW, ScreenH);
     Vita_DrawRectColor(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, red, green, blue, alpha);
 }
 
 void FrmMain::renderRectBR(int _left, int _top, int _right, int _bottom, float red, float green, float blue, float alpha)
 {
-    PGE_RectF rect = __NormalizeToGL(_left + viewport_offset_x, _top + viewport_offset_y, _right - _left, _bottom - _top, viewport_w, viewport_h);
+    PGE_RectF rect = __NormalizeToGL(_left + viewport_offset_x, _top + viewport_offset_y, _right - _left, _bottom - _top, ScreenW, ScreenH);
     Vita_DrawRectColor(rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, red, green, blue, alpha);
 }
 
@@ -942,7 +942,7 @@ void FrmMain::renderTexturePrivate(float xDst, float yDst, float wDst, float hDs
         pLogDebug("WARNING: texture IDs differ for a specific drawcall: %u %u.", tx.texture, tx.ex_data.textureID);
     }
 
-    PGE_RectF dest = __NormalizeToGL(xDst + viewport_offset_x, yDst + viewport_offset_y, wDst, hDst, DISPLAY_WIDTH_DEF, DISPLAY_HEIGHT_DEF);
+    PGE_RectF dest = __NormalizeToGL(xDst + viewport_offset_x, yDst + viewport_offset_y, wDst, hDst, ScreenW, ScreenH);
     PGE_RectF src;
     if(tx.w_orig == 0 && tx.h_orig == 0)
         src = {xSrc, ySrc, wSrc, hSrc};

--- a/src/vita/frm_main.cpp
+++ b/src/vita/frm_main.cpp
@@ -823,13 +823,13 @@ void FrmMain::renderRect(int x, int y, int w, int h, float red, float green, flo
     (void)filled;
     // TODO: Filled or not?
     PGE_RectF rect = __NormalizeToGL(x + viewport_offset_x, y + viewport_offset_y, w, h, ScreenW, ScreenH);
-    Vita_DrawRectColor(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, red, green, blue, alpha);
+    Vita_DrawRectColor(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, red, green, blue, alpha, filled);
 }
 
 void FrmMain::renderRectBR(int _left, int _top, int _right, int _bottom, float red, float green, float blue, float alpha)
 {
     PGE_RectF rect = __NormalizeToGL(_left + viewport_offset_x, _top + viewport_offset_y, _right - _left, _bottom - _top, ScreenW, ScreenH);
-    Vita_DrawRectColor(rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, red, green, blue, alpha);
+    Vita_DrawRectColor(rect.left, rect.top, rect.right-rect.left, rect.bottom-rect.top, red, green, blue, alpha, true);
 }
 
 void FrmMain::renderTexturePrivate(float xDst, float yDst, float wDst, float hDst,

--- a/src/vita/vgl_renderer.h
+++ b/src/vita/vgl_renderer.h
@@ -193,8 +193,8 @@ void Vita_DrawRectColor(float x, float y,
                         float _r,
                         float _g,
                         float _b,
-                        float _a
-);
+                        float _a,
+                        char filled);
 
 /**
  * Vita_DrawRect4xColor():
@@ -206,7 +206,8 @@ void Vita_DrawRect4xColor(float x, float y,
                           float rgba0[4],
                           float rgba1[4],
                           float rgba2[4],
-                          float rgba3[4]
+                          float rgba3[4],
+                          char filled
 );
 
 /**


### PR DESCRIPTION
I present two humble commits based off of the `devel` branch that fix 2 Vita issues on my end.
All files in this patch edit only Vita specific files luckily :+1: 

## First issue
![image](https://user-images.githubusercontent.com/861492/135731799-cb107293-27f0-4ebe-976a-98fff450d307.png)

As pointed out by ds-sloth, Vita clearly had a problem with its `FrmMain::renderRect` function. Upon closer inspection of my code, I discovered that I was naively normalizing coordinates passed into `renderRect` against the current `viewport_(width/height)`. Thus, resulting in the stretched screen. 

After fix, on real hardware:
![VITA_VIEWPORT_FIXED](https://user-images.githubusercontent.com/861492/135731883-e1f5dd5b-0729-4035-9b87-a87bae3a25a8.jpg)


## Second Issue
![image](https://user-images.githubusercontent.com/861492/135731895-cd8a4cb1-9ba2-4a5e-9ba1-43dd72eaa028.png)

The second issue fixed in this PR is the Vita's lack of unfilled rectangles. This made me realize some of the short comings of my specialized vgl_renderer.c object, however I found a way to make it work *for now* and not throw off the stride of my glDrawArrays call. 
However, marking draw calls as filled or unfilled was the difficult part. Once I found a decent way to do that, it was a simple matter of setting the draw mode to `GL_LINE_LOOP` (![good ref](http://cse.csusb.edu/tongyu/courses/cs420/notes/drawing.php)) and swapping the last two vertices.

After fix, again on real hardware:
![image](https://user-images.githubusercontent.com/861492/135731924-0f04ca14-16f2-4608-bf8e-04eeffdc8e19.png)

I have tested these fixes on my personal Vita with `-DCMAKE_BUILD_TYPE=Release` and they work as intended. In Discord, I aluded to the right side borders disappearing on single screen levels. I believe this is due to a tainted SDK setup on my MacBook Pro, where I was working when I made that discovery. Re-building the fixes from scratch on my Linux machine seems to produce much better results.

Here is a pre-compiled VPK in `Release` configuration for anyone to try out:
[thextech_Release.zip](https://github.com/Wohlstand/TheXTech/files/7272244/thextech_Release.zip)

