### PR TITLE
Get rid of all ugly "X = X + n"-like formulas, making normal use of +=/-= operators

### DIFF
--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -419,14 +419,14 @@ void BlockHit(int A, bool HitDown, int whatPlayer)
             }
             else
             {
-                Coins = Coins + 1;
+                Coins += 1;
                 if(Coins >= 100)
                 {
                     if(Lives < 99)
                     {
-                        Lives = Lives + 1;
+                        Lives += 1;
                         PlaySound(SFX_1up);
-                        Coins = Coins - 100;
+                        Coins -= 100;
                     }
                     else
                     {
@@ -435,7 +435,7 @@ void BlockHit(int A, bool HitDown, int whatPlayer)
                 }
                 PlaySound(SFX_Coin);
                 NewEffect(11, b.Location);
-                b.Special = b.Special - 1;
+                b.Special -= 1;
             }
         }
         else if(b.RapidHit > 0) // (whatPlayer > 0 And Player(whatPlayer).Character = 3)
@@ -483,18 +483,18 @@ void BlockHit(int A, bool HitDown, int whatPlayer)
                 NPC[numNPCs].Immune = 20;
                 PlaySound(SFX_Coin);
                 CheckSectionNPC(numNPCs);
-                b.Special = b.Special - 1;
+                b.Special -= 1;
             }
             else
             {
-                Coins = Coins + 1;
+                Coins += 1;
                 if(Coins >= 100)
                 {
                     if(Lives < 99)
                     {
-                        Lives = Lives + 1;
+                        Lives += 1;
                         PlaySound(SFX_1up);
-                        Coins = Coins - 100;
+                        Coins -= 100;
                     }
                     else
                     {
@@ -503,13 +503,13 @@ void BlockHit(int A, bool HitDown, int whatPlayer)
                 }
                 PlaySound(SFX_Coin);
                 NewEffect(11, b.Location);
-                b.Special = b.Special - 1;
+                b.Special -= 1;
             }
 
         }
         else
         {
-            Coins = Coins + 1;
+            Coins += 1;
             if(Coins >= 100)
             {
                 if(Lives < 99)
@@ -525,7 +525,7 @@ void BlockHit(int A, bool HitDown, int whatPlayer)
             }
             PlaySound(SFX_Coin);
             NewEffect(11, b.Location);
-            b.Special = b.Special - 1;
+            b.Special -= 1;
         }
 
         if(b.Special == 0 && !(b.Type == 55))
@@ -675,8 +675,8 @@ void BlockHit(int A, bool HitDown, int whatPlayer)
             // Make block a bit smaller to allow player take a bonus easier (Redigit's idea)
             if(fEqual(b.Location.Width, 32) && !b.wasShrinkResized)
             {
-                b.Location.Width = b.Location.Width - 0.1;
-                b.Location.X = b.Location.X + 0.05;
+                b.Location.Width -= 0.1;
+                b.Location.X += 0.05;
                 b.wasShrinkResized = true; // Don't move it!!!
             }
 
@@ -1341,8 +1341,8 @@ void BlockHit(int A, bool HitDown, int whatPlayer)
         NPC[numNPCs].Location = b.Location;
         NPC[numNPCs].Location.Width = NPCWidth[NPC[numNPCs].Type];
         NPC[numNPCs].Location.Height = NPCHeight[NPC[numNPCs].Type];
-        NPC[numNPCs].Location.X = NPC[numNPCs].Location.X + (b.Location.Width - NPC[numNPCs].Location.Width) / 2.0;
-        NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y - 0.01;
+        NPC[numNPCs].Location.X += (b.Location.Width - NPC[numNPCs].Location.Width) / 2.0;
+        NPC[numNPCs].Location.Y -= 0.01;
         NPC[numNPCs].DefaultLocation = NPC[numNPCs].Location;
         NPC[numNPCs].DefaultType = NPC[numNPCs].Type;
         CheckSectionNPC(numNPCs);
@@ -1397,7 +1397,7 @@ void BlockShakeDown(int A)
 
     if(A != iBlock[iBlocks])
     {
-        iBlocks = iBlocks + 1;
+        iBlocks += 1;
         iBlock[iBlocks] = A;
     }
 }
@@ -1416,7 +1416,7 @@ void BlockHitHard(int A)
     else
     {
         Block[A].Kill = true;
-        iBlocks = iBlocks + 1;
+        iBlocks += 1;
         iBlock[iBlocks] = A;
     }
 }
@@ -1462,7 +1462,7 @@ void KillBlock(int A, bool Splode)
         {
             Block[A] = Block[numBlock];
             Block[numBlock] = blankBlock;
-            numBlock = numBlock - 1;
+            numBlock -= 1;
         }
     }
     else
@@ -1518,40 +1518,40 @@ void BlockFrames()
         return;
 
     // Update block frame counter
-    BlockFrame2[4] = BlockFrame2[4] + 1;
+    BlockFrame2[4] += 1;
     if(BlockFrame2[4] == 8)
         BlockFrame2[4] = 0;
-    BlockFrame2[5] = BlockFrame2[5] + 1;
+    BlockFrame2[5] += 1;
     if(BlockFrame2[5] == 8)
         BlockFrame2[5] = 0;
-    BlockFrame2[30] = BlockFrame2[30] + 1;
+    BlockFrame2[30] += 1;
     if(BlockFrame2[30] == 8)
         BlockFrame2[30] = 0;
-    BlockFrame2[55] = BlockFrame2[55] + 1;
+    BlockFrame2[55] += 1;
     if(BlockFrame2[55] == 8)
         BlockFrame2[55] = 0;
-    BlockFrame2[88] = BlockFrame2[88] + 1;
+    BlockFrame2[88] += 1;
     if(BlockFrame2[88] == 8)
         BlockFrame2[88] = 0;
-    BlockFrame2[109] = BlockFrame2[109] + 1;
+    BlockFrame2[109] += 1;
     if(BlockFrame2[109] == 4)
         BlockFrame2[109] = 0;
-    BlockFrame2[371] = BlockFrame2[371] + 1;
+    BlockFrame2[371] += 1;
     if(BlockFrame2[371] == 8)
         BlockFrame2[371] = 0;
-    BlockFrame2[379] = BlockFrame2[379] + 1;
+    BlockFrame2[379] += 1;
     if(BlockFrame2[379] >= 12)
         BlockFrame2[379] = 0;
     // Check if the block type is ready for the next frame
     if(BlockFrame2[4] == 0)
     {
-        BlockFrame[4] = BlockFrame[4] + 1;
+        BlockFrame[4] += 1;
         if(BlockFrame[4] == 4)
             BlockFrame[4] = 0;
     }
     if(BlockFrame2[5] == 0)
     {
-        BlockFrame[5] = BlockFrame[5] + 1;
+        BlockFrame[5] += 1;
         if(BlockFrame[5] == 4)
             BlockFrame[5] = 0;
     }
@@ -1614,7 +1614,7 @@ void BlockFrames()
             BlockFrame[631] = 4;
     }
 
-    BlockFrame2[626] = BlockFrame2[626] + 1;
+    BlockFrame2[626] += 1;
     if(BlockFrame2[626] < 8)
         BlockFrame[626] = 3;
     else if(BlockFrame2[626] < 16)
@@ -1651,21 +1651,21 @@ void BlockFrames()
 
     if(BlockFrame2[30] == 0)
     {
-        BlockFrame[30] = BlockFrame[30] + 1;
+        BlockFrame[30] += 1;
         if(BlockFrame[30] == 4)
             BlockFrame[30] = 0;
     }
 
     if(BlockFrame2[55] == 0)
     {
-        BlockFrame[55] = BlockFrame[55] + 1;
+        BlockFrame[55] += 1;
         if(BlockFrame[55] == 4)
             BlockFrame[55] = 0;
     }
 
     if(BlockFrame2[88] == 0)
     {
-        BlockFrame[88] = BlockFrame[88] + 1;
+        BlockFrame[88] += 1;
         if(BlockFrame[88] == 4)
             BlockFrame[88] = 0;
     }
@@ -1674,21 +1674,21 @@ void BlockFrames()
 
     if(BlockFrame2[109] == 0)
     {
-        BlockFrame[109] = BlockFrame[109] + 1;
+        BlockFrame[109] += 1;
         if(BlockFrame[109] == 8)
             BlockFrame[109] = 0;
     }
 
     if(BlockFrame2[371] == 0)
     {
-        BlockFrame[371] = BlockFrame[371] + 1;
+        BlockFrame[371] += 1;
         if(BlockFrame[371] == 8)
             BlockFrame[371] = 0;
     }
 
     if(BlockFrame2[379] == 0)
     {
-        BlockFrame[379] = BlockFrame[379] + 1;
+        BlockFrame[379] += 1;
         if(BlockFrame[379] == 4)
             BlockFrame[379] = 0;
     }
@@ -1697,7 +1697,7 @@ void BlockFrames()
     BlockFrame[381] = BlockFrame[379];
     BlockFrame[382] = BlockFrame[379];
 
-    BlockFrame2[530] = BlockFrame2[530] + 1;
+    BlockFrame2[530] += 1;
 
     if(BlockFrame2[530] <= 8)
         BlockFrame[530] = 0;
@@ -1732,20 +1732,20 @@ void BlockFrames()
         }
         if(BlockFrame[458] < 5 && tempBool == true)
         {
-            BlockFrame2[458] = BlockFrame2[458] + 1;
+            BlockFrame2[458] += 1;
             if(BlockFrame2[458] >= 4)
             {
                 BlockFrame2[458] = 0;
-                BlockFrame[458] = BlockFrame[458] + 1;
+                BlockFrame[458] += 1;
             }
         }
         else if(BlockFrame[458] > 0 && tempBool == false)
         {
-            BlockFrame2[458] = BlockFrame2[458] + 1;
+            BlockFrame2[458] += 1;
             if(BlockFrame2[458] >= 4)
             {
                 BlockFrame2[458] = 0;
-                BlockFrame[458] = BlockFrame[458] - 1;
+                BlockFrame[458] -= 1;
             }
         }
         else
@@ -1769,7 +1769,7 @@ void UpdateBlocks()
             // respawn
             if(Block[A].RespawnDelay > 0)
             {
-                Block[A].RespawnDelay = Block[A].RespawnDelay + 1;
+                Block[A].RespawnDelay += 1;
                 if(Block[A].RespawnDelay >= 65 * 60)
                 {
                     if(Block[A].DefaultType > 0 || Block[A].DefaultSpecial > 0 || Block[A].Layer == "Destroyed Blocks")
@@ -1832,8 +1832,8 @@ void UpdateBlocks()
 
         if(Block[iBlock[A]].ShakeY < 0) // Block Shake Up
         {
-            Block[iBlock[A]].ShakeY = Block[iBlock[A]].ShakeY + 2;
-            Block[iBlock[A]].ShakeY3 = Block[iBlock[A]].ShakeY3 - 2;
+            Block[iBlock[A]].ShakeY += 2;
+            Block[iBlock[A]].ShakeY3 -= 2;
 
             if(Block[iBlock[A]].ShakeY == 0)
             {
@@ -1858,8 +1858,8 @@ void UpdateBlocks()
         }
         else if(Block[iBlock[A]].ShakeY > 0) // Block Shake Down
         {
-            Block[iBlock[A]].ShakeY = Block[iBlock[A]].ShakeY - 2;
-            Block[iBlock[A]].ShakeY3 = Block[iBlock[A]].ShakeY3 + 2;
+            Block[iBlock[A]].ShakeY -= 2;
+            Block[iBlock[A]].ShakeY3 += 2;
 
             if(Block[iBlock[A]].ShakeY == 0)
             {
@@ -1885,19 +1885,19 @@ void UpdateBlocks()
         }
         else if(Block[iBlock[A]].ShakeY2 > 0) // Come back down
         {
-            Block[iBlock[A]].ShakeY2 = Block[iBlock[A]].ShakeY2 - 2;
-            Block[iBlock[A]].ShakeY3 = Block[iBlock[A]].ShakeY3 + 2;
+            Block[iBlock[A]].ShakeY2 -= 2;
+            Block[iBlock[A]].ShakeY3 += 2;
 
             if(Block[iBlock[A]].RapidHit > 0 && Block[iBlock[A]].Special > 0 && Block[iBlock[A]].ShakeY3 == 0)
             {
                 BlockHit(iBlock[A]);
-                Block[iBlock[A]].RapidHit = Block[iBlock[A]].RapidHit - 1;
+                Block[iBlock[A]].RapidHit -= 1;
             }
         }
         else if(Block[iBlock[A]].ShakeY2 < 0) // Go back up
         {
-            Block[iBlock[A]].ShakeY2 = Block[iBlock[A]].ShakeY2 + 2;
-            Block[iBlock[A]].ShakeY3 = Block[iBlock[A]].ShakeY3 - 2;
+            Block[iBlock[A]].ShakeY2 += 2;
+            Block[iBlock[A]].ShakeY3 -= 2;
         }
 
         if(Block[iBlock[A]].ShakeY3 != 0)
@@ -1987,7 +1987,7 @@ void UpdateBlocks()
                 if(Block[iBlock[A]].ShakeY3 == 0)
                 {
                     iBlock[A] = iBlock[iBlocks];
-                    iBlocks = iBlocks - 1;
+                    iBlocks -= 1;
                 }
             }
         }
@@ -2060,7 +2060,7 @@ void PSwitch(bool enabled)
                     Block[numBlock].Location = NPC[A].Location;
                     Block[numBlock].Location.Width = BlockWidth[Block[numBlock].Type];
                     Block[numBlock].Location.Height = BlockHeight[Block[numBlock].Type];
-                    Block[numBlock].Location.X = Block[numBlock].Location.X + (NPC[A].Location.Width - Block[numBlock].Location.Width) / 2.0;
+                    Block[numBlock].Location.X += (NPC[A].Location.Width - Block[numBlock].Location.Width) / 2.0;
                     Block[numBlock].Location.SpeedX = 0;
                     Block[numBlock].Location.SpeedY = 0;
                     Block[numBlock].Special = 0;
@@ -2103,7 +2103,7 @@ void PSwitch(bool enabled)
                     NPC[numNPCs].Location.SpeedY = 0;
                     NPC[numNPCs].Location.Width = NPCWidth[NPC[numNPCs].Type];
                     NPC[numNPCs].Location.Height = NPCHeight[NPC[numNPCs].Type];
-                    NPC[numNPCs].Location.X = NPC[numNPCs].Location.X + (Block[A].Location.Width - NPC[numNPCs].Location.Width) / 2.0;
+                    NPC[numNPCs].Location.X += (Block[A].Location.Width - NPC[numNPCs].Location.Width) / 2.0;
                     NPC[numNPCs].DefaultLocation = NPC[numNPCs].Location;
                     NPC[numNPCs].DefaultType = NPC[numNPCs].Type;
                     CheckSectionNPC(numNPCs);
@@ -2136,7 +2136,7 @@ void PSwitch(bool enabled)
                     Block[numBlock].Location.SpeedY = 0;
                     Block[numBlock].Location.Width = BlockWidth[Block[numBlock].Type];
                     Block[numBlock].Location.Height = BlockHeight[Block[numBlock].Type];
-                    Block[numBlock].Location.X = Block[numBlock].Location.X + (NPC[A].Location.Width - Block[numBlock].Location.Width) / 2.0;
+                    Block[numBlock].Location.X += (NPC[A].Location.Width - Block[numBlock].Location.Width) / 2.0;
                     Block[numBlock].Special = 0;
                     Block[numBlock].Kill = false;
                 }
@@ -2166,7 +2166,7 @@ void PSwitch(bool enabled)
                     NPC[numNPCs].Location.SpeedY = 0;
                     NPC[numNPCs].Location.Width = NPCWidth[NPC[numNPCs].Type];
                     NPC[numNPCs].Location.Height = NPCHeight[NPC[numNPCs].Type];
-                    NPC[numNPCs].Location.X = NPC[numNPCs].Location.X + (Block[A].Location.Width - NPC[numNPCs].Location.Width) / 2.0;
+                    NPC[numNPCs].Location.X += (Block[A].Location.Width - NPC[numNPCs].Location.Width) / 2.0;
                     NPC[numNPCs].DefaultLocation = NPC[numNPCs].Location;
                     NPC[numNPCs].DefaultType = NPC[numNPCs].Type;
                     CheckSectionNPC(numNPCs);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -177,7 +177,7 @@ void UpdateEditor()
         {
             if(EditorControls.Up)
             {
-                vScreenY[1] = vScreenY[1] + 32;
+                vScreenY[1] += 32;
                 EditorCursor.Location.Y -= 32;
                 ScrollDelay = 2;
                 MouseRelease = true;
@@ -185,30 +185,30 @@ void UpdateEditor()
 
             if(EditorControls.Down)
             {
-                vScreenY[1] = vScreenY[1] - 32;
-                EditorCursor.Location.Y = EditorCursor.Location.Y + 32;
+                vScreenY[1] -= 32;
+                EditorCursor.Location.Y += 32;
                 ScrollDelay = 2;
                 MouseRelease = true;
             }
 
             if(EditorControls.Left)
             {
-                vScreenX[1] = vScreenX[1] + 32;
-                EditorCursor.Location.X = EditorCursor.Location.X - 32;
+                vScreenX[1] += 32;
+                EditorCursor.Location.X -= 32;
                 ScrollDelay = 2;
                 MouseRelease = true;
             }
 
             if(EditorControls.Right)
             {
-                vScreenX[1] = vScreenX[1] - 32;
-                EditorCursor.Location.X = EditorCursor.Location.X + 32;
+                vScreenX[1] -= 32;
+                EditorCursor.Location.X += 32;
                 ScrollDelay = 2;
                 MouseRelease = true;
             }
         }
         else
-            ScrollDelay = ScrollDelay - 1;
+            ScrollDelay -= 1;
         SetCursor();
 
         // this is where objects are placed/grabbed/deleted
@@ -269,7 +269,7 @@ void UpdateEditor()
 ////                                    while(frmNPCs::NPC(NPC[A].Special).Visible == false)
 ////                                    {
 ////                                        frmNPCs::optGame(B).Value = true;
-////                                        B = B + 1;
+////                                        B += 1;
 ////                                        if(B > frmNPCs::optGame.Count - 1)
 ////                                            break;
 ////                                    }
@@ -280,7 +280,7 @@ void UpdateEditor()
 ////                                while(frmNPCs::NPC(NPC[A].Type).Visible == false)
 ////                                {
 ////                                    frmNPCs::optGame(B).Value = true;
-////                                    B = B + 1;
+////                                    B += 1;
 ////                                    if(B > frmNPCs::optGame.Count - 1)
 ////                                        break;
 ////                                }
@@ -516,7 +516,7 @@ void UpdateEditor()
 //                                                break;
 //                                        }
 //                                    }
-//                                    B = B + 1;
+//                                    B += 1;
 //                                }
 //                                frmBlocks::Block(Block[A].Type).Value = true;
 //                                frmAdvancedBlock::TriggerHit.Text = Block[A].TriggerHit;
@@ -706,7 +706,7 @@ void UpdateEditor()
 //                            while(frmBackgrounds::Background(Background[A].Type).Visible == false)
 //                            {
 //                                frmBackgrounds::optGame(B).Value = true;
-//                                B = B + 1;
+//                                B += 1;
 //                            }
 //                            for(B = 0; B < frmLayers::lstLayer::ListCount; B++)
 //                            {
@@ -724,7 +724,7 @@ void UpdateEditor()
                             SetCursor();
 //                            Netplay::sendData Netplay::EraseBackground(A, 1) + "p23" + LB;
                             Background[A] = Background[numBackground];
-                            numBackground = numBackground - 1;
+                            numBackground -= 1;
                             if(MagicHand)
                             {
                                 qSortBackgrounds(1, numBackground);
@@ -813,7 +813,7 @@ void UpdateEditor()
 //                                                break;
 //                                        }
 //                                    }
-//                                    B = B + 1;
+//                                    B += 1;
 //                                }
 //                                frmBlocks::Block(Block[A].Type).Value = true;
 //                                if(Block[A].Special >= 1 && Block[A].Special <= 99)
@@ -927,7 +927,7 @@ void UpdateEditor()
                             SetCursor();
 //                            frmMusic::optMusic(WorldMusic[A].Type).Value = true;
                             WorldMusic[A] = WorldMusic[numWorldMusic];
-                            numWorldMusic = numWorldMusic - 1;
+                            numWorldMusic -= 1;
                             MouseRelease = false;
                             EditorControls.Mouse1 = false; /* Simulate "Focus out" inside of SMBX Editor */
                             break;
@@ -950,7 +950,7 @@ void UpdateEditor()
                             EditorCursor.Location = WorldPath[A].Location;
                             SetCursor();
 //                            WorldPath[A] = WorldPath(numWorldPaths);
-                            numWorldPaths = numWorldPaths - 1;
+                            numWorldPaths -= 1;
                             MouseRelease = false;
                             EditorControls.Mouse1 = false; /* Simulate "Focus out" inside of SMBX Editor */
                             break;
@@ -975,7 +975,7 @@ void UpdateEditor()
                             MouseMove(EditorCursor.X, EditorCursor.Y);
                             for(B = A; B < numScenes; B++)
                                 Scene[B] = Scene[B + 1];
-                            numScenes = numScenes - 1;
+                            numScenes -= 1;
                             MouseRelease = false;
                             EditorControls.Mouse1 = false; /* Simulate "Focus out" inside of SMBX Editor */
                             break;
@@ -1028,7 +1028,7 @@ void UpdateEditor()
                             EditorCursor.Location = WorldLevel[A].Location;
                             SetCursor();
                             WorldLevel[A] = WorldLevel[numWorldLevels];
-                            numWorldLevels = numWorldLevels - 1;
+                            numWorldLevels -= 1;
                             MouseRelease = false;
                             EditorControls.Mouse1 = false; /* Simulate "Focus out" inside of SMBX Editor */
                             break;
@@ -1060,7 +1060,7 @@ void UpdateEditor()
                             EditorCursor.Location = Tile[A].Location;
                             SetCursor();
                             Tile[A] = Tile[numTiles];
-                            numTiles = numTiles - 1;
+                            numTiles -= 1;
                             MouseRelease = false;
                             EditorControls.Mouse1 = false; /* Simulate "Focus out" inside of SMBX Editor */
                             break;
@@ -1104,7 +1104,7 @@ void UpdateEditor()
                     {
                         tempLocation = NPC[A].Location;
                         if(NPC[A].Type == 91)
-                            tempLocation.Y = tempLocation.Y - 16;
+                            tempLocation.Y -= 16;
                         if(CursorCollision(EditorCursor.Location, tempLocation) == true && NPC[A].Hidden == false)
                         {
                             if(static_cast<int>(floor(static_cast<double>(std::rand() % 2))) == 0)
@@ -1176,8 +1176,8 @@ void UpdateEditor()
                         {
 //                            Netplay::sendData Netplay::EraseBackground(A, 0);
                             auto &b = Background[A];
-                            b.Location.X = b.Location.X + b.Location.Width / 2.0 - EffectWidth[10] / 2;
-                            b.Location.Y = b.Location.Y + b.Location.Height / 2.0 - EffectHeight[10] / 2;
+                            b.Location.X += b.Location.Width / 2.0 - EffectWidth[10] / 2;
+                            b.Location.Y += b.Location.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, b.Location);
                             PlaySound(SFX_Smash);
                             Background[A] = Background[numBackground];
@@ -1222,7 +1222,7 @@ void UpdateEditor()
 //                            if(nPlay.Online == true)
 //                                Netplay::sendData "y" + std::to_string(A) + LB + "p36" + LB;
                             Water[A] = Water[numWater];
-                            numWater = numWater - 1;
+                            numWater -= 1;
                             MouseRelease = false;
                             break;
                         }
@@ -1236,12 +1236,12 @@ void UpdateEditor()
                         if(CursorCollision(EditorCursor.Location, WorldMusic[A].Location) == true)
                         {
                             tempLocation = WorldMusic[A].Location;
-                            tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2;
-                            tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2;
+                            tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
+                            tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
                             PlaySound(SFX_ShellHit);
                             WorldMusic[A] = WorldMusic[numWorldMusic];
-                            numWorldMusic = numWorldMusic - 1;
+                            numWorldMusic -= 1;
                             MouseRelease = false;
                             break;
                         }
@@ -1255,8 +1255,8 @@ void UpdateEditor()
                         if(CursorCollision(EditorCursor.Location, WorldPath[A].Location) == true)
                         {
                             tempLocation = WorldPath[A].Location;
-                            tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2;
-                            tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2;
+                            tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
+                            tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
                             PlaySound(SFX_ShellHit);
                             WorldPath[A] = WorldPath[numWorldPaths];
@@ -1274,13 +1274,13 @@ void UpdateEditor()
                         if(CursorCollision(EditorCursor.Location, Scene[A].Location) == true)
                         {
                             tempLocation = Scene[A].Location;
-                            tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2;
-                            tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2;
+                            tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
+                            tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
                             PlaySound(SFX_ShellHit);
                             for(B = A; B < numScenes; B++)
                                 Scene[B] = Scene[B + 1];
-                            numScenes = numScenes - 1;
+                            numScenes -= 1;
                             MouseRelease = false;
                             break;
                         }
@@ -1294,12 +1294,12 @@ void UpdateEditor()
                         if(CursorCollision(EditorCursor.Location, WorldLevel[A].Location) == true)
                         {
                             tempLocation = WorldLevel[A].Location;
-                            tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2;
-                            tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2;
+                            tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
+                            tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
                             PlaySound(SFX_ShellHit);
                             WorldLevel[A] = WorldLevel[numWorldLevels];
-                            numWorldLevels = numWorldLevels - 1;
+                            numWorldLevels -= 1;
                             MouseRelease = false;
                             break;
                         }
@@ -1313,12 +1313,12 @@ void UpdateEditor()
                         if(CursorCollision(EditorCursor.Location, Tile[A].Location) == true)
                         {
                             tempLocation = Tile[A].Location;
-                            tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2;
-                            tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2;
+                            tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
+                            tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
                             PlaySound(SFX_ShellHit);
                             Tile[A] = Tile[numTiles];
-                            numTiles = numTiles - 1;
+                            numTiles -= 1;
                             MouseRelease = false;
                             break;
                         }
@@ -2123,7 +2123,7 @@ int EditorNPCFrame(int A, float& C, int N)
     {
         ret = SpecialFrame[2];
         if(int(B) == 1)
-            ret = ret + 4;
+            ret += 4;
     }
 
     if(A == 57) // smb3 belt
@@ -2406,9 +2406,9 @@ void SetCursor()
 //        for(int tempVar = frmNPCs::NPCText.Text.Length, A = 1; A <= tempVar; A++)
 //        {
 //            if(frmNPCs::NPCText.Text.substr(A - 1, 1) == StringHelper::toString(static_cast<char>(34)))
-//                EditorCursor.NPC.Text = EditorCursor.NPC.Text + "'";
+//                EditorCursor.NPC.Text += "'";
 //            else
-//                EditorCursor.NPC.Text = EditorCursor.NPC.Text + frmNPCs::NPCText.Text.substr(A - 1, 1);
+//                EditorCursor.NPC.Text += frmNPCs::NPCText.Text.substr(A - 1, 1);
 //        }
 
 //        if(frmGenerator::Spawn.Caption == "Yes")
@@ -2634,7 +2634,7 @@ void SetCursor()
 void PositionCursor()
 {
 //    if(EditorCursor.Mode == 4 && frmNPCs::Buried.Caption == "Yes")
-//        EditorCursor.Location.Y = EditorCursor.Location.Y + 16;
+//        EditorCursor.Location.Y += 16;
 
     if(EditorCursor.Mode == 9)
     {
@@ -2648,13 +2648,13 @@ void PositionCursor()
 
     if(!enableAutoAlign)
     {
-        EditorCursor.Location.X = EditorCursor.Location.X - EditorCursor.Location.Width + 4;
-        EditorCursor.Location.Y = EditorCursor.Location.Y - EditorCursor.Location.Height + 12;
+        EditorCursor.Location.X += -EditorCursor.Location.Width + 4;
+        EditorCursor.Location.Y += -EditorCursor.Location.Height + 12;
         return;
     }
 
     if(EditorCursor.Mode == OptCursor_t::LVL_SETTINGS /*&& (frmLevelSettings::optLevel(4).Value == true || frmLevelSettings::optLevel(5).Value == true)*/)
-        EditorCursor.Location.X = EditorCursor.Location.X - 14;
+        EditorCursor.Location.X -= 14;
 
     if(EditorCursor.Mode == OptCursor_t::LVL_SETTINGS || EditorCursor.Mode == OptCursor_t::LVL_NPCS)
     {
@@ -2663,20 +2663,20 @@ void PositionCursor()
             if(std::fmod(EditorCursor.Location.Width, 32) != 0.0)
             {
                 if(EditorCursor.Location.Width > 32)
-                    EditorCursor.Location.X = EditorCursor.Location.X - std::fmod(EditorCursor.Location.Width, 32) / 2.0;
+                    EditorCursor.Location.X += -std::fmod(EditorCursor.Location.Width, 32) / 2.0;
                 else if(EditorCursor.Location.Width <= 16)
                 {
-                    EditorCursor.Location.X = EditorCursor.Location.X + std::fmod(32, EditorCursor.Location.Width) / 2.0;
-                    EditorCursor.Location.X = EditorCursor.Location.X + (32 - EditorCursor.Location.Width) / 2.0;
+                    EditorCursor.Location.X += std::fmod(32, EditorCursor.Location.Width) / 2.0;
+                    EditorCursor.Location.X += (32 - EditorCursor.Location.Width) / 2.0;
                 }
                 else if(EditorCursor.Location.Width < 32)
-                    EditorCursor.Location.X = EditorCursor.Location.X + std::fmod(32, EditorCursor.Location.Width) / 2.0;
+                    EditorCursor.Location.X += std::fmod(32, EditorCursor.Location.Width) / 2.0;
                 else
-                    EditorCursor.Location.X = EditorCursor.Location.X + std::fmod(32, EditorCursor.Location.Width) / 2.0;
+                    EditorCursor.Location.X += std::fmod(32, EditorCursor.Location.Width) / 2.0;
             }
 
             if(std::fmod(EditorCursor.Location.Height, 32) != 0.0)
-                EditorCursor.Location.Y = EditorCursor.Location.Y - std::fmod(EditorCursor.Location.Height, 32);
+                EditorCursor.Location.Y += -std::fmod(EditorCursor.Location.Height, 32);
         }
     }
 
@@ -2684,11 +2684,11 @@ void PositionCursor()
     {
         if(EditorCursor.Background.Type == 13) // End level container
         {
-            EditorCursor.Location.X = EditorCursor.Location.X - 12;
-            EditorCursor.Location.Y = EditorCursor.Location.Y - 12;
+            EditorCursor.Location.X -= 12;
+            EditorCursor.Location.Y -= 12;
         }
         if(EditorCursor.Background.Type == 156 || EditorCursor.Background.Type == 157)
-            EditorCursor.Location.Y = EditorCursor.Location.Y + 16;
+            EditorCursor.Location.Y += 16;
     }
 
     else if(EditorCursor.Mode == OptCursor_t::LVL_NPCS)
@@ -2697,33 +2697,33 @@ void PositionCursor()
            EditorCursor.NPC.Type == 270 || EditorCursor.NPC.Type == 93 ||
            EditorCursor.NPC.Type == 180 || EditorCursor.NPC.Type ==179 ||
            EditorCursor.NPC.Type == 37 || EditorCursor.NPC.Type ==51) // Piranha Plants
-            EditorCursor.Location.X = EditorCursor.Location.X + 16;
+            EditorCursor.Location.X += 16;
         else if(EditorCursor.NPC.Type == 197)
         {
-            EditorCursor.Location.X = EditorCursor.Location.X - 8;
-            EditorCursor.Location.Y = EditorCursor.Location.Y + 16;
+            EditorCursor.Location.X -= 8;
+            EditorCursor.Location.Y += 16;
         }
 
 //        if(frmNPCs::Buried.Caption == "Yes")
         if(EditorCursor.NPC.Type == 91)
         {
             if(!enableAutoAlign)
-                EditorCursor.Location.Y = EditorCursor.Location.Y + 0/*16*/;
+                EditorCursor.Location.Y += 0/*16*/;
             else
-                EditorCursor.Location.Y = EditorCursor.Location.Y + 16/*32*/;
+                EditorCursor.Location.Y += 16/*32*/;
         }
         else if(EditorCursor.NPC.Type == 105)
-            EditorCursor.Location.Y = EditorCursor.Location.Y + 22;
+            EditorCursor.Location.Y += 22;
         else if(EditorCursor.NPC.Type == 106)
-            EditorCursor.Location.Y = EditorCursor.Location.Y + 16;
+            EditorCursor.Location.Y += 16;
         else if(EditorCursor.NPC.Type == 260)
-            EditorCursor.Location.Y = EditorCursor.Location.Y - 8;
+            EditorCursor.Location.Y -= 8;
     }
 
     if(EditorCursor.Mode == 4)
     {
         if(NPCHeight[EditorCursor.NPC.Type] < 32)
-            EditorCursor.Location.Y = EditorCursor.Location.Y + 32;
+            EditorCursor.Location.Y += 32;
     }
 }
 
@@ -2993,7 +2993,7 @@ void MouseMove(float X, float Y, bool /*nCur*/)
             {
                 EditorCursor.Location.X = double(std::floor(X / 16)) * 16 - vScreenX[A];
                 EditorCursor.Location.Y = double(std::floor(Y / 16)) * 16 - vScreenY[A];
-                EditorCursor.Location.Y = EditorCursor.Location.Y - 8;
+                EditorCursor.Location.Y -= 8;
                 PositionCursor();
             }
         }
@@ -3008,7 +3008,7 @@ void MouseMove(float X, float Y, bool /*nCur*/)
 //            {
 //                EditorCursor.Location.X = static_cast<float>(floor(X / 8)) * 8 - vScreenX[A];
 //                EditorCursor.Location.Y = static_cast<float>(floor(Y / 8)) * 8 - vScreenY[A];
-//                EditorCursor.Location.Y = EditorCursor.Location.Y - 8;
+//                EditorCursor.Location.Y -= 8;
 //                PositionCursor();
 //            }
         }
@@ -3016,26 +3016,26 @@ void MouseMove(float X, float Y, bool /*nCur*/)
         {
             EditorCursor.Location.X = double(std::floor(X / 16)) * 16 - vScreenX[A];
             EditorCursor.Location.Y = double(std::floor(Y / 16)) * 16 - vScreenY[A];
-            EditorCursor.Location.Y = EditorCursor.Location.Y - 8;
+            EditorCursor.Location.Y -= 8;
             PositionCursor();
         }
         else if(EditorCursor.Mode == OptCursor_t::LVL_WATER)
         {
             EditorCursor.Location.X = double(std::floor(X / 16)) * 16 - vScreenX[A];
             EditorCursor.Location.Y = double(std::floor(Y / 16)) * 16 - vScreenY[A];
-            EditorCursor.Location.Y = EditorCursor.Location.Y - 8;
+            EditorCursor.Location.Y -= 8;
             PositionCursor();
         }
         else // Everything also align as 32x32
         {
             EditorCursor.Location.X = double(std::floor(X / 32)) * 32 - vScreenX[A];
             EditorCursor.Location.Y = double(std::floor(Y / 32)) * 32 - vScreenY[A];
-            EditorCursor.Location.Y = EditorCursor.Location.Y - 8;
+            EditorCursor.Location.Y -= 8;
             PositionCursor();
         }
     }
-    EditorCursor.Location.X = EditorCursor.Location.X - vScreen[A].Left;
-    EditorCursor.Location.Y = EditorCursor.Location.Y - vScreen[A].Top;
+    EditorCursor.Location.X += -vScreen[A].Left;
+    EditorCursor.Location.Y += -vScreen[A].Top;
 //    if(nPlay.Online == true && nCur == true)
 //    {
 //        if(nPlay.Mode == 0)
@@ -3098,16 +3098,16 @@ void BlockFill(Location_t Loc)
         Block[numBlock].DefaultSpecial2 = Block[numBlock].Special2;
         Block[numBlock].Location = Loc;
         tempLoc = Loc;
-        tempLoc.X = tempLoc.X - Loc.Width;
+        tempLoc.X += -Loc.Width;
         BlockFill(tempLoc); // left
         tempLoc = Loc;
-        tempLoc.X = tempLoc.X + Loc.Width;
+        tempLoc.X += Loc.Width;
         BlockFill(tempLoc); // right
         tempLoc = Loc;
-        tempLoc.Y = tempLoc.Y - Loc.Height;
+        tempLoc.Y += -Loc.Height;
         BlockFill(tempLoc); // top
         tempLoc = Loc;
-        tempLoc.Y = tempLoc.Y + Loc.Height;
+        tempLoc.Y += Loc.Height;
         BlockFill(tempLoc); // bottom
     }
 }

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -86,12 +86,12 @@ void UpdateEffects()
         }
         else if(e.Type == 111)
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.5;
+            e.Location.SpeedY += 0.5;
             e.FrameCount += 1;
             if(e.FrameCount >= 4)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 7)
                     e.Frame = 0;
                 if(e.Frame >= 14)
@@ -104,7 +104,7 @@ void UpdateEffects()
             if(e.FrameCount >= 4)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
             }
             if(e.Frame >= 7)
                 e.Life = 0;
@@ -112,8 +112,8 @@ void UpdateEffects()
         else if(e.Type == 136) // RotoDisk
         {
             if(e.Location.SpeedX != 0.0 || e.Location.SpeedY != 0.0)
-                e.Location.SpeedY = e.Location.SpeedY + 0.5;
-            e.Frame = e.Frame + 1;
+                e.Location.SpeedY += 0.5;
+            e.Frame += 1;
             if(e.Frame >= 5)
                 e.Frame = 0;
         }
@@ -131,7 +131,7 @@ void UpdateEffects()
         }
         else if(e.Type == 1 || e.Type == 21 || e.Type == 30 || e.Type == 51 || e.Type == 100 || e.Type == 135) // Block break
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.6;
+            e.Location.SpeedY += 0.6;
             e.Location.SpeedX = e.Location.SpeedX * 0.99;
             if(e.Location.SpeedY >= 10)
                 e.Location.SpeedY = 10;
@@ -139,7 +139,7 @@ void UpdateEffects()
             if(e.FrameCount >= 3)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 4)
                     e.Frame = 0;
             }
@@ -149,7 +149,7 @@ void UpdateEffects()
             e.FrameCount += 1;
             if(e.FrameCount >= 4)
             {
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 e.FrameCount = 0;
             }
             if(e.Frame > 7)
@@ -213,16 +213,16 @@ void UpdateEffects()
         }
         else if(e.Type == 57) // egg shells
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.6;
+            e.Location.SpeedY += 0.6;
             e.Location.SpeedX = e.Location.SpeedX * 0.99;
             if(e.Location.SpeedY >= 10)
                 e.Location.SpeedY = 10;
         }
         else if(e.Type == 3 || e.Type == 5 || e.Type == 129 || e.Type == 130 || e.Type == 134) // Mario & Luigi death
-            e.Location.SpeedY = e.Location.SpeedY + 0.25;
+            e.Location.SpeedY += 0.25;
         else if(e.Type == 145 || e.Type == 110 || e.Type == 127 || e.Type == 4 || e.Type == 143 || e.Type == 142 || e.Type == 7 || e.Type == 22 || e.Type == 31 || e.Type == 33 || e.Type == 34 || e.Type == 38 || e.Type == 40 || e.Type == 42 || e.Type == 44 || e.Type == 46 || e.Type == 53 || e.Type == 117) // Goomba air ride of dooom
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.5;
+            e.Location.SpeedY += 0.5;
             if(e.Location.SpeedY >= 10)
                 e.Location.SpeedY = 10;
             e.FrameCount += 1;
@@ -231,14 +231,14 @@ void UpdateEffects()
             if(e.FrameCount >= 8)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 2)
                     e.Frame = 0;
             }
         }
         else if(e.Type == 104) // Blaarg eyes
         {
-            e.Life = e.Life + 2;
+            e.Life += 2;
             if(e.Life <= 30)
                 e.Location.SpeedY = -2.8;
             else if(e.Life <= 40)
@@ -253,34 +253,34 @@ void UpdateEffects()
             if(e.FrameCount >= 16)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 2)
                     e.Frame = 0;
             }
         }
         else if(e.Type == 61) // Beack Koopa
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.5;
+            e.Location.SpeedY += 0.5;
             if(e.Location.SpeedY >= 10)
                 e.Location.SpeedY = 10;
             e.FrameCount += 1;
             if(e.FrameCount >= 15)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame - 1;
+                e.Frame -= 1;
             }
             else if(e.FrameCount == 8)
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
         }
         else if(e.Type == 8 || e.Type == 9 || e.Type == 15 || e.Type == 16 || e.Type == 19 || e.Type == 27 || e.Type == 146 || e.Type == 28 || e.Type == 29 || e.Type == 32 || e.Type == 36 || e.Type == 47 || e.Type == 60 || e.Type == 95 || e.Type == 96 || e.Type == 109) // Flying turtle shell / Bullet bill /hard thing
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.5;
+            e.Location.SpeedY += 0.5;
             if(e.Location.SpeedY >= 10)
                 e.Location.SpeedY = 10;
         }
         else if(e.Type == 26 || e.Type == 101 || e.Type == 102) // Goombas shoes
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.5;
+            e.Location.SpeedY += 0.5;
             if(e.Location.SpeedY >= 10)
                 e.Location.SpeedY = 10;
             if(e.Location.SpeedX > 0)
@@ -290,24 +290,24 @@ void UpdateEffects()
         }
         else if(e.Type == 10 || e.Type == 131) // SMW / SMB3 Puff of smoke
         {
-            e.Location.X = e.Location.X + e.Location.SpeedX;
+            e.Location.X += e.Location.SpeedX;
             e.FrameCount += 1;
             if(e.FrameCount >= 3)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 4)
                     e.Life = 0;
             }
         }
         else if(e.Type == 147) // SMB2 Puff of smoke
         {
-            e.Location.X = e.Location.X + e.Location.SpeedX;
+            e.Location.X += e.Location.SpeedX;
             e.FrameCount += 1;
             if(e.FrameCount >= 6)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 4)
                     e.Life = 0;
             }
@@ -318,7 +318,7 @@ void UpdateEffects()
             if(e.FrameCount >= 3)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 2)
                 {
                     e.Life = 0;
@@ -332,7 +332,7 @@ void UpdateEffects()
             if(e.FrameCount >= 1)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 4)
                     e.Frame = 0;
             }
@@ -349,7 +349,7 @@ void UpdateEffects()
                 // ElseIf .Frame = 1 Then
                     // .Frame = 3
                 // Else
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame > 3)
                 {
                     e.Frame = 0;
@@ -363,7 +363,7 @@ void UpdateEffects()
             e.FrameCount += 1;
             if(e.FrameCount >= 4)
             {
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame > 1)
                     e.Life = 0;
                 e.FrameCount = 0;
@@ -371,25 +371,25 @@ void UpdateEffects()
         }
         else if(e.Type == 76)
         {
-            e.Location.X = e.Location.X + e.Location.SpeedX;
-            e.Location.Y = e.Location.Y + e.Location.SpeedY;
+            e.Location.X += e.Location.SpeedX;
+            e.Location.Y += e.Location.SpeedY;
         }
         else if(e.Type == 81 || e.Type == 123 || e.Type == 124) // P Switch
         {
             if(e.Life == 1)
             {
-                e.Location.X = e.Location.X + e.Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                e.Location.Y = e.Location.Y + e.Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                e.Location.X += e.Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                e.Location.Y += e.Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10, e.Location);
             }
         }
         else if(e.Type == 74) // Slide Smoke
         {
             e.FrameCount += 1;
-            e.Location.Y = e.Location.Y - 0.1;
+            e.Location.Y -= 0.1;
             if(e.FrameCount >= 4)
             {
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 e.FrameCount = 0;
                 if(e.Frame > 2)
                     e.Life = 0;
@@ -397,12 +397,12 @@ void UpdateEffects()
         }
         else if(e.Type == 63) // Zelda Smoke
         {
-            e.Location.X = e.Location.X + e.Location.SpeedX;
+            e.Location.X += e.Location.SpeedX;
             e.FrameCount += 1;
             if(e.FrameCount >= 4)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 4)
                     e.Life = 0;
             }
@@ -411,7 +411,7 @@ void UpdateEffects()
         {
             if(e.Life == 1)
             {
-                CoinCount = CoinCount + 1;
+                CoinCount += 1;
                 if(CoinCount > 13)
                     CoinCount = 10;
                 MoreScore(CoinCount, e.Location);
@@ -433,12 +433,12 @@ void UpdateEffects()
             }
             else
             {
-                e.Location.SpeedY = e.Location.SpeedY + 0.4;
+                e.Location.SpeedY += 0.4;
                 e.FrameCount += 1;
                 if(e.FrameCount >= 3)
                 {
                     e.FrameCount = 0;
-                    e.Frame = e.Frame + 1;
+                    e.Frame += 1;
                     if(e.Frame >= 4)
                         e.Frame = 0;
                 }
@@ -452,7 +452,7 @@ void UpdateEffects()
             if(e.FrameCount >= 4)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
             }
         }
         else if(e.Type == 78) // Coin
@@ -463,7 +463,7 @@ void UpdateEffects()
             if(e.FrameCount >= 5)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 3)
                     e.Life = 0;
             }
@@ -502,7 +502,7 @@ void UpdateEffects()
             if(e.FrameCount >= 8)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 3)
                     e.Life = 0;
             }
@@ -515,7 +515,7 @@ void UpdateEffects()
             if(e.FrameCount >= 4)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame == 3 || e.Frame == 6 || e.Frame == 9 || e.Frame == 12 || e.Frame == 15)
                     e.Life = 0;
             }
@@ -528,7 +528,7 @@ void UpdateEffects()
             if(e.FrameCount >= 6)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 e.FrameCount = 0;
             }
         }
@@ -540,7 +540,7 @@ void UpdateEffects()
             if(e.FrameCount >= 2)
             {
                 e.FrameCount = 0;
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 e.FrameCount = 0;
                 if(e.Frame >= 4)
                     e.Frame = 0;
@@ -551,7 +551,7 @@ void UpdateEffects()
             if(e.FrameCount == 0)
             {
                 NewEffect(71, e.Location, static_cast<float>(e.Frame));
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 if(e.Frame >= 4)
                     e.Frame = 0;
             }
@@ -565,7 +565,7 @@ void UpdateEffects()
                 if(e.FrameCount >= 4)
                 {
                     e.FrameCount = 0;
-                    e.Frame = e.Frame + 1;
+                    e.Frame += 1;
                     if(e.Frame >= 4)
                         e.Frame = 0;
                 }
@@ -582,7 +582,7 @@ void UpdateEffects()
                 if(e.FrameCount >= 4)
                 {
                     e.FrameCount = 0;
-                    e.Frame = e.Frame + 1;
+                    e.Frame += 1;
                     if(e.Frame >= 4)
                     {
                         e.Life = 0;
@@ -614,13 +614,13 @@ void UpdateEffects()
         }
         else if(e.Type == 15 || e.Type == 16 || e.Type == 25 || e.Type == 48 || e.Type == 49 || e.Type == 50 || e.Type == 68 || e.Type == 72 || e.Type == 89 || e.Type == 90 || e.Type == 91 || e.Type == 92 || e.Type == 93 || e.Type == 94 || e.Type == 98 || e.Type == 99 || e.Type == 105 || e.Type == 138 || e.Type == 106 || e.Type == 141) // Bullet Bill / Hammer Bro
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.5;
+            e.Location.SpeedY += 0.5;
             if(e.Location.SpeedY >= 10)
                 e.Location.SpeedY = 10;
         }
         else if(e.Type == 128)
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.5;
+            e.Location.SpeedY += 0.5;
             if(e.Location.SpeedY >= 10)
                 e.Location.SpeedY = 10;
             e.FrameCount += 1;
@@ -635,7 +635,7 @@ void UpdateEffects()
         }
         else if(e.Type == 17 || e.Type == 18 || e.Type == 20 || e.Type == 24 || (e.Type >= 64 && e.Type <= 67) || e.Type == 83) // Shy guy free falling
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.5;
+            e.Location.SpeedY += 0.5;
             if(e.Location.SpeedY >= 10)
                 e.Location.SpeedY = 10;
             e.FrameCount += 1;
@@ -654,7 +654,7 @@ void UpdateEffects()
         }
         else if(e.Type == 85 || e.Type == 86 || e.Type == 87 || e.Type == 88 || e.Type == 97 || e.Type == 115 || e.Type == 122 || e.Type == 116 || e.Type == 118 || e.Type == 119 || e.Type == 120 || e.Type == 121 || e.Type == 137) // Rex / mega mole / smw goomba free falling
         {
-            e.Location.SpeedY = e.Location.SpeedY + 0.5;
+            e.Location.SpeedY += 0.5;
             if(e.Location.SpeedY >= 10)
                 e.Location.SpeedY = 10;
             e.FrameCount += 1;
@@ -677,7 +677,7 @@ void UpdateEffects()
                 e.FrameCount = 19;
             e.FrameCount += 1;
             if(e.FrameCount == 10)
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
             else if(e.FrameCount == 20)
             {
                 e.Frame = 2;
@@ -701,8 +701,8 @@ void UpdateEffects()
                         NPC[numNPCs].Type = e.NewNpc;
                         NPC[numNPCs].Location.Height = NPCHeight[NPC[numNPCs].Type];
                         NPC[numNPCs].Location.Width = NPCWidth[NPC[numNPCs].Type];
-                        NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y + 32 - NPC[numNPCs].Location.Height;
-                        NPC[numNPCs].Location.X = NPC[numNPCs].Location.X - NPC[numNPCs].Location.Width / 2.0 + 16;
+                        NPC[numNPCs].Location.Y += 32 - NPC[numNPCs].Location.Height;
+                        NPC[numNPCs].Location.X += -NPC[numNPCs].Location.Width / 2.0 + 16;
                         if(NPC[numNPCs].Type == 34)
                             NPC[numNPCs].Location.SpeedY = -6;
                         CheckSectionNPC(numNPCs);
@@ -715,7 +715,7 @@ void UpdateEffects()
             e.FrameCount += 1;
             if(e.FrameCount >= 4)
             {
-                e.Frame = e.Frame + 1;
+                e.Frame += 1;
                 e.FrameCount = 0;
             }
             if(e.Frame >= 3)
@@ -752,19 +752,19 @@ void UpdateEffects()
                 CheckSectionNPC(numNPCs);
             }
             if(e.NewNpc == 98)
-                e.Frame = e.Frame + 2;
+                e.Frame += 2;
             else if(e.NewNpc == 99)
-                e.Frame = e.Frame + 4;
+                e.Frame += 4;
             else if(e.NewNpc == 100)
-                e.Frame = e.Frame + 6;
+                e.Frame += 6;
             else if(e.NewNpc == 148)
-                e.Frame = e.Frame + 8;
+                e.Frame += 8;
             else if(e.NewNpc == 149)
-                e.Frame = e.Frame + 10;
+                e.Frame += 10;
             else if(e.NewNpc == 150)
-                e.Frame = e.Frame + 12;
+                e.Frame += 12;
             else if(e.NewNpc == 228)
-                e.Frame = e.Frame + 14;
+                e.Frame += 14;
         }
         else if(e.Type == 79)
             e.Location.SpeedY = e.Location.SpeedY * 0.97;
@@ -975,8 +975,8 @@ void NewEffect(int A, Location_t Location, float Direction, int NewNpc, bool Sha
             else
                 Effect[numEffects].Frame = 2;
 
-            // .Location.SpeedX = .Location.SpeedX + Rnd * 2 - 1
-            // .Location.SpeedY = .Location.SpeedY + Rnd * 4 - 2
+            // .Location.SpeedX += Rnd * 2 - 1
+            // .Location.SpeedY += Rnd * 4 - 2
             if(B == 1)
             {
                 Effect[numEffects].Location.X = Location.X;
@@ -1158,8 +1158,8 @@ void NewEffect(int A, Location_t Location, float Direction, int NewNpc, bool Sha
         Effect[numEffects].Location.Height = EffectHeight[Effect[numEffects].Type];
         Effect[numEffects].Location.X = Location.X - Effect[numEffects].Location.Width * 0.5 + Location.Width * 0.5;
         Effect[numEffects].Location.Y = Location.Y - Effect[numEffects].Location.Height * 0.5 + Location.Height * 0.5;
-        Effect[numEffects].Location.X = Effect[numEffects].Location.X + dRand() * 32 - 16;
-        Effect[numEffects].Location.Y = Effect[numEffects].Location.Y + dRand() * 32 - 16;
+        Effect[numEffects].Location.X += dRand() * 32 - 16;
+        Effect[numEffects].Location.Y += dRand() * 32 - 16;
         Effect[numEffects].Location.SpeedY = -2;
         Effect[numEffects].Location.SpeedX = 0;
         Effect[numEffects].Frame = 0;
@@ -1214,8 +1214,8 @@ void NewEffect(int A, Location_t Location, float Direction, int NewNpc, bool Sha
                     Effect[numEffects].Location.SpeedY = -Effect[numEffects].Location.SpeedY;
                 if(B == 1 || B == 3)
                     Effect[numEffects].Location.SpeedX = -Effect[numEffects].Location.SpeedX;
-                Effect[numEffects].Location.Y = Effect[numEffects].Location.Y + Effect[numEffects].Location.SpeedY * 6;
-                Effect[numEffects].Location.X = Effect[numEffects].Location.X + Effect[numEffects].Location.SpeedX * 6;
+                Effect[numEffects].Location.Y += Effect[numEffects].Location.SpeedY * 6;
+                Effect[numEffects].Location.X += Effect[numEffects].Location.SpeedX * 6;
                 Effect[numEffects].Frame = 0;
             }
         }
@@ -1274,8 +1274,8 @@ void NewEffect(int A, Location_t Location, float Direction, int NewNpc, bool Sha
                 Effect[numEffects].Location.SpeedX = Effect[numEffects].Location.SpeedX * 0.5;
                 Effect[numEffects].Location.SpeedY = Effect[numEffects].Location.SpeedY * 0.5;
 
-                Effect[numEffects].Location.X = Effect[numEffects].Location.X + Effect[numEffects].Location.SpeedX * 3;
-                Effect[numEffects].Location.Y = Effect[numEffects].Location.Y + Effect[numEffects].Location.SpeedY * 3;
+                Effect[numEffects].Location.X += Effect[numEffects].Location.SpeedX * 3;
+                Effect[numEffects].Location.Y += Effect[numEffects].Location.SpeedY * 3;
 
                 Effect[numEffects].Frame = iRand() % 4;
                 Effect[numEffects].Type = A;
@@ -1387,13 +1387,13 @@ void NewEffect(int A, Location_t Location, float Direction, int NewNpc, bool Sha
             Effect[numEffects].Location.SpeedY = 0;
             Effect[numEffects].Location.SpeedX = 0;
             if(B == 1)
-                Effect[numEffects].Location.X = Effect[numEffects].Location.X - 10;
+                Effect[numEffects].Location.X -= 10;
             if(B == 3)
-                Effect[numEffects].Location.X = Effect[numEffects].Location.X + 10;
+                Effect[numEffects].Location.X += 10;
             if(B == 2)
-                Effect[numEffects].Location.Y = Effect[numEffects].Location.Y + 16;
+                Effect[numEffects].Location.Y += 16;
             if(B == 4)
-                Effect[numEffects].Location.Y = Effect[numEffects].Location.Y - 16;
+                Effect[numEffects].Location.Y -= 16;
             Effect[numEffects].Frame = 0 - B;
             Effect[numEffects].Life = 20 * B;
             Effect[numEffects].Type = A;
@@ -1626,8 +1626,8 @@ void NewEffect(int A, Location_t Location, float Direction, int NewNpc, bool Sha
         Effect[numEffects].Location.Y = Location.Y;
         Effect[numEffects].Location.SpeedY = Location.SpeedY;
         Effect[numEffects].Location.SpeedX = Location.SpeedX;
-        Effect[numEffects].Location.X = Effect[numEffects].Location.X + Effect[numEffects].Location.Width / 2.0 - 16;
-        Effect[numEffects].Location.Y = Effect[numEffects].Location.Y + Effect[numEffects].Location.Height / 2.0 - 16;
+        Effect[numEffects].Location.X += Effect[numEffects].Location.Width / 2.0 - 16;
+        Effect[numEffects].Location.Y += Effect[numEffects].Location.Height / 2.0 - 16;
         Effect[numEffects].Location.Width = 32;
         Effect[numEffects].Location.Height = 32;
         Effect[numEffects].Frame = 0;
@@ -1735,12 +1735,12 @@ void NewEffect(int A, Location_t Location, float Direction, int NewNpc, bool Sha
         Effect[numEffects].Location.SpeedX = -Location.SpeedX;
         if(A == 91)
         {
-            Effect[numEffects].Location.X = Effect[numEffects].Location.X + Effect[numEffects].Location.Width / 2.0;
-            Effect[numEffects].Location.Y = Effect[numEffects].Location.Y + Effect[numEffects].Location.Height / 2.0;
+            Effect[numEffects].Location.X += Effect[numEffects].Location.Width / 2.0;
+            Effect[numEffects].Location.Y += Effect[numEffects].Location.Height / 2.0;
             Effect[numEffects].Location.Width = EffectWidth[A];
             Effect[numEffects].Location.Height = EffectHeight[A];
-            Effect[numEffects].Location.X = Effect[numEffects].Location.X - Effect[numEffects].Location.Width / 2.0;
-            Effect[numEffects].Location.Y = Effect[numEffects].Location.Y - Effect[numEffects].Location.Height / 2.0;
+            Effect[numEffects].Location.X += -Effect[numEffects].Location.Width / 2.0;
+            Effect[numEffects].Location.Y += -Effect[numEffects].Location.Height / 2.0;
         }
         if(Effect[numEffects].Location.SpeedX != 0 && Effect[numEffects].Location.SpeedX > -2 && Effect[numEffects].Location.SpeedX < 2)
             Effect[numEffects].Location.SpeedX = 2 * -Direction;

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -1301,7 +1301,7 @@ void NPCyFix()
                 XnHfix = std::abs((int(XnH * 100) % 800) / 100);
             else
                 XnHfix = std::abs(8 - ((int(XnH * 100) % 800) / 100));
-            NPC[A].Location.Y = NPC[A].Location.Y + XnHfix;
+            NPC[A].Location.Y += XnHfix;
         }
     }
 }

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -41,8 +41,8 @@ void GetvScreen(int A)
 //            Player[nPlay.MySlot + 1].Location.Height = 0;
 //        vScreenX[1] = -Player[nPlay.MySlot + 1].Location.X + (vScreen[1].Width * 0.5) - Player[nPlay.MySlot + 1].Location.Width / 2.0;
 //        vScreenY[1] = -Player[nPlay.MySlot + 1].Location.Y + (vScreen[1].Height * 0.5) - vScreenYOffset - Player[nPlay.MySlot + 1].Location.Height;
-//        vScreenX[1] = vScreenX[1] - vScreen[1].tempX;
-//        vScreenY[1] = vScreenY[1] - vScreen[1].TempY;
+//        vScreenX[1] += -vScreen[1].tempX;
+//        vScreenY[1] += -vScreen[1].TempY;
 //        if(-vScreenX[1] < level[Player[nPlay.MySlot + 1].Section].X)
 //            vScreenX[1] = -level[Player[nPlay.MySlot + 1].Section].X;
 //        if(-vScreenX[1] + vScreen[1].Width > level[Player[nPlay.MySlot + 1].Section].Width)
@@ -52,17 +52,17 @@ void GetvScreen(int A)
 //        if(-vScreenY[1] + vScreen[1].Height > level[Player[nPlay.MySlot + 1].Section].Height)
 //            vScreenY[1] = -(level[Player[nPlay.MySlot + 1].Section].Height - vScreen[1].Height);
 //        if(vScreen[1].TempDelay > 0)
-//            vScreen[1].TempDelay = vScreen[1].TempDelay - 1;
+//            vScreen[1].TempDelay -= 1;
 //        else
 //        {
 //            if(vScreen[1].tempX > 0)
-//                vScreen[1].tempX = vScreen[1].tempX - 1;
+//                vScreen[1].tempX -= 1;
 //            if(vScreen[1].tempX < 0)
-//                vScreen[1].tempX = vScreen[1].tempX + 1;
+//                vScreen[1].tempX += 1;
 //            if(vScreen[1].TempY > 0)
-//                vScreen[1].TempY = vScreen[1].TempY - 1;
+//                vScreen[1].TempY -= 1;
 //            if(vScreen[1].TempY < 0)
-//                vScreen[1].TempY = vScreen[1].TempY + 1;
+//                vScreen[1].TempY += 1;
 //        }
 //        if(Player[nPlay.MySlot + 1].Mount == 2)
 //            Player[nPlay.MySlot + 1].Location.Height = 128;
@@ -73,8 +73,8 @@ void GetvScreen(int A)
             Player[A].Location.Height = 0;
         vScreenX[A] = -Player[A].Location.X + (vScreen[A].Width * 0.5) - Player[A].Location.Width / 2.0;
         vScreenY[A] = -Player[A].Location.Y + (vScreen[A].Height * 0.5) - vScreenYOffset - Player[A].Location.Height;
-        vScreenX[A] = vScreenX[A] - vScreen[A].tempX;
-        vScreenY[A] = vScreenY[A] - vScreen[A].TempY;
+        vScreenX[A] += -vScreen[A].tempX;
+        vScreenY[A] += -vScreen[A].TempY;
         if(-vScreenX[A] < level[Player[A].Section].X)
             vScreenX[A] = -level[Player[A].Section].X;
         if(-vScreenX[A] + vScreen[A].Width > level[Player[A].Section].Width)
@@ -84,17 +84,17 @@ void GetvScreen(int A)
         if(-vScreenY[A] + vScreen[A].Height > level[Player[A].Section].Height)
             vScreenY[A] = -(level[Player[A].Section].Height - vScreen[A].Height);
         if(vScreen[A].TempDelay > 0)
-            vScreen[A].TempDelay = vScreen[A].TempDelay - 1;
+            vScreen[A].TempDelay -= 1;
         else
         {
             if(vScreen[A].tempX > 0)
-                vScreen[A].tempX = vScreen[A].tempX - 1;
+                vScreen[A].tempX -= 1;
             if(vScreen[A].tempX < 0)
-                vScreen[A].tempX = vScreen[A].tempX + 1;
+                vScreen[A].tempX += 1;
             if(vScreen[A].TempY > 0)
-                vScreen[A].TempY = vScreen[A].TempY - 1;
+                vScreen[A].TempY -= 1;
             if(vScreen[A].TempY < 0)
-                vScreen[A].TempY = vScreen[A].TempY + 1;
+                vScreen[A].TempY += 1;
         }
         if(Player[A].Mount == 2)
             Player[A].Location.Height = 128;
@@ -120,12 +120,12 @@ void GetvScreenAverage()
     {
         if(!Player[A].Dead && Player[A].Effect != 6)
         {
-            vScreenX[1] = vScreenX[1] - Player[A].Location.X - Player[A].Location.Width / 2.0;
+            vScreenX[1] += -Player[A].Location.X - Player[A].Location.Width / 2.0;
             if(Player[A].Mount == 2)
-                vScreenY[1] = vScreenY[1] - Player[A].Location.Y;
+                vScreenY[1] += -Player[A].Location.Y;
             else
-                vScreenY[1] = vScreenY[1] - Player[A].Location.Y - Player[A].Location.Height;
-            B = B + 1;
+                vScreenY[1] += -Player[A].Location.Y - Player[A].Location.Height;
+            B += 1;
         }
     }
 
@@ -178,12 +178,12 @@ void GetvScreenAverage2()
     {
         if(!Player[A].Dead)
         {
-            vScreenX[1] = vScreenX[1] - Player[A].Location.X - Player[A].Location.Width / 2.0;
+            vScreenX[1] += -Player[A].Location.X - Player[A].Location.Width / 2.0;
             if(Player[A].Mount == 2)
-                vScreenY[1] = vScreenY[1] - Player[A].Location.Y;
+                vScreenY[1] += -Player[A].Location.Y;
             else
-                vScreenY[1] = vScreenY[1] - Player[A].Location.Y - Player[A].Location.Height;
-            B = B + 1;
+                vScreenY[1] += -Player[A].Location.Y - Player[A].Location.Height;
+            B += 1;
         }
     }
 
@@ -266,7 +266,7 @@ void PlayerWarpGFX(int A, Location_t &tempLocation, float &X2, float &Y2)
             {
                 Y2 = float(warp_enter.Y - tempLocation.Y);
                 tempLocation.Y = warp_enter.Y;
-                tempLocation.Height = tempLocation.Height - Y2;
+                tempLocation.Height += -Y2;
             }
         }
         else if(warp_dir_enter == 4) // Moving right
@@ -293,7 +293,7 @@ void PlayerWarpGFX(int A, Location_t &tempLocation, float &X2, float &Y2)
             {
                 Y2 = float(warp_exit.Y - tempLocation.Y);
                 tempLocation.Y = warp_exit.Y;
-                tempLocation.Height = tempLocation.Height - double(Y2);
+                tempLocation.Height += -double(Y2);
             }
         }
         else if(warp_dir_exit == 4) // Moving left
@@ -349,7 +349,7 @@ void NPCWarpGFX(int A, Location_t &tempLocation, float &X2, float &Y2)
             {
                 Y2 = float(warp_enter.Y - tempLocation.Y);
                 tempLocation.Y = warp_enter.Y;
-                tempLocation.Height = tempLocation.Height - double(Y2);
+                tempLocation.Height += -double(Y2);
             }
         }
         else if(warp_dir_enter == 4) // Moving right
@@ -376,7 +376,7 @@ void NPCWarpGFX(int A, Location_t &tempLocation, float &X2, float &Y2)
             {
                 Y2 = float(warp_exit.Y - tempLocation.Y);
                 tempLocation.Y = warp_exit.Y;
-                tempLocation.Height = tempLocation.Height - double(Y2);
+                tempLocation.Height += -double(Y2);
             }
         }
         else if(warp_dir_exit == 4) // Moving left
@@ -430,16 +430,16 @@ void ChangeScreen()
 //        frmMain.Width = 12240
 //        frmMain.Height = 9570
 //        Do While frmMain.ScaleWidth > 800
-//            frmMain.Width = frmMain.Width - 5
+//            frmMain.Width += -5
 //        Loop
 //        Do While frmMain.ScaleHeight > 600
-//            frmMain.Height = frmMain.Height - 5
+//            frmMain.Height += -5
 //        Loop
 //        Do While frmMain.ScaleWidth < 800
-//            frmMain.Width = frmMain.Width + 5
+//            frmMain.Width += 5
 //        Loop
 //        Do While frmMain.ScaleHeight < 600
-//            frmMain.Height = frmMain.Height + 5
+//            frmMain.Height += 5
 //        Loop
 //        SetRes
         SetRes();
@@ -474,11 +474,11 @@ void GetvScreenCredits()
     {
         if((!Player[A].Dead || g_gameInfo.outroDeadMode) && Player[A].Effect != 6)
         {
-            vScreenX[1] = vScreenX[1] - Player[A].Location.X - Player[A].Location.Width / 2.0;
+            vScreenX[1] += -Player[A].Location.X - Player[A].Location.Width / 2.0;
             if(Player[A].Mount == 2)
-                vScreenY[1] = vScreenY[1] - Player[A].Location.Y;
+                vScreenY[1] += -Player[A].Location.Y;
             else
-                vScreenY[1] = vScreenY[1] - Player[A].Location.Y - Player[A].Location.Height;
+                vScreenY[1] += -Player[A].Location.Y - Player[A].Location.Height;
             B++;
         }
     }
@@ -507,9 +507,9 @@ int pfrX(int plrFrame)
 #else
     int A;
     A = plrFrame;
-    A = A - 50;
+    A -= 50;
     while(A > 100)
-        A = A - 100;
+        A -= 100;
     if(A > 90)
         A = 9;
     else if(A > 90)
@@ -544,12 +544,12 @@ int pfrY(int plrFrame)
 #else
     int A;
     A = plrFrame;
-    A = A - 50;
+    A -= 50;
     while(A > 100)
-        A = A - 100;
-    A = A - 1;
+        A -= 100;
+    A -= 1;
     while(A > 9)
-        A = A - 10;
+        A -= 10;
     return A * 100;
 #endif
 }

--- a/src/graphics/gfx_print.cpp
+++ b/src/graphics/gfx_print.cpp
@@ -147,14 +147,14 @@ void SuperPrint(const std::string &SuperWords, int Font, float X, float Y,
 //                BitBlt myBackBuffer, X + B, Y, 18, 16, GFX.Font2Mask(2).hdc, 2, C, vbSrcAnd
 //                BitBlt myBackBuffer, X + B, Y, 18, 16, GFX.Font2(2).hdc, 2, C, vbSrcPaint
                 frmMain.renderTexture(X + B, Y, 18, 16, GFX.Font2[2], 2, C, r, g, b, a);
-//                B = B + 18
+//                B += 18
                 B += 18;
-//                If Left(Words, 1) = "M" Then B = B + 2
+//                If Left(Words, 1) = "M" Then B += 2
                 if(c == 'M')
                     B += 2;
 //            Else
             } else {
-//                B = B + 16
+//                B += 16
                 B += 16;
             }
 //            End If
@@ -175,11 +175,11 @@ void SuperPrint(const std::string &SuperWords, int Font, float X, float Y,
                 C = (c - 33) * 16;
 //                BitBlt myBackBuffer, X + B, Y, 18, 16, GFX.Font2(3).hdc, 2, C, vbSrcPaint
                 frmMain.renderTexture(X + B, Y, 18, 16, GFX.Font2[3], 2, C, r, g, b, a);
-//                B = B + 18
+//                B += 18
                 B += 18;
 //            Else
             } else {
-//                B = B + 18
+//                B += 18
                 B += 18;
 //            End If
             }

--- a/src/graphics/gfx_special_frames.cpp
+++ b/src/graphics/gfx_special_frames.cpp
@@ -24,39 +24,39 @@
 /*Private*/
 void SpecialFrames()
 {
-    SpecialFrameCount[1] = SpecialFrameCount[1] + 1;
+    SpecialFrameCount[1] += 1;
     if(SpecialFrameCount[1] >= 6)
     {
-        SpecialFrame[1] = SpecialFrame[1] + 1;
+        SpecialFrame[1] += 1;
         if(SpecialFrame[1] >= 2)
             SpecialFrame[1] = 0;
         SpecialFrameCount[1] = 0;
     }
-    SpecialFrameCount[2] = SpecialFrameCount[2] + 1;
+    SpecialFrameCount[2] += 1;
     if(SpecialFrameCount[2] >= 3)
     {
-        SpecialFrame[2] = SpecialFrame[2] + 1;
+        SpecialFrame[2] += 1;
         if(SpecialFrame[2] >= 4)
             SpecialFrame[2] = 0;
         SpecialFrameCount[2] = 0;
     }
-    SpecialFrameCount[3] = SpecialFrameCount[3] + 1;
+    SpecialFrameCount[3] += 1;
     if(SpecialFrameCount[3] >= 8)
     {
-        SpecialFrame[3] = SpecialFrame[3] + 1;
+        SpecialFrame[3] += 1;
         if(SpecialFrame[3] >= 4)
             SpecialFrame[3] = 0;
         SpecialFrameCount[3] = 0;
     }
-    SpecialFrameCount[4] = SpecialFrameCount[4] + 1;
+    SpecialFrameCount[4] += 1;
     if(SpecialFrameCount[4] >= 2.475F)
     {
-        SpecialFrame[4] = SpecialFrame[4] + 1;
+        SpecialFrame[4] += 1;
         if(SpecialFrame[4] >= 4)
             SpecialFrame[4] = 0;
         SpecialFrameCount[4] = (float)(SpecialFrameCount[4] - 2.475);
     }
-    SpecialFrameCount[5] = SpecialFrameCount[5] + 1;
+    SpecialFrameCount[5] += 1;
     if(SpecialFrameCount[5] < 20)
         SpecialFrame[5] = 1;
     else if(SpecialFrameCount[5] < 25)
@@ -73,16 +73,16 @@ void SpecialFrames()
         SpecialFrame[5] = 0;
     else
         SpecialFrameCount[5] = 0;
-    SpecialFrameCount[6] = SpecialFrameCount[6] + 1;
+    SpecialFrameCount[6] += 1;
     if(SpecialFrameCount[6] >= 12)
     {
-        SpecialFrame[6] = SpecialFrame[6] + 1;
+        SpecialFrame[6] += 1;
         if(SpecialFrame[6] >= 4)
             SpecialFrame[6] = 0;
         SpecialFrameCount[6] = 0;
     }
 
-    SpecialFrameCount[7] = SpecialFrameCount[7] + 1;
+    SpecialFrameCount[7] += 1;
     if(SpecialFrameCount[7] < 8)
         SpecialFrame[7] = 0;
     else if(SpecialFrameCount[7] < 16)
@@ -97,19 +97,19 @@ void SpecialFrames()
         SpecialFrame[7] = 1;
     else
         SpecialFrameCount[7] = 0;
-    SpecialFrameCount[8] = SpecialFrameCount[8] + 1;
+    SpecialFrameCount[8] += 1;
     if(SpecialFrameCount[8] >= 8)
     {
-        SpecialFrame[8] = SpecialFrame[8] + 1;
+        SpecialFrame[8] += 1;
         if(SpecialFrame[8] >= 3)
             SpecialFrame[8] = 0;
         SpecialFrameCount[8] = 0;
     }
 
-    SpecialFrameCount[9] = SpecialFrameCount[9] + 1; // Fairy frame
+    SpecialFrameCount[9] += 1; // Fairy frame
     if(SpecialFrameCount[9] >= 8)
     {
-        SpecialFrame[9] = SpecialFrame[9] + 1;
+        SpecialFrame[9] += 1;
         if(SpecialFrame[9] >= 2)
             SpecialFrame[9] = 0;
         SpecialFrameCount[9] = 0;

--- a/src/graphics/gfx_update.cpp
+++ b/src/graphics/gfx_update.cpp
@@ -339,7 +339,7 @@ void UpdateGraphics(bool skipRepaint)
                             }
                             NPC[A].TimeLeft = Physics.NPCTimeOffScreen;
 //                            if(nPlay.Online == true && nPlay.NPCWaitCount >= 10 && nPlay.Mode == 0)
-//                                timeStr = timeStr + "2b" + std::to_string(A) + LB;
+//                                timeStr += "2b" + std::to_string(A) + LB;
                             NPC[A].Active = true;
                         }
                         NPC[A].Reset[1] = false;
@@ -424,19 +424,19 @@ void UpdateGraphics(bool skipRepaint)
             BackgroundFrame[161] = BackgroundFrame[18];
             BackgroundFrameCount[18] = 0;
         }
-        BackgroundFrameCount[36] = BackgroundFrameCount[36] + 1;
+        BackgroundFrameCount[36] += 1;
         if(BackgroundFrameCount[36] >= 2)
         {
-            BackgroundFrame[36] = BackgroundFrame[36] + 1;
+            BackgroundFrame[36] += 1;
             if(BackgroundFrame[36] >= 4)
                 BackgroundFrame[36] = 0;
             BackgroundFrameCount[36] = 0;
         }
         BackgroundFrame[68] = BackgroundFrame[36];
-        BackgroundFrameCount[65] = BackgroundFrameCount[65] + 1;
+        BackgroundFrameCount[65] += 1;
         if(BackgroundFrameCount[65] >= 8)
         {
-            BackgroundFrame[65] = BackgroundFrame[65] + 1;
+            BackgroundFrame[65] += 1;
             if(BackgroundFrame[65] >= 4)
                 BackgroundFrame[65] = 0;
             BackgroundFrameCount[65] = 0;
@@ -454,26 +454,26 @@ void UpdateGraphics(bool skipRepaint)
         BackgroundFrame[138] = BackgroundFrame[65];
 
 
-        BackgroundFrameCount[82] = BackgroundFrameCount[82] + 1;
+        BackgroundFrameCount[82] += 1;
         if(BackgroundFrameCount[82] >= 10)
         {
-            BackgroundFrame[82] = BackgroundFrame[82] + 1;
+            BackgroundFrame[82] += 1;
             if(BackgroundFrame[82] >= 4)
                 BackgroundFrame[82] = 0;
             BackgroundFrameCount[82] = 0;
         }
 
-        BackgroundFrameCount[170] = BackgroundFrameCount[170] + 1;
+        BackgroundFrameCount[170] += 1;
         if(BackgroundFrameCount[170] >= 8)
         {
-            BackgroundFrame[170] = BackgroundFrame[170] + 1;
+            BackgroundFrame[170] += 1;
             if(BackgroundFrame[170] >= 4)
                 BackgroundFrame[170] = 0;
             BackgroundFrame[171] = BackgroundFrame[170];
             BackgroundFrameCount[170] = 0;
         }
 
-        BackgroundFrameCount[125] = BackgroundFrameCount[125] + 1;
+        BackgroundFrameCount[125] += 1;
         if(BackgroundFrameCount[125] >= 4)
         {
             if(BackgroundFrame[125] == 0)
@@ -491,24 +491,24 @@ void UpdateGraphics(bool skipRepaint)
     if(BackgroundFrameCount[158] >= 6)
     {
         BackgroundFrameCount[158] = 0;
-        BackgroundFrame[158] = BackgroundFrame[158] + 1;
-        BackgroundFrame[159] = BackgroundFrame[159] + 1;
+        BackgroundFrame[158] += 1;
+        BackgroundFrame[159] += 1;
         if(BackgroundFrame[158] >= 4)
             BackgroundFrame[158] = 0;
         if(BackgroundFrame[159] >= 8)
             BackgroundFrame[159] = 0;
     }
 
-    BackgroundFrameCount[168] = BackgroundFrameCount[168] + 1;
+    BackgroundFrameCount[168] += 1;
     if(BackgroundFrameCount[168] >= 8)
     {
-        BackgroundFrame[168] = BackgroundFrame[168] + 1;
+        BackgroundFrame[168] += 1;
         if(BackgroundFrame[168] >= 8)
             BackgroundFrame[168] = 0;
         BackgroundFrameCount[168] = 0;
     }
 
-    BackgroundFrameCount[173] = BackgroundFrameCount[173] + 1;
+    BackgroundFrameCount[173] += 1;
     if(BackgroundFrameCount[173] >= 8)
     {
         BackgroundFrameCount[173] = 0;
@@ -518,10 +518,10 @@ void UpdateGraphics(bool skipRepaint)
             BackgroundFrame[173] = 0;
     }
 
-    BackgroundFrameCount[187] = BackgroundFrameCount[187] + 1;
+    BackgroundFrameCount[187] += 1;
     if(BackgroundFrameCount[187] >= 6)
     {
-        BackgroundFrame[187] = BackgroundFrame[187] + 1;
+        BackgroundFrame[187] += 1;
         if(BackgroundFrame[187] >= 4)
             BackgroundFrame[187] = 0;
         BackgroundFrame[188] = BackgroundFrame[187];
@@ -602,13 +602,13 @@ void UpdateGraphics(bool skipRepaint)
         if(qScreen)
         {
             if(vScreenX[1] < qScreenX[1] - 2)
-                qScreenX[1] = qScreenX[1] - 2;
+                qScreenX[1] -= 2;
             else if(vScreenX[1] > qScreenX[1] + 2)
-                qScreenX[1] = qScreenX[1] + 2;
+                qScreenX[1] += 2;
             if(vScreenY[1] < qScreenY[1] - 2)
-                qScreenY[1] = qScreenY[1] - 2;
+                qScreenY[1] -= 2;
             else if(vScreenY[1] > qScreenY[1] + 2)
-                qScreenY[1] = qScreenY[1] + 2;
+                qScreenY[1] += 2;
             if(qScreenX[1] < vScreenX[1] + 5 && qScreenX[1] > vScreenX[1] - 5 &&
                qScreenY[1] < vScreenY[1] + 5 && qScreenY[1] > vScreenY[1] - 5)
                 qScreen = false;
@@ -967,7 +967,7 @@ void UpdateGraphics(bool skipRepaint)
                             }
                             NPC[A].TimeLeft = Physics.NPCTimeOffScreen;
 //                            if(nPlay.Online == true && nPlay.NPCWaitCount >= 10 && nPlay.Mode == 0)
-//                                timeStr = timeStr + "2b" + std::to_string(A) + LB;
+//                                timeStr += "2b" + std::to_string(A) + LB;
                             NPC[A].Active = true;
                         }
                         NPC[A].Reset[1] = false;
@@ -1022,8 +1022,8 @@ void UpdateGraphics(bool skipRepaint)
                                 tempLocation.Width = NPCWidth[NPC[Player[A].HoldingNPC].Type];
                             }
 
-                            tempLocation.X = tempLocation.X + NPCFrameOffsetX[NPC[Player[A].HoldingNPC].Type];
-                            tempLocation.Y = tempLocation.Y + NPCFrameOffsetY[NPC[Player[A].HoldingNPC].Type];
+                            tempLocation.X += NPCFrameOffsetX[NPC[Player[A].HoldingNPC].Type];
+                            tempLocation.Y += NPCFrameOffsetY[NPC[Player[A].HoldingNPC].Type];
                             Y2 = 0;
                             X2 = 0;
 
@@ -1047,8 +1047,8 @@ void UpdateGraphics(bool skipRepaint)
                         tempLocation = Player[A].Location;
                         tempLocation.Height = 32;
                         tempLocation.Width = 32;
-                        tempLocation.X = tempLocation.X + Player[A].YoshiBX;
-                        tempLocation.Y = tempLocation.Y + Player[A].YoshiBY;
+                        tempLocation.X += Player[A].YoshiBX;
+                        tempLocation.Y += Player[A].YoshiBY;
                         Y2 = 0;
                         X2 = 0;
                         PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1057,8 +1057,8 @@ void UpdateGraphics(bool skipRepaint)
                         tempLocation = Player[A].Location;
                         tempLocation.Height = 32;
                         tempLocation.Width = 32;
-                        tempLocation.X = tempLocation.X + Player[A].YoshiTX;
-                        tempLocation.Y = tempLocation.Y + Player[A].YoshiTY;
+                        tempLocation.X += Player[A].YoshiTX;
+                        tempLocation.Y += Player[A].YoshiTY;
                         Y2 = 0;
                         X2 = 0;
                         PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1075,8 +1075,8 @@ void UpdateGraphics(bool skipRepaint)
                             else
                                 tempLocation.Height = Player[A].Location.Height - MarioFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] - 30;
                             tempLocation.Width = 100;
-                            tempLocation.X = tempLocation.X + MarioFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
-                            tempLocation.Y = tempLocation.Y + MarioFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.X += MarioFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.Y += MarioFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1084,8 +1084,8 @@ void UpdateGraphics(bool skipRepaint)
                             tempLocation = Player[A].Location;
                             tempLocation.Height = 32;
                             tempLocation.Width = 32;
-                            tempLocation.X = tempLocation.X + Player[A].Location.Width / 2.0 - 16;
-                            tempLocation.Y = tempLocation.Y + Player[A].Location.Height - 30;
+                            tempLocation.X += Player[A].Location.Width / 2.0 - 16;
+                            tempLocation.Y += Player[A].Location.Height - 30;
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1096,8 +1096,8 @@ void UpdateGraphics(bool skipRepaint)
                             tempLocation = Player[A].Location;
                             tempLocation.Height = 100;
                             tempLocation.Width = 100;
-                            tempLocation.X = tempLocation.X + MarioFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
-                            tempLocation.Y = tempLocation.Y + MarioFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + Player[A].MountOffsetY;
+                            tempLocation.X += MarioFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.Y += MarioFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + Player[A].MountOffsetY;
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1114,8 +1114,8 @@ void UpdateGraphics(bool skipRepaint)
                             else
                                 tempLocation.Height = Player[A].Location.Height - LuigiFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] - 30;
                             tempLocation.Width = 100;
-                            tempLocation.X = tempLocation.X + LuigiFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
-                            tempLocation.Y = tempLocation.Y + LuigiFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.X += LuigiFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.Y += LuigiFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1123,8 +1123,8 @@ void UpdateGraphics(bool skipRepaint)
                             tempLocation = Player[A].Location;
                             tempLocation.Height = 32;
                             tempLocation.Width = 32;
-                            tempLocation.X = tempLocation.X + Player[A].Location.Width / 2.0 - 16;
-                            tempLocation.Y = tempLocation.Y + Player[A].Location.Height - 30;
+                            tempLocation.X += Player[A].Location.Width / 2.0 - 16;
+                            tempLocation.Y += Player[A].Location.Height - 30;
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1135,8 +1135,8 @@ void UpdateGraphics(bool skipRepaint)
                             tempLocation = Player[A].Location;
                             tempLocation.Height = 100;
                             tempLocation.Width = 100;
-                            tempLocation.X = tempLocation.X + LuigiFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
-                            tempLocation.Y = tempLocation.Y + LuigiFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + Player[A].MountOffsetY;
+                            tempLocation.X += LuigiFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.Y += LuigiFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + Player[A].MountOffsetY;
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1155,8 +1155,8 @@ void UpdateGraphics(bool skipRepaint)
                                 tempLocation.Height = Player[A].Location.Height - PeachFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] - 30;
 
                             tempLocation.Width = 100;
-                            tempLocation.X = tempLocation.X + PeachFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
-                            tempLocation.Y = tempLocation.Y + PeachFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.X += PeachFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.Y += PeachFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1170,8 +1170,8 @@ void UpdateGraphics(bool skipRepaint)
                             tempLocation = Player[A].Location;
                             tempLocation.Height = 32;
                             tempLocation.Width = 32;
-                            tempLocation.X = tempLocation.X + Player[A].Location.Width / 2.0 - 16;
-                            tempLocation.Y = tempLocation.Y + Player[A].Location.Height - 30;
+                            tempLocation.X += Player[A].Location.Width / 2.0 - 16;
+                            tempLocation.Y += Player[A].Location.Height - 30;
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1188,8 +1188,8 @@ void UpdateGraphics(bool skipRepaint)
                             tempLocation = Player[A].Location;
                             tempLocation.Height = 100;
                             tempLocation.Width = 100;
-                            tempLocation.X = tempLocation.X + PeachFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
-                            tempLocation.Y = tempLocation.Y + PeachFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + Player[A].MountOffsetY;
+                            tempLocation.X += PeachFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.Y += PeachFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + Player[A].MountOffsetY;
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1206,11 +1206,11 @@ void UpdateGraphics(bool skipRepaint)
                             else
                                 tempLocation.Height = Player[A].Location.Height - ToadFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] - 26;
                             tempLocation.Width = 100;
-                            tempLocation.X = tempLocation.X + ToadFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.X += ToadFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
                             if(Player[A].State == 1)
-                                tempLocation.Y = tempLocation.Y + ToadFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + 6;
+                                tempLocation.Y += ToadFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + 6;
                             else
-                                tempLocation.Y = tempLocation.Y + ToadFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] - 4;
+                                tempLocation.Y += ToadFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] - 4;
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1218,8 +1218,8 @@ void UpdateGraphics(bool skipRepaint)
                             tempLocation = Player[A].Location;
                             tempLocation.Height = 32;
                             tempLocation.Width = 32;
-                            tempLocation.X = tempLocation.X + Player[A].Location.Width / 2.0 - 16;
-                            tempLocation.Y = tempLocation.Y + Player[A].Location.Height - 30;
+                            tempLocation.X += Player[A].Location.Width / 2.0 - 16;
+                            tempLocation.Y += Player[A].Location.Height - 30;
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1230,8 +1230,8 @@ void UpdateGraphics(bool skipRepaint)
                             tempLocation = Player[A].Location;
                             tempLocation.Height = 100;
                             tempLocation.Width = 100;
-                            tempLocation.X = tempLocation.X + ToadFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
-                            tempLocation.Y = tempLocation.Y + ToadFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + Player[A].MountOffsetY;
+                            tempLocation.X += ToadFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                            tempLocation.Y += ToadFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + Player[A].MountOffsetY;
                             Y2 = 0;
                             X2 = 0;
                             PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1245,8 +1245,8 @@ void UpdateGraphics(bool skipRepaint)
                         tempLocation = Player[A].Location;
                         tempLocation.Height = 100;
                         tempLocation.Width = 100;
-                        tempLocation.X = tempLocation.X + LinkFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
-                        tempLocation.Y = tempLocation.Y + LinkFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + Player[A].MountOffsetY;
+                        tempLocation.X += LinkFrameX[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)];
+                        tempLocation.Y += LinkFrameY[(Player[A].State * 100) + (Player[A].Frame * Player[A].Direction)] + Player[A].MountOffsetY;
                         Y2 = 0;
                         X2 = 0;
                         PlayerWarpGFX(A, tempLocation, X2, Y2);
@@ -1277,8 +1277,8 @@ void UpdateGraphics(bool skipRepaint)
                             tempLocation.Width = NPCWidth[hNpc.Type];
                         }
 
-                        tempLocation.X = tempLocation.X + NPCFrameOffsetX[hNpc.Type];
-                        tempLocation.Y = tempLocation.Y + NPCFrameOffsetY[hNpc.Type];
+                        tempLocation.X += NPCFrameOffsetX[hNpc.Type];
+                        tempLocation.Y += NPCFrameOffsetY[hNpc.Type];
                         Y2 = 0;
                         X2 = 0;
 
@@ -1407,7 +1407,7 @@ void UpdateGraphics(bool skipRepaint)
 
                             NPC[A].TimeLeft = Physics.NPCTimeOffScreen;
 //                                if(nPlay.Online == true && nPlay.NPCWaitCount >= 10 && nPlay.Mode == 0)
-//                                    timeStr = timeStr + "2b" + std::to_string(A) + LB;
+//                                    timeStr += "2b" + std::to_string(A) + LB;
                             NPC[A].Active = true;
                         }
 
@@ -1458,7 +1458,7 @@ void UpdateGraphics(bool skipRepaint)
 
                         NPC[A].TimeLeft = Physics.NPCTimeOffScreen;
 //                        if(nPlay.Online == true && nPlay.NPCWaitCount >= 10 && nPlay.Mode == 0)
-//                            timeStr = timeStr + "2b" + std::to_string(A) + LB;
+//                            timeStr += "2b" + std::to_string(A) + LB;
                         NPC[A].Active = true;
                     }
                     NPC[A].Reset[1] = false;
@@ -1561,7 +1561,7 @@ void UpdateGraphics(bool skipRepaint)
                                     if(NPC[A].Special == 0.0)
                                     {
                                         if(!FreezeNPCs)
-                                            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                                            NPC[A].FrameCount += 1;
                                         if(NPC[A].FrameCount >= 70)
                                         {
                                             if(!FreezeNPCs)
@@ -1573,7 +1573,7 @@ void UpdateGraphics(bool skipRepaint)
                                     else
                                     {
                                         if(!FreezeNPCs)
-                                            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                                            NPC[A].FrameCount += 1;
                                         if(NPC[A].FrameCount > 8)
                                         {
                                             YoshiBFrame = 0;
@@ -1582,28 +1582,28 @@ void UpdateGraphics(bool skipRepaint)
                                         else if(NPC[A].FrameCount > 6)
                                         {
                                             YoshiBFrame = 1;
-                                            YoshiTX = YoshiTX - 1;
-                                            YoshiTY = YoshiTY + 2;
-                                            YoshiBY = YoshiBY + 1;
+                                            YoshiTX -= 1;
+                                            YoshiTY += 2;
+                                            YoshiBY += 1;
                                         }
                                         else if(NPC[A].FrameCount > 4)
                                         {
                                             YoshiBFrame = 2;
-                                            YoshiTX = YoshiTX - 2;
-                                            YoshiTY = YoshiTY + 4;
-                                            YoshiBY = YoshiBY + 2;
+                                            YoshiTX -= 2;
+                                            YoshiTY += 4;
+                                            YoshiBY += 2;
                                         }
                                         else if(NPC[A].FrameCount > 2)
                                         {
                                             YoshiBFrame = 1;
-                                            YoshiTX = YoshiTX - 1;
-                                            YoshiTY = YoshiTY + 2;
-                                            YoshiBY = YoshiBY + 1;
+                                            YoshiTX -= 1;
+                                            YoshiTY += 2;
+                                            YoshiBY += 1;
                                         }
                                         else
                                             YoshiBFrame = 0;
                                         if(!FreezeNPCs)
-                                            NPC[A].Special2 = NPC[A].Special2 + 1;
+                                            NPC[A].Special2 += 1;
                                         if(NPC[A].Special2 > 30)
                                         {
                                             YoshiTFrame = 0;
@@ -1616,21 +1616,21 @@ void UpdateGraphics(bool skipRepaint)
                                     }
                                     if(YoshiBFrame == 6)
                                     {
-                                        YoshiBY = YoshiBY + 10;
-                                        YoshiTY = YoshiTY + 10;
+                                        YoshiBY += 10;
+                                        YoshiTY += 10;
                                     }
                                     if(NPC[A].Direction == 1)
                                     {
-                                        YoshiTFrame = YoshiTFrame + 5;
-                                        YoshiBFrame = YoshiBFrame + 7;
+                                        YoshiTFrame += 5;
+                                        YoshiBFrame += 7;
                                     }
                                     else
                                     {
                                         YoshiBX = -YoshiBX;
                                         YoshiTX = -YoshiTX;
                                     }
-                                    // YoshiBX = YoshiBX + 4
-                                    // YoshiTX = YoshiTX + 4
+                                    // YoshiBX += 4
+                                    // YoshiTX += 4
                                     g_stats.renderedNPCs++;
                                     // Yoshi's Body
                                     frmMain.renderTexture(vScreenX[Z] + SDL_floor(NPC[A].Location.X) + YoshiBX, vScreenY[Z] + NPC[A].Location.Y + YoshiBY, 32, 32, GFXYoshiB[B], 0, 32 * YoshiBFrame, cn, cn, cn);
@@ -1655,7 +1655,7 @@ void UpdateGraphics(bool skipRepaint)
                                     NPC[A].TimeLeft = Physics.NPCTimeOffScreen * 20;
 
 //                                if(nPlay.Online == true && nPlay.NPCWaitCount >= 10 && nPlay.Mode == 0)
-//                                    timeStr = timeStr + "2b" + std::to_string(A) + LB;
+//                                    timeStr += "2b" + std::to_string(A) + LB;
                                 NPC[A].Active = true;
                             }
                             NPC[A].Reset[1] = false;
@@ -1891,7 +1891,7 @@ void UpdateGraphics(bool skipRepaint)
                                 }
                                 NPC[A].TimeLeft = Physics.NPCTimeOffScreen;
 //                                if(nPlay.Online == true && nPlay.NPCWaitCount >= 10 && nPlay.Mode == 0)
-//                                    timeStr = timeStr + "2b" + std::to_string(A) + LB;
+//                                    timeStr += "2b" + std::to_string(A) + LB;
                                 NPC[A].Active = true;
                             }
                             NPC[A].Reset[1] = false;
@@ -2082,7 +2082,7 @@ void UpdateGraphics(bool skipRepaint)
                                 {
                                     NPC[A].TimeLeft = Physics.NPCTimeOffScreen;
 //                                    if(nPlay.Online == true && nPlay.NPCWaitCount >= 10 && nPlay.Mode == 0)
-//                                        timeStr = timeStr + "2b" + std::to_string(A) + LB;
+//                                        timeStr += "2b" + std::to_string(A) + LB;
                                     NPC[A].Active = true;
                                 }
 
@@ -2241,7 +2241,7 @@ void UpdateGraphics(bool skipRepaint)
             if(LevelEditor)
             {
 
-    //            BlockFlash = BlockFlash + 1
+    //            BlockFlash += 1
                 BlockFlash += 1;
 
     //            If BlockFlash > 45 Then BlockFlash = 0
@@ -2350,12 +2350,12 @@ void UpdateGraphics(bool skipRepaint)
     //                        .Width = level(A).Width - .X
     //                        .Height = level(A).Height - .Y
     //                        If .X < -vScreenX(Z) Then
-    //                            .Width = .Width - (-vScreenX(Z) - .X)
+    //                            .Width += -(-vScreenX(Z) - .X)
     //                            .X = -vScreenX(Z)
 
     //                        End If
     //                        If .Y < -vScreenY(Z) Then
-    //                            .Height = .Height - (-vScreenY(Z) - .Y)
+    //                            .Height += -(-vScreenY(Z) - .Y)
     //                            .Y = -vScreenY(Z)
     //                        End If
     //                        BitBlt myBackBuffer, .X + vScreenX(Z), .Y + vScreenY(Z), .Width, .Height, 0, 0, 0, vbWhiteness
@@ -2747,27 +2747,27 @@ void UpdateGraphics(bool skipRepaint)
         ScreenShot();
 
     // Update Coin Frames
-    CoinFrame2[1] = CoinFrame2[1] + 1;
+    CoinFrame2[1] += 1;
     if(CoinFrame2[1] >= 6)
     {
         CoinFrame2[1] = 0;
-        CoinFrame[1] = CoinFrame[1] + 1;
+        CoinFrame[1] += 1;
         if(CoinFrame[1] >= 4)
             CoinFrame[1] = 0;
     }
-    CoinFrame2[2] = CoinFrame2[2] + 1;
+    CoinFrame2[2] += 1;
     if(CoinFrame2[2] >= 6)
     {
         CoinFrame2[2] = 0;
-        CoinFrame[2] = CoinFrame[2] + 1;
+        CoinFrame[2] += 1;
         if(CoinFrame[2] >= 7)
             CoinFrame[2] = 0;
     }
-    CoinFrame2[3] = CoinFrame2[3] + 1;
+    CoinFrame2[3] += 1;
     if(CoinFrame2[3] >= 7)
     {
         CoinFrame2[3] = 0;
-        CoinFrame[3] = CoinFrame[3] + 1;
+        CoinFrame[3] += 1;
         if(CoinFrame[3] >= 4)
             CoinFrame[3] = 0;
     }
@@ -2775,7 +2775,7 @@ void UpdateGraphics(bool skipRepaint)
 //    {
 //        if(nPlay.NPCWaitCount >= 11)
 //            nPlay.NPCWaitCount = 0;
-//        nPlay.NPCWaitCount = nPlay.NPCWaitCount + 2;
+//        nPlay.NPCWaitCount += 2;
 //        if(timeStr != "")
 //            Netplay::sendData timeStr + LB;
 //    }

--- a/src/graphics/gfx_update2.cpp
+++ b/src/graphics/gfx_update2.cpp
@@ -82,11 +82,11 @@ void UpdateGraphics2(bool skipRepaint)
     vScreen[Z].Width = ScreenW;
     vScreen[Z].Height = ScreenH;
     SpecialFrames();
-    SceneFrame2[1] = SceneFrame2[1] + 1;
+    SceneFrame2[1] += 1;
     if(SceneFrame2[1] >= 12)
     {
         SceneFrame2[1] = 0;
-        SceneFrame[1] = SceneFrame[1] + 1;
+        SceneFrame[1] += 1;
         if(SceneFrame[1] >= 4)
             SceneFrame[1] = 0;
         SceneFrame[4] = SceneFrame[1];
@@ -101,18 +101,18 @@ void UpdateGraphics2(bool skipRepaint)
         SceneFrame[54] = SceneFrame[1];
         SceneFrame[55] = SceneFrame[1];
     }
-    SceneFrame2[27] = SceneFrame2[27] + 1;
+    SceneFrame2[27] += 1;
     if(SceneFrame2[27] >= 8)
     {
         SceneFrame2[27] = 0;
-        SceneFrame[27] = SceneFrame[27] + 1;
+        SceneFrame[27] += 1;
         if(SceneFrame[27] >= 12)
             SceneFrame[27] = 0;
         SceneFrame[28] = SceneFrame[27];
         SceneFrame[29] = SceneFrame[27];
         SceneFrame[30] = SceneFrame[27];
     }
-    SceneFrame2[33] = SceneFrame2[33] + 1;
+    SceneFrame2[33] += 1;
     if(SceneFrame2[33] >= 4)
     {
         SceneFrame2[33] = 0;
@@ -121,20 +121,20 @@ void UpdateGraphics2(bool skipRepaint)
             SceneFrame[33] = 0;
         SceneFrame[34] = SceneFrame[33];
     }
-    SceneFrame2[62] = SceneFrame2[62] + 1;
+    SceneFrame2[62] += 1;
     if(SceneFrame2[62] >= 8)
     {
         SceneFrame2[62] = 0;
-        SceneFrame[62] = SceneFrame[62] + 1;
+        SceneFrame[62] += 1;
         if(SceneFrame[62] >= 8)
             SceneFrame[62] = 0;
         SceneFrame[63] = SceneFrame[62];
     }
-    LevelFrame2[2] = LevelFrame2[2] + 1;
+    LevelFrame2[2] += 1;
     if(LevelFrame2[2] >= 6)
     {
         LevelFrame2[2] = 0;
-        LevelFrame[2] = LevelFrame[2] + 1;
+        LevelFrame[2] += 1;
         if(LevelFrame[2] >= 6)
             LevelFrame[2] = 0;
         LevelFrame[9] = LevelFrame[2];
@@ -144,36 +144,36 @@ void UpdateGraphics2(bool skipRepaint)
         LevelFrame[31] = LevelFrame[2];
         LevelFrame[32] = LevelFrame[2];
     }
-    LevelFrame2[8] = LevelFrame2[8] + 1;
+    LevelFrame2[8] += 1;
     if(LevelFrame2[8] >= 12)
     {
         LevelFrame2[8] = 0;
-        LevelFrame[8] = LevelFrame[8] + 1;
+        LevelFrame[8] += 1;
         if(LevelFrame[8] >= 4)
             LevelFrame[8] = 0;
     }
-    LevelFrame2[12] = LevelFrame2[12] + 1;
+    LevelFrame2[12] += 1;
     if(LevelFrame2[12] >= 8)
     {
         LevelFrame2[12] = 0;
-        LevelFrame[12] = LevelFrame[12] + 1;
+        LevelFrame[12] += 1;
         if(LevelFrame[12] >= 2)
             LevelFrame[12] = 0;
     }
-    LevelFrame2[25] = LevelFrame2[25] + 1;
+    LevelFrame2[25] += 1;
     if(LevelFrame2[25] >= 8)
     {
         LevelFrame2[25] = 0;
-        LevelFrame[25] = LevelFrame[25] + 1;
+        LevelFrame[25] += 1;
         if(LevelFrame[25] >= 4)
             LevelFrame[25] = 0;
         LevelFrame[26] = LevelFrame[25];
     }
-    TileFrame2[14] = TileFrame2[14] + 1;
+    TileFrame2[14] += 1;
     if(TileFrame2[14] >= 14)
     {
         TileFrame2[14] = 0;
-        TileFrame[14] = TileFrame[14] + 1;
+        TileFrame[14] += 1;
         if(TileFrame[14] >= 4)
             TileFrame[14] = 0;
         TileFrame[27] = TileFrame[14];
@@ -546,7 +546,7 @@ void UpdateGraphics2(bool skipRepaint)
 
                     if(Player[A].MountType == 3)
                     {
-                        Player[A].YoshiWingsFrameCount = Player[A].YoshiWingsFrameCount + 1;
+                        Player[A].YoshiWingsFrameCount += 1;
                         Player[A].YoshiWingsFrame = 0;
                         if(Player[A].YoshiWingsFrameCount <= 12)
                             Player[A].YoshiWingsFrame = 1;
@@ -588,7 +588,7 @@ void UpdateGraphics2(bool skipRepaint)
 
                     if(Player[A].MountType == 3)
                     {
-                        Player[A].YoshiWingsFrameCount = Player[A].YoshiWingsFrameCount + 1;
+                        Player[A].YoshiWingsFrameCount += 1;
                         Player[A].YoshiWingsFrame = 0;
                         if(Player[A].YoshiWingsFrameCount <= 12)
                             Player[A].YoshiWingsFrame = 1;
@@ -629,7 +629,7 @@ void UpdateGraphics2(bool skipRepaint)
 
                     if(Player[A].MountType == 3)
                     {
-                        Player[A].YoshiWingsFrameCount = Player[A].YoshiWingsFrameCount + 1;
+                        Player[A].YoshiWingsFrameCount += 1;
                         Player[A].YoshiWingsFrame = 0;
                         if(Player[A].YoshiWingsFrameCount <= 12)
                             Player[A].YoshiWingsFrame = 1;
@@ -669,7 +669,7 @@ void UpdateGraphics2(bool skipRepaint)
 
                     if(Player[A].MountType == 3)
                     {
-                        Player[A].YoshiWingsFrameCount = Player[A].YoshiWingsFrameCount + 1;
+                        Player[A].YoshiWingsFrameCount += 1;
                         Player[A].YoshiWingsFrame = 0;
                         if(Player[A].YoshiWingsFrameCount <= 12)
                             Player[A].YoshiWingsFrame = 1;

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -84,8 +84,8 @@ void ShowLayer(std::string LayerName, bool NoEffect)
                 if(!NoEffect && !NPC[A].Generator)
                 {
                     tempLocation = NPC[A].Location;
-                    tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
-                    tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
+                    tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
+                    tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
                     NewEffect(10, tempLocation);
                 }
 
@@ -124,8 +124,8 @@ void ShowLayer(std::string LayerName, bool NoEffect)
                 if(!NoEffect && !Block[A].Invis)
                 {
                     tempLocation = Block[A].Location;
-                    tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
-                    tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
+                    tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
+                    tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
                     NewEffect(10, tempLocation);
                 }
             }
@@ -156,8 +156,8 @@ void ShowLayer(std::string LayerName, bool NoEffect)
                 if(!NoEffect)
                 {
                     tempLocation = Background[A].Location;
-                    tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
-                    tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
+                    tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
+                    tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
                     NewEffect(10, tempLocation);
                 }
             }
@@ -200,8 +200,8 @@ void HideLayer(std::string LayerName, bool NoEffect)
                 if(!NoEffect && !NPC[A].Generator)
                 {
                     tempLocation = NPC[A].Location;
-                    tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
-                    tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
+                    tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
+                    tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
                     NewEffect(10, tempLocation);
                 }
             }
@@ -222,8 +222,8 @@ void HideLayer(std::string LayerName, bool NoEffect)
                 if(!NoEffect && !Block[A].Invis)
                 {
                     tempLocation = Block[A].Location;
-                    tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
-                    tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
+                    tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
+                    tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
                     NewEffect(10, tempLocation);
                 }
             }
@@ -241,8 +241,8 @@ void HideLayer(std::string LayerName, bool NoEffect)
                 if(!NoEffect)
                 {
                     tempLocation = Background[A].Location;
-                    tempLocation.X = tempLocation.X + tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
-                    tempLocation.Y = tempLocation.Y + tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
+                    tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2.0;
+                    tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2.0;
                     NewEffect(10, tempLocation);
                 }
             }
@@ -408,16 +408,16 @@ void ProcEvent(std::string EventName, bool NoEffect)
                             if(int(screenLoc.Width) == 400)
                             {
                                 if(qScreenX[1] < tX + screenLoc.Left)
-                                    qScreenX[1] = qScreenX[1] + 200;
+                                    qScreenX[1] += 200;
                                 else
-                                    qScreenX[1] = qScreenX[1] - 200;
+                                    qScreenX[1] -= 200;
                             }
                             if(int(screenLoc.Height) == 300)
                             {
                                 if(qScreenY[1] < tY + screenLoc.Top)
-                                    qScreenY[1] = qScreenY[1] + 150;
+                                    qScreenY[1] += 150;
                                 else
-                                    qScreenY[1] = qScreenY[1] - 150;
+                                    qScreenY[1] -= 150;
                             }
                             if(-qScreenX[1] < level[Player[C].Section].X)
                                 qScreenX[1] = -level[Player[C].Section].X;

--- a/src/main/cheat_code.cpp
+++ b/src/main/cheat_code.cpp
@@ -138,10 +138,10 @@ void CheatCode(char NewKey)
             for(B = 1; B <= numWorldPaths; B++)
             {
                 tempLocation = WorldPath[B].Location;
-                tempLocation.X = tempLocation.X + 4;
-                tempLocation.Y = tempLocation.Y + 4;
-                tempLocation.Width = tempLocation.Width - 8;
-                tempLocation.Height = tempLocation.Height - 8;
+                tempLocation.X += 4;
+                tempLocation.Y += 4;
+                tempLocation.Width -= 8;
+                tempLocation.Height -= 8;
                 WorldPath[B].Active = true;
                 for(C = 1; C <= numScenes; C++)
                 {
@@ -430,7 +430,7 @@ void CheatCode(char NewKey)
                               Player[B].Location.Y + Player[B].Location.Height / 2.0 - EffectHeight[10] / 2.0));
                 }
                 if(Player[B].Character >= 3 && Player[B].Hearts < 3)
-                    Player[B].Hearts = Player[B].Hearts + 1;
+                    Player[B].Hearts += 1;
             }
             CheatString.clear();
             cheated = true;
@@ -454,7 +454,7 @@ void CheatCode(char NewKey)
                               Player[B].Location.Y + Player[B].Location.Height / 2.0 - EffectHeight[10] / 2.0));
                 }
                 if(Player[B].Character >= 3 && Player[B].Hearts < 3)
-                    Player[B].Hearts = Player[B].Hearts + 1;
+                    Player[B].Hearts += 1;
             }
             CheatString.clear();
             cheated = true;
@@ -479,7 +479,7 @@ void CheatCode(char NewKey)
                               Player[B].Location.Y + Player[B].Location.Height / 2.0 - EffectHeight[10] / 2.0));
                 }
                 if(Player[B].Character >= 3 && Player[B].Hearts < 3)
-                    Player[B].Hearts = Player[B].Hearts + 1;
+                    Player[B].Hearts += 1;
             }
             CheatString.clear();
             cheated = true;
@@ -503,7 +503,7 @@ void CheatCode(char NewKey)
                               Player[B].Location.Y + Player[B].Location.Height / 2.0 - EffectHeight[10] / 2.0));
                 }
                 if(Player[B].Character >= 3 && Player[B].Hearts < 3)
-                    Player[B].Hearts = Player[B].Hearts + 1;
+                    Player[B].Hearts += 1;
             }
             CheatString.clear();
             cheated = true;
@@ -527,7 +527,7 @@ void CheatCode(char NewKey)
                               Player[B].Location.Y + Player[B].Location.Height / 2.0 - EffectHeight[10] / 2.0));
                 }
                 if(Player[B].Character >= 3 && Player[B].Hearts < 3)
-                    Player[B].Hearts = Player[B].Hearts + 1;
+                    Player[B].Hearts += 1;
             }
             CheatString.clear();
             cheated = true;
@@ -551,7 +551,7 @@ void CheatCode(char NewKey)
                               Player[B].Location.Y + Player[B].Location.Height / 2.0 - EffectHeight[10] / 2.0));
                 }
                 if(Player[B].Character >= 3 && Player[B].Hearts < 3)
-                    Player[B].Hearts = Player[B].Hearts + 1;
+                    Player[B].Hearts += 1;
             }
             CheatString.clear();
             cheated = true;
@@ -657,11 +657,11 @@ void CheatCode(char NewKey)
                 Player[B].Immune = 50;
                 if(Player[B].Mount <= 1)
                 {
-                    Player[B].Location.Y = Player[B].Location.Y + Player[B].Location.Height;
+                    Player[B].Location.Y += Player[B].Location.Height;
                     Player[B].Location.Height = Physics.PlayerHeight[Player[B].Character][Player[B].State];
                     if(Player[B].Mount == 1 && Player[B].State == 1)
                         Player[B].Location.Height = Physics.PlayerHeight[1][2];
-                    Player[B].Location.Y = Player[B].Location.Y - Player[B].Location.Height;
+                    Player[B].Location.Y += -Player[B].Location.Height;
                     Player[B].StandUp = true;
                 }
                 tempLocation = Player[B].Location;
@@ -682,11 +682,11 @@ void CheatCode(char NewKey)
                 Player[B].Immune = 50;
                 if(Player[B].Mount <= 1)
                 {
-                    Player[B].Location.Y = Player[B].Location.Y + Player[B].Location.Height;
+                    Player[B].Location.Y += Player[B].Location.Height;
                     Player[B].Location.Height = Physics.PlayerHeight[Player[B].Character][Player[B].State];
                     if(Player[B].Mount == 1 && Player[B].State == 1)
                         Player[B].Location.Height = Physics.PlayerHeight[1][2];
-                    Player[B].Location.Y = Player[B].Location.Y - Player[B].Location.Height;
+                    Player[B].Location.Y += -Player[B].Location.Height;
                     Player[B].StandUp = true;
                 }
                 tempLocation = Player[B].Location;
@@ -707,11 +707,11 @@ void CheatCode(char NewKey)
                 Player[B].Immune = 50;
                 if(Player[B].Mount <= 1)
                 {
-                    Player[B].Location.Y = Player[B].Location.Y + Player[B].Location.Height;
+                    Player[B].Location.Y += Player[B].Location.Height;
                     Player[B].Location.Height = Physics.PlayerHeight[Player[B].Character][Player[B].State];
                     if(Player[B].Mount == 1 && Player[B].State == 1)
                         Player[B].Location.Height = Physics.PlayerHeight[1][2];
-                    Player[B].Location.Y = Player[B].Location.Y - Player[B].Location.Height;
+                    Player[B].Location.Y += -Player[B].Location.Height;
                     Player[B].StandUp = true;
                 }
                 tempLocation = Player[B].Location;
@@ -733,11 +733,11 @@ void CheatCode(char NewKey)
                 Player[B].Immune = 50;
                 if(Player[B].Mount <= 1)
                 {
-                    Player[B].Location.Y = Player[B].Location.Y + Player[B].Location.Height;
+                    Player[B].Location.Y += Player[B].Location.Height;
                     Player[B].Location.Height = Physics.PlayerHeight[Player[B].Character][Player[B].State];
                     if(Player[B].Mount == 1 && Player[B].State == 1)
                         Player[B].Location.Height = Physics.PlayerHeight[1][2];
-                    Player[B].Location.Y = Player[B].Location.Y - Player[B].Location.Height;
+                    Player[B].Location.Y += -Player[B].Location.Height;
                     Player[B].StandUp = true;
                 }
                 tempLocation = Player[B].Location;
@@ -758,11 +758,11 @@ void CheatCode(char NewKey)
                 Player[B].Immune = 50;
                 if(Player[B].Mount <= 1)
                 {
-                    Player[B].Location.Y = Player[B].Location.Y + Player[B].Location.Height;
+                    Player[B].Location.Y += Player[B].Location.Height;
                     Player[B].Location.Height = Physics.PlayerHeight[Player[B].Character][Player[B].State];
                     if(Player[B].Mount == 1 && Player[B].State == 1)
                         Player[B].Location.Height = Physics.PlayerHeight[1][2];
-                    Player[B].Location.Y = Player[B].Location.Y - Player[B].Location.Height;
+                    Player[B].Location.Y += -Player[B].Location.Height;
                     Player[B].StandUp = true;
                 }
                 tempLocation = Player[B].Location;
@@ -942,11 +942,11 @@ void CheatCode(char NewKey)
                         Player[C].Character = 1;
                         if(Player[C].Mount <= 1)
                         {
-                            Player[C].Location.Y = Player[C].Location.Y + Player[C].Location.Height;
+                            Player[C].Location.Y += Player[C].Location.Height;
                             Player[C].Location.Height = Physics.PlayerHeight[Player[C].Character][Player[C].State];
                             if(Player[C].Mount == 1 && Player[C].State == 1)
                                 Player[C].Location.Height = Physics.PlayerHeight[1][2];
-                            Player[C].Location.Y = Player[C].Location.Y - Player[C].Location.Height;
+                            Player[C].Location.Y += -Player[C].Location.Height;
                             Player[C].StandUp = true;
                         }
                     }
@@ -955,11 +955,11 @@ void CheatCode(char NewKey)
                         Player[C].Character = 2;
                         if(Player[C].Mount <= 1)
                         {
-                            Player[C].Location.Y = Player[C].Location.Y + Player[C].Location.Height;
+                            Player[C].Location.Y += Player[C].Location.Height;
                             Player[C].Location.Height = Physics.PlayerHeight[Player[C].Character][Player[C].State];
                             if(Player[C].Mount == 1 && Player[C].State == 1)
                                 Player[C].Location.Height = Physics.PlayerHeight[1][2];
-                            Player[C].Location.Y = Player[C].Location.Y - Player[C].Location.Height;
+                            Player[C].Location.Y += -Player[C].Location.Height;
                             Player[C].StandUp = true;
                         }
                     }
@@ -994,11 +994,11 @@ void CheatCode(char NewKey)
                 Player[C].Character = 1;
                 if(Player[C].Mount <= 1)
                 {
-                    Player[C].Location.Y = Player[C].Location.Y + Player[C].Location.Height;
+                    Player[C].Location.Y += Player[C].Location.Height;
                     Player[C].Location.Height = Physics.PlayerHeight[Player[C].Character][Player[C].State];
                     if(Player[C].Mount == 1 && Player[C].State == 1)
                         Player[C].Location.Height = Physics.PlayerHeight[1][2];
-                    Player[C].Location.Y = Player[C].Location.Y - Player[C].Location.Height;
+                    Player[C].Location.Y += -Player[C].Location.Height;
                     Player[C].StandUp = true;
                 }
                 Player[C].Immune = 1;
@@ -1032,11 +1032,11 @@ void CheatCode(char NewKey)
                         Player[C].Character = 1;
                         if(Player[C].Mount <= 1)
                         {
-                            Player[C].Location.Y = Player[C].Location.Y + Player[C].Location.Height;
+                            Player[C].Location.Y += Player[C].Location.Height;
                             Player[C].Location.Height = Physics.PlayerHeight[Player[C].Character][Player[C].State];
                             if(Player[C].Mount == 1 && Player[C].State == 1)
                                 Player[C].Location.Height = Physics.PlayerHeight[1][2];
-                            Player[C].Location.Y = Player[C].Location.Y - Player[C].Location.Height;
+                            Player[C].Location.Y += -Player[C].Location.Height;
                             Player[C].StandUp = true;
                         }
                     }
@@ -1045,11 +1045,11 @@ void CheatCode(char NewKey)
                         Player[C].Character = 2;
                         if(Player[C].Mount <= 1)
                         {
-                            Player[C].Location.Y = Player[C].Location.Y + Player[C].Location.Height;
+                            Player[C].Location.Y += Player[C].Location.Height;
                             Player[C].Location.Height = Physics.PlayerHeight[Player[C].Character][Player[C].State];
                             if(Player[C].Mount == 1 && Player[C].State == 1)
                                 Player[C].Location.Height = Physics.PlayerHeight[1][2];
-                            Player[C].Location.Y = Player[C].Location.Y - Player[C].Location.Height;
+                            Player[C].Location.Y += -Player[C].Location.Height;
                             Player[C].StandUp = true;
                         }
                     }
@@ -1075,17 +1075,17 @@ void CheatCode(char NewKey)
                     )
                     {
                         PlaySound(SFX_Raccoon);
-                        NPC[B].Location.Y = NPC[B].Location.Y + NPC[B].Location.Height / 2.0;
-                        NPC[B].Location.X = NPC[B].Location.X + NPC[B].Location.Width / 2.0;
+                        NPC[B].Location.Y += NPC[B].Location.Height / 2.0;
+                        NPC[B].Location.X += NPC[B].Location.Width / 2.0;
                         tempLocation = NPC[B].Location;
-                        tempLocation.Y = tempLocation.Y - 16;
-                        tempLocation.X = tempLocation.X - 16;
+                        tempLocation.Y -= 16;
+                        tempLocation.X -= 16;
                         NewEffect(10, tempLocation);
                         NPC[B].Type = 10;
                         NPC[B].Location.Width = NPCWidth[NPC[B].Type];
                         NPC[B].Location.Height = NPCHeight[NPC[B].Type];
-                        NPC[B].Location.Y = NPC[B].Location.Y - NPC[B].Location.Height / 2.0;
-                        NPC[B].Location.X = NPC[B].Location.X - NPC[B].Location.Width / 2.0;
+                        NPC[B].Location.Y += -NPC[B].Location.Height / 2.0;
+                        NPC[B].Location.X += -NPC[B].Location.Width / 2.0;
                         NPC[B].Location.SpeedX = 0;
                         NPC[B].Location.SpeedY = 0;
                     }

--- a/src/main/game_loop.cpp
+++ b/src/main/game_loop.cpp
@@ -313,13 +313,13 @@ void PauseGame(int plr)
                     if(upPressed)
                     {
                         PlaySound(SFX_Slide);
-                        MenuCursor = MenuCursor - 1;
+                        MenuCursor -= 1;
                         noButtons = false;
                     }
                     else if(downPressed)
                     {
                         PlaySound(SFX_Slide);
-                        MenuCursor = MenuCursor + 1;
+                        MenuCursor += 1;
                         noButtons = false;
                     }
 
@@ -365,7 +365,7 @@ void PauseGame(int plr)
                                     {
                                         do
                                         {
-                                            Player[A].Character = Player[A].Character - 1;
+                                            Player[A].Character -= 1;
                                             if(Player[A].Character <= 0)
                                                 Player[A].Character = 5;
                                         } while(Player[A].Character == Player[B].Character || blockCharacter[Player[A].Character]);
@@ -374,7 +374,7 @@ void PauseGame(int plr)
                                     {
                                         do
                                         {
-                                            Player[A].Character = Player[A].Character + 1;
+                                            Player[A].Character += 1;
                                             if(Player[A].Character >= 6)
                                                 Player[A].Character = 1;
                                         } while(Player[A].Character == Player[B].Character || blockCharacter[Player[A].Character]);

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -56,7 +56,7 @@ void SaveGame()
                 Star[numStars].level.clear();
                 Star[numStars].Section = 0;
             }
-            numStars = numStars - 1;
+            numStars -= 1;
         }
     }
 

--- a/src/main/level_file.cpp
+++ b/src/main/level_file.cpp
@@ -730,7 +730,7 @@ bool OpenLevelData(LevelData &lvl, const std::string FilePath)
 //        curSection = 0;
 //        vScreenY[1] = -(level[curSection].Height - 600);
 //        vScreenX[1] = -level[curSection].X;
-//        numWarps = numWarps + 1;
+//        numWarps += 1;
 //        for(A = 0; A < frmLevelSettings::optBackground.Count; A++)
 //        {
 //            if(Background2[0] == A)
@@ -785,7 +785,7 @@ bool OpenLevelData(LevelData &lvl, const std::string FilePath)
         for(A = 0; A <= numSections; A++) // Automatically correct 608 section height to 600
         {
 //            if(int(level[A].Height - level[A].Y) == 608)
-//                level[A].Y = level[A].Y + 8;
+//                level[A].Y += 8;
             int height = int(level[A].Height - level[A].Y);
             if(height > 600 && height < 610)
                 level[A].Y = level[A].Height - 600; // Better and cleaner logic

--- a/src/main/menu_loop.cpp
+++ b/src/main/menu_loop.cpp
@@ -287,7 +287,7 @@ static void updateIntroLevelActivity()
                     if(p.State == 1)
                     {
                         p.Location.Height = Physics.PlayerHeight[1][2];
-                        p.Location.Y = p.Location.Y - Physics.PlayerHeight[1][2] + Physics.PlayerHeight[p.Character][1];
+                        p.Location.Y += -Physics.PlayerHeight[1][2] + Physics.PlayerHeight[p.Character][1];
                     }
                 }
             }
@@ -298,9 +298,9 @@ static void updateIntroLevelActivity()
                 {
                     p.Mount = 3;
                     p.MountType = (iRand() % 7) + 1;
-                    p.Location.Y = p.Location.Y + p.Location.Height;
+                    p.Location.Y += p.Location.Height;
                     p.Location.Height = Physics.PlayerHeight[2][2];
-                    p.Location.Y = p.Location.Y - p.Location.Height - 0.01;
+                    p.Location.Y += -p.Location.Height - 0.01;
                 }
             }
 
@@ -419,7 +419,7 @@ static void updateIntroLevelActivity()
         {
             tempLocation = Player[A].Location;
             tempLocation.Width = 95;
-            tempLocation.Height = tempLocation.Height - 1;
+            tempLocation.Height -= 1;
 
             for(auto B = 1; B <= numBlock; B++)
             {

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -980,10 +980,10 @@ bool mainMenuUpdate()
                                 tempLocation = WorldPath[A].Location;
                                 {
                                     Location_t &l =tempLocation;
-                                    l.X = l.X + 4;
-                                    l.Y = l.Y + 4;
-                                    l.Width = l.Width - 8;
-                                    l.Height = l.Height - 8;
+                                    l.X += 4;
+                                    l.Y += 4;
+                                    l.Width -= 8;
+                                    l.Height -= 8;
                                 }
 
                                 WorldPath[A].Active = true;
@@ -1678,11 +1678,11 @@ void mainMenuDraw()
             SuperPrint(g_mainMenu.selectPlayer[2], 3, 300, 380 + A);
         else
         {
-            A = A - 30;
+            A -= 30;
             if(MenuCursor + 1 >= 2)
-                B = B - 30;
+                B -= 30;
             if(PlayerCharacter >= 2)
-                C = C - 30;
+                C -= 30;
         }
 
         if(!blockCharacter[3])

--- a/src/main/player_frames.cpp
+++ b/src/main/player_frames.cpp
@@ -106,7 +106,7 @@ void SetupPlayerFrames()
 
     For(A, 151, 349)
     {
-        ToadFrameY[A] = ToadFrameY[A] - 4;
+        ToadFrameY[A] -= 4;
     }
 
     ToadFrameY[227] = 0;
@@ -480,18 +480,18 @@ void SetupPlayerFrames()
     LuigiFrameX[421] = -16;
     For(A, 150, maxPlayerFrames) // Adjust the players frames to their new sizes
     {
-        MarioFrameX[A] = MarioFrameX[A] - 2;
-        LuigiFrameX[A] = LuigiFrameX[A] - 2;
-        LuigiFrameY[A] = LuigiFrameY[A] - 2;
+        MarioFrameX[A] -= 2;
+        LuigiFrameX[A] -= 2;
+        LuigiFrameY[A] -= 2;
     }
-    LuigiFrameY[101] = LuigiFrameY[101] - 2;
-    LuigiFrameY[102] = LuigiFrameY[102] - 2;
-    LuigiFrameY[105] = LuigiFrameY[105] - 2;
-    LuigiFrameY[106] = LuigiFrameY[106] - 2;
-    LuigiFrameY[99] = LuigiFrameY[99] - 2;
-    LuigiFrameY[98] = LuigiFrameY[98] - 2;
-    LuigiFrameY[95] = LuigiFrameY[95] - 2;
-    LuigiFrameY[94] = LuigiFrameY[94] - 2;
+    LuigiFrameY[101] -= 2;
+    LuigiFrameY[102] -= 2;
+    LuigiFrameY[105] -= 2;
+    LuigiFrameY[106] -= 2;
+    LuigiFrameY[99] -= 2;
+    LuigiFrameY[98] -= 2;
+    LuigiFrameY[95] -= 2;
+    LuigiFrameY[94] -= 2;
 // Yoshi Frames
     MarioFrameX[130] = -2 - 4;
     MarioFrameX[70] = 6 - 4;
@@ -661,12 +661,12 @@ void SetupPlayerFrames()
         LuigiFrameX[A + 100] = LuigiFrameX[A - 200];
         LuigiFrameY[A + 100] = LuigiFrameY[A - 200];
     }
-    MarioFrameY[508] = MarioFrameY[508] - 2;
-    MarioFrameY[509] = MarioFrameY[509] - 2;
-    MarioFrameY[510] = MarioFrameY[510] - 2;
-    MarioFrameY[492] = MarioFrameY[492] - 2;
-    MarioFrameY[491] = MarioFrameY[491] - 2;
-    MarioFrameY[490] = MarioFrameY[490] - 2;
+    MarioFrameY[508] -= 2;
+    MarioFrameY[509] -= 2;
+    MarioFrameY[510] -= 2;
+    MarioFrameY[492] -= 2;
+    MarioFrameY[491] -= 2;
+    MarioFrameY[490] -= 2;
     MarioFrameY[501] = -2;
     MarioFrameY[499] = -2;
     MarioFrameY[502] = -2;
@@ -689,9 +689,9 @@ void SetupPlayerFrames()
     MarioFrameX[518] = -16;
     MarioFrameX[517] = -16;
     MarioFrameX[516] = -16;
-    MarioFrameY[530] = MarioFrameY[530] - 2;
-    MarioFrameY[531] = MarioFrameY[531] - 2;
-    MarioFrameY[470] = MarioFrameY[470] - 2;
+    MarioFrameY[530] -= 2;
+    MarioFrameY[531] -= 2;
+    MarioFrameY[470] -= 2;
     MarioFrameY[569] = MarioFrameY[469] - 2;
     MarioFrameY[500] = -2;
     MarioFrameX[500] = -4;

--- a/src/main/world_file.cpp
+++ b/src/main/world_file.cpp
@@ -284,8 +284,8 @@ void OpenWorld(std::string FilePath)
         // In game they are smaller (30x30), in world they are 32x32
         box.Location.Width = 30;
         box.Location.Height = 30;
-        box.Location.Y = box.Location.Y + 1;
-        box.Location.X = box.Location.X + 1;
+        box.Location.Y += 1;
+        box.Location.X += 1;
         box.Z = zCounter++;
         treeWorldMusicAdd(&box);
     }

--- a/src/main/world_loop.cpp
+++ b/src/main/world_loop.cpp
@@ -214,11 +214,11 @@ void WorldLoop()
 
     if(WorldPlayer[1].Move > 0)
     {
-        WorldPlayer[1].Frame2 = WorldPlayer[1].Frame2 + 1;
+        WorldPlayer[1].Frame2 += 1;
         if(WorldPlayer[1].Frame2 >= 8)
         {
             WorldPlayer[1].Frame2 = 0;
-            WorldPlayer[1].Frame = WorldPlayer[1].Frame + 1;
+            WorldPlayer[1].Frame += 1;
         }
         if(WorldPlayer[1].Move == 1)
         {
@@ -294,7 +294,7 @@ void WorldLoop()
 
         if(Player[1].Controls.Up)
         {
-            tempLocation.Y = tempLocation.Y - 32;
+            tempLocation.Y -= 32;
             treeWorldPathQuery(tempLocation, parr, true);
             //for(A = 1; A <= numWorldPaths; A++)
             for(auto *t : parr)
@@ -332,7 +332,7 @@ void WorldLoop()
         }
         else if(Player[1].Controls.Left)
         {
-            tempLocation.X = tempLocation.X - 32;
+            tempLocation.X -= 32;
             treeWorldPathQuery(tempLocation, parr, true);
             //for(A = 1; A <= numWorldPaths; A++)
             for(auto *t : parr)
@@ -371,7 +371,7 @@ void WorldLoop()
         }
         else if(Player[1].Controls.Down)
         {
-            tempLocation.Y = tempLocation.Y + 32;
+            tempLocation.Y += 32;
             treeWorldPathQuery(tempLocation, parr, true);
             //for(A = 1; A <= numWorldPaths; A++)
             for(auto *t : parr)
@@ -410,7 +410,7 @@ void WorldLoop()
         }
         else if(Player[1].Controls.Right)
         {
-            tempLocation.X = tempLocation.X + 32;
+            tempLocation.X += 32;
             treeWorldPathQuery(tempLocation, parr, true);
             //for(A = 1; A <= numWorldPaths; A++)
             for(auto *t : parr)
@@ -541,12 +541,12 @@ void WorldLoop()
     }
     else if(WorldPlayer[1].Move == 1)
     {
-        WorldPlayer[1].Move2 = WorldPlayer[1].Move2 + 2;
-        WorldPlayer[1].Location.Y = WorldPlayer[1].Location.Y - 2;
+        WorldPlayer[1].Move2 += 2;
+        WorldPlayer[1].Location.Y -= 2;
         if(WalkAnywhere)
         {
-            WorldPlayer[1].Move2 = WorldPlayer[1].Move2 + 2;
-            WorldPlayer[1].Location.Y = WorldPlayer[1].Location.Y - 2;
+            WorldPlayer[1].Move2 += 2;
+            WorldPlayer[1].Location.Y -= 2;
         }
         if(WorldPlayer[1].Move2 >= 32)
         {
@@ -557,12 +557,12 @@ void WorldLoop()
     }
     else if(WorldPlayer[1].Move == 2)
     {
-        WorldPlayer[1].Move2 = WorldPlayer[1].Move2 + 2;
-        WorldPlayer[1].Location.X = WorldPlayer[1].Location.X - 2;
+        WorldPlayer[1].Move2 += 2;
+        WorldPlayer[1].Location.X -= 2;
         if(WalkAnywhere)
         {
-            WorldPlayer[1].Move2 = WorldPlayer[1].Move2 + 2;
-            WorldPlayer[1].Location.X = WorldPlayer[1].Location.X - 2;
+            WorldPlayer[1].Move2 += 2;
+            WorldPlayer[1].Location.X -= 2;
         }
         if(WorldPlayer[1].Move2 >= 32)
         {
@@ -573,12 +573,12 @@ void WorldLoop()
     }
     else if(WorldPlayer[1].Move == 3)
     {
-        WorldPlayer[1].Move2 = WorldPlayer[1].Move2 + 2;
-        WorldPlayer[1].Location.Y = WorldPlayer[1].Location.Y + 2;
+        WorldPlayer[1].Move2 += 2;
+        WorldPlayer[1].Location.Y += 2;
         if(WalkAnywhere)
         {
-            WorldPlayer[1].Move2 = WorldPlayer[1].Move2 + 2;
-            WorldPlayer[1].Location.Y = WorldPlayer[1].Location.Y + 2;
+            WorldPlayer[1].Move2 += 2;
+            WorldPlayer[1].Location.Y += 2;
         }
         if(WorldPlayer[1].Move2 >= 32)
         {
@@ -589,12 +589,12 @@ void WorldLoop()
     }
     else if(WorldPlayer[1].Move == 4)
     {
-        WorldPlayer[1].Move2 = WorldPlayer[1].Move2 + 2;
-        WorldPlayer[1].Location.X = WorldPlayer[1].Location.X + 2;
+        WorldPlayer[1].Move2 += 2;
+        WorldPlayer[1].Location.X += 2;
         if(WalkAnywhere)
         {
-            WorldPlayer[1].Move2 = WorldPlayer[1].Move2 + 2;
-            WorldPlayer[1].Location.X = WorldPlayer[1].Location.X + 2;
+            WorldPlayer[1].Move2 += 2;
+            WorldPlayer[1].Location.X += 2;
         }
         if(WorldPlayer[1].Move2 >= 32)
         {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -302,17 +302,17 @@ void TurnNPCsIntoCoins()
                    !(NPC[A].Type >= 78 && NPC[A].Type <= 83) &&
                    NPC[A].Type != 91 && NPC[A].Type != 260 && NPC[A].Type != 259)
                 {
-                    NPC[A].Location.Y = NPC[A].Location.Y + 32;
+                    NPC[A].Location.Y += 32;
                     NewEffect(11, NPC[A].Location);
                     PlaySound(SFX_Coin);
-                    Coins = Coins + 1;
+                    Coins += 1;
                     if(Coins >= 100)
                     {
                         if(Lives < 99)
                         {
-                            Lives = Lives + 1;
+                            Lives += 1;
                             PlaySound(SFX_1up);
-                            Coins = Coins - 100;
+                            Coins -= 100;
                         }
                         else
                             Coins = 99;
@@ -534,13 +534,13 @@ void NPCSpecial(int A)
         {
             if(npc.Location.SpeedX < 0)
                 npc.Location.SpeedX = npc.Location.SpeedX * 0.95;
-            npc.Location.SpeedX = npc.Location.SpeedX + 0.1;
+            npc.Location.SpeedX += 0.1;
         }
         else if(npc.Special5 < 0)
         {
             if(npc.Location.SpeedX > 0)
                 npc.Location.SpeedX = npc.Location.SpeedX * 0.95;
-            npc.Location.SpeedX = npc.Location.SpeedX - 0.1;
+            npc.Location.SpeedX -= 0.1;
         }
         else
         {
@@ -553,13 +553,13 @@ void NPCSpecial(int A)
         {
             if(npc.Location.SpeedY < 0)
                 npc.Location.SpeedY = npc.Location.SpeedY * 0.95;
-            npc.Location.SpeedY = npc.Location.SpeedY + 0.1;
+            npc.Location.SpeedY += 0.1;
         }
         else if(npc.Special6 < 0)
         {
             if(npc.Location.SpeedY > 0)
                 npc.Location.SpeedY = npc.Location.SpeedY * 0.95;
-            npc.Location.SpeedY = npc.Location.SpeedY - 0.1;
+            npc.Location.SpeedY -= 0.1;
         }
         else
         {
@@ -717,7 +717,7 @@ void NPCSpecial(int A)
         if(npc.Special2 == 0.0)
             npc.Special2 = -1;
 
-        npc.Location.SpeedY = npc.Location.SpeedY + 0.05 * npc.Special2;
+        npc.Location.SpeedY += 0.05 * npc.Special2;
         if(npc.Location.SpeedY > 1)
         {
             npc.Location.SpeedY = 1;
@@ -739,12 +739,12 @@ void NPCSpecial(int A)
             npc.Special = 0;
             npc.Frame = EditorNPCFrame(npc.Type, npc.Direction);
             npc.FrameCount = 0;
-            npc.Location.X = npc.Location.X + npc.Location.Width / 2.0;
-            npc.Location.Y = npc.Location.Y + npc.Location.Height / 2.0;
+            npc.Location.X += npc.Location.Width / 2.0;
+            npc.Location.Y += npc.Location.Height / 2.0;
             npc.Location.Width = NPCWidth[npc.Type];
             npc.Location.Height = NPCHeight[npc.Type];
-            npc.Location.X = npc.Location.X - npc.Location.Width / 2.0;
-            npc.Location.Y = npc.Location.Y - npc.Location.Height / 2.0;
+            npc.Location.X += -npc.Location.Width / 2.0;
+            npc.Location.Y += -npc.Location.Height / 2.0;
             npc.Location.SpeedX = 0;
             npc.Location.SpeedY = 0;
             npc.Direction = npc.DefaultDirection;
@@ -850,13 +850,13 @@ void NPCSpecial(int A)
         }
         else
         {
-            npc.Location.SpeedY = npc.Location.SpeedY + 0.02;
+            npc.Location.SpeedY += 0.02;
             if(npc.Location.SpeedY > 2)
                 npc.Location.SpeedY = 2;
 
             if(npc.Location.SpeedY > 0.25)
             {
-                npc.Special2 = npc.Special2 + 1;
+                npc.Special2 += 1;
                 if(npc.Special2 < 7)
                     npc.Location.SpeedX = -0.8;
                 else if(npc.Special2 < 13)
@@ -932,24 +932,24 @@ void NPCSpecial(int A)
             npc.Special2 += 1;
             if(npc.Special2 >= 30 && npc.Special != 2)
             {
-                npc.Location.X = npc.Location.X + npc.Location.Width;
-                npc.Location.Y = npc.Location.Y + npc.Location.Height;
+                npc.Location.X += npc.Location.Width;
+                npc.Location.Y += npc.Location.Height;
                 npc.Location.Width = 16;
                 npc.Location.Height = 32;
                 npc.Special = 2;
-                npc.Location.X = npc.Location.X - npc.Location.Width;
-                npc.Location.Y = npc.Location.Y - npc.Location.Height;
+                npc.Location.X += -npc.Location.Width;
+                npc.Location.Y += -npc.Location.Height;
                 npc.Special2 = 21;
             }
             else if(npc.Special2 >= 15 && npc.Special != 1)
             {
-                npc.Location.X = npc.Location.X + npc.Location.Width;
-                npc.Location.Y = npc.Location.Y + npc.Location.Height;
+                npc.Location.X += npc.Location.Width;
+                npc.Location.Y += npc.Location.Height;
                 npc.Location.Width = 10;
                 npc.Location.Height = 20;
                 npc.Special = 1;
-                npc.Location.X = npc.Location.X - npc.Location.Width;
-                npc.Location.Y = npc.Location.Y - npc.Location.Height;
+                npc.Location.X += -npc.Location.Width;
+                npc.Location.Y += -npc.Location.Height;
             }
         }
     }
@@ -986,9 +986,9 @@ void NPCSpecial(int A)
         else if(npc.Special == 1)
         {
             if(npc.Type == 281 && fEqual((float)npc.Location.SpeedY, Physics.NPCGravity))
-                npc.Location.SpeedX = npc.Location.SpeedX + 0.1 * npc.Direction;
+                npc.Location.SpeedX += 0.1 * npc.Direction;
             else
-                npc.Location.SpeedX = npc.Location.SpeedX + 0.2 * npc.Direction;
+                npc.Location.SpeedX += 0.2 * npc.Direction;
             if(npc.Type == 281 && npc.Damage >= 5)
             {
                 if(npc.Location.SpeedX > 5.5)
@@ -1013,7 +1013,7 @@ void NPCSpecial(int A)
 
             if(npc.Type == 281 && fEqual((float)npc.Location.SpeedY, Physics.NPCGravity))
             {
-                npc.Special3 = npc.Special3 + 1;
+                npc.Special3 += 1;
                 if((npc.Location.SpeedX < -2 && npc.Direction < 0) || (npc.Location.SpeedX > 2 && npc.Direction > 0))
                 {
                     if(npc.Special3 >= 20 - npc.Damage * 2)
@@ -1063,7 +1063,7 @@ void NPCSpecial(int A)
                 npc.Special6 = 0;
                 npc.Location.X += npc.Location.Width / 2.0;
                 npc.Location.Y += npc.Location.Height;
-                npc.Type = npc.Type - 1;
+                npc.Type -= 1;
                 npc.Location.Width = NPCWidth[npc.Type];
                 npc.Location.Height = NPCHeight[npc.Type];
                 npc.Location.X -= npc.Location.Width / 2.0;
@@ -1679,8 +1679,8 @@ void NPCSpecial(int A)
 
         if(npc.Special == 0)
         {
-            npc.Location.SpeedX = npc.Location.SpeedX + C;
-            npc.Location.SpeedY = npc.Location.SpeedY + C * npc.DefaultDirection;
+            npc.Location.SpeedX += C;
+            npc.Location.SpeedY += C * npc.DefaultDirection;
             if(npc.Special5 == 0)
             {
                 npc.Special5 = 1;
@@ -1689,7 +1689,7 @@ void NPCSpecial(int A)
             }
             if(npc.Location.SpeedX >= 0)
             {
-                npc.Special = npc.Special + 1 * npc.DefaultDirection;
+                npc.Special += 1 * npc.DefaultDirection;
                 if(npc.Special < 0)
                     npc.Special = 3;
                 npc.Special5 = 0;
@@ -1697,8 +1697,8 @@ void NPCSpecial(int A)
         }
         else if(npc.Special == 1)
         {
-            npc.Location.SpeedX = npc.Location.SpeedX + C * npc.DefaultDirection;
-            npc.Location.SpeedY = npc.Location.SpeedY - C;
+            npc.Location.SpeedX += C * npc.DefaultDirection;
+            npc.Location.SpeedY += -C;
             if(npc.Special5 == 0)
             {
                 npc.Special5 = 1;
@@ -1707,14 +1707,14 @@ void NPCSpecial(int A)
             }
             if(npc.Location.SpeedY <= 0)
             {
-                npc.Special = npc.Special + 1 * npc.DefaultDirection;
+                npc.Special += 1 * npc.DefaultDirection;
                 npc.Special5 = 0;
             }
         }
         else if(npc.Special == 2)
         {
-            npc.Location.SpeedX = npc.Location.SpeedX - C;
-            npc.Location.SpeedY = npc.Location.SpeedY - C * npc.DefaultDirection;
+            npc.Location.SpeedX += -C;
+            npc.Location.SpeedY += -C * npc.DefaultDirection;
             if(npc.Special5 == 0)
             {
                 npc.Special5 = 1;
@@ -1723,14 +1723,14 @@ void NPCSpecial(int A)
             }
             if(npc.Location.SpeedX <= 0)
             {
-                npc.Special = npc.Special + 1 * npc.DefaultDirection;
+                npc.Special += 1 * npc.DefaultDirection;
                 npc.Special5 = 0;
             }
         }
         else if(npc.Special == 3)
         {
-            npc.Location.SpeedX = npc.Location.SpeedX - C * npc.DefaultDirection;
-            npc.Location.SpeedY = npc.Location.SpeedY + C;
+            npc.Location.SpeedX += -C * npc.DefaultDirection;
+            npc.Location.SpeedY += C;
 
             if(npc.Special5 == 0)
             {
@@ -1740,7 +1740,7 @@ void NPCSpecial(int A)
             }
             if(npc.Location.SpeedY >= 0)
             {
-                npc.Special = npc.Special + 1 * npc.DefaultDirection;
+                npc.Special += 1 * npc.DefaultDirection;
                 if(npc.Special > 3)
                     npc.Special = 0;
                 npc.Special5 = 0;
@@ -1772,7 +1772,7 @@ void NPCSpecial(int A)
             C *= 15;
             npc.Location.X = npc.DefaultLocation.X + dRand() * B - dRand() * C;
             npc.Location.Y = npc.DefaultLocation.Y + dRand() * B - dRand() * C;
-            npc.Special = npc.Special + 1;
+            npc.Special += 1;
             if(npc.Special >= 45)
                 npc.Special = 0;
         }
@@ -1817,7 +1817,7 @@ void NPCSpecial(int A)
     }
     else if(npc.Type == NPCID_RINKAGEN) // Metroid O shooter thing
     {
-        npc.Special = npc.Special + 1 + dRand();
+        npc.Special += 1 + dRand();
         if(npc.Special >= 200 + dRand() * 200)
         {
             npc.Special = 0;
@@ -1951,7 +1951,7 @@ void NPCSpecial(int A)
                         if(npc.Special3 > 0)
                         {
                             npc.Location.X = Block[npc.Special3].Location.X + Block[npc.Special3].Location.Width + 2;
-                            npc.Location.Y = npc.Location.Y + 2;
+                            npc.Location.Y += 2;
                         }
                         npc.Special = 4;
                         npc.Special2 = 1;
@@ -2231,7 +2231,7 @@ void NPCSpecial(int A)
             if(npc.Special3 == 0)
                 PlaySound(SFX_WartBubbles);
 
-            npc.Special3 = npc.Special3 + 1;
+            npc.Special3 += 1;
             if((int(npc.Special3) % 10) == 0)
             {
                 numNPCs++;
@@ -2247,7 +2247,7 @@ void NPCSpecial(int A)
                 NPC[numNPCs].TimeLeft = 50;
                 NPC[numNPCs].Location.SpeedY = -7;
                 NPC[numNPCs].Location.SpeedX = 7 * NPC[numNPCs].Direction;
-                NPC[numNPCs].Location.SpeedY = NPC[numNPCs].Location.SpeedY + dRand() * 6 - 3;
+                NPC[numNPCs].Location.SpeedY += dRand() * 6 - 3;
                 NPC[numNPCs].Location.SpeedX = NPC[numNPCs].Location.SpeedX * (1 - (npc.Special3 / 140));
             }
 
@@ -2483,7 +2483,7 @@ void NPCSpecial(int A)
         }
 
         Block[npc.tempBlock].Location = npc.Location;
-        Block[npc.tempBlock].Location.X = Block[npc.tempBlock].Location.X + npc.Location.SpeedX;
+        Block[npc.tempBlock].Location.X += npc.Location.SpeedX;
 
         if(npc.Location.SpeedY < 0)
             Block[npc.tempBlock].Location.Y += npc.Location.SpeedY;
@@ -2565,7 +2565,7 @@ void NPCSpecial(int A)
 
         if(npc.Special > 0)
         {
-            npc.Special3 = npc.Special3 + 1;
+            npc.Special3 += 1;
             if(npc.Special3 < 40)
                 npc.Special = 1;
             else if(npc.Special3 < 70)
@@ -2936,8 +2936,8 @@ void SpecialNPC(int A)
 
                         if(NPC[A].Type != 13 && NPC[A].Type != 265)
                         {
-                            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                            NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                            NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                             NewEffect(10, NPC[A].Location);
                         }
                     }
@@ -2979,33 +2979,33 @@ void SpecialNPC(int A)
 
         if(npcHCenter > playerHCenter)
         {
-            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.2;
+            NPC[A].Location.SpeedX -= 0.2;
             if(NPC[A].Location.SpeedX > -4 && NPC[A].Location.SpeedX < 4)
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.5;
+                NPC[A].Location.SpeedX -= 0.5;
 
         }
         else if(npcHCenter < playerHCenter)
         {
-            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.2;
+            NPC[A].Location.SpeedX += 0.2;
             if(NPC[A].Location.SpeedX > -4 && NPC[A].Location.SpeedX < 4)
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.5;
+                NPC[A].Location.SpeedX += 0.5;
         }
 
-        NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + (playerHCenter - npcHCenter) * 0.0005;
+        NPC[A].Location.SpeedX += (playerHCenter - npcHCenter) * 0.0005;
 
         if(NPC[A].Location.Y + NPC[A].Location.Height / 2.0 > playerVCenter)
         {
-            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.2;
+            NPC[A].Location.SpeedY -= 0.2;
             if(NPC[A].Location.SpeedY > 0 && NPC[A].Direction != NPC[A].Special6)
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - std::abs(NPC[A].Location.SpeedY) * 0.04;
+                NPC[A].Location.SpeedY += -std::abs(NPC[A].Location.SpeedY) * 0.04;
         }
         else if(NPC[A].Location.Y + NPC[A].Location.Height / 2.0 < playerVCenter)
         {
-            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.2;
+            NPC[A].Location.SpeedY += 0.2;
             if(NPC[A].Location.SpeedY < 0 && NPC[A].Direction != NPC[A].Special6)
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + std::abs(NPC[A].Location.SpeedY) * 0.04;
+                NPC[A].Location.SpeedY += std::abs(NPC[A].Location.SpeedY) * 0.04;
         }
-        NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + (playerVCenter - NPC[A].Location.Y + NPC[A].Location.Height / 2.0) * 0.004;
+        NPC[A].Location.SpeedY += (playerVCenter - NPC[A].Location.Y + NPC[A].Location.Height / 2.0) * 0.004;
 
 
         for(B = 1; B <= numNPCs; B++)
@@ -3058,22 +3058,22 @@ void SpecialNPC(int A)
             if(NPC[A].Location.X + NPC[A].Location.Width / 2.0 > playerHCenter)
             {
                 if(NPC[A].Location.SpeedX > 0)
-                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.1;
+                    NPC[A].Location.SpeedX -= 0.1;
             }
             else if(NPC[A].Location.X + NPC[A].Location.Width / 2.0 < playerHCenter)
             {
                 if(NPC[A].Location.SpeedX < 0)
-                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.1;
+                    NPC[A].Location.SpeedX += 0.1;
             }
             if(NPC[A].Location.Y + NPC[A].Location.Height / 2.0 > playerVCenter)
             {
                 if(NPC[A].Location.SpeedY > 0)
-                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.3;
+                    NPC[A].Location.SpeedY -= 0.3;
             }
             else if(NPC[A].Location.Y + NPC[A].Location.Height / 2.0 < playerVCenter)
             {
                 if(NPC[A].Location.SpeedY < 0)
-                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.1;
+                    NPC[A].Location.SpeedY += 0.1;
             }
         }
 
@@ -3088,9 +3088,9 @@ void SpecialNPC(int A)
     else if(NPC[A].Type == 251 || NPC[A].Type == 252 || NPC[A].Type == 253) // Rupee
     {
         if(NPC[A].Location.SpeedX < -0.02)
-            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.02;
+            NPC[A].Location.SpeedX += 0.02;
         else if(NPC[A].Location.SpeedX > 0.02)
-            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.02;
+            NPC[A].Location.SpeedX -= 0.02;
         else
             NPC[A].Location.SpeedX = 0;
     }
@@ -3153,13 +3153,13 @@ void SpecialNPC(int A)
                     if(NPC[A].Special4 == 1)
                     {
                         NPC[A].Special4 = 0;
-                        NPC[A].Location.Y = NPC[A].Location.Y - 0.1;
+                        NPC[A].Location.Y -= 0.1;
                     }
                 }
             }
             if(NPC[A].Special2 > 0)
             {
-                NPC[A].Special2 = NPC[A].Special2 - 1;
+                NPC[A].Special2 -= 1;
                 NPC[A].Location.SpeedY = -1.75;
                 NPC[A].Frame = 0;
             }
@@ -3171,7 +3171,7 @@ void SpecialNPC(int A)
             if(NPC[A].Special2 == 0)
                 NPC[A].Special2 = -20;
             if(NPC[A].Special2 < 0)
-                NPC[A].Special2 = NPC[A].Special2 + 1;
+                NPC[A].Special2 += 1;
             if(NPC[A].Location.SpeedY >= 0)
                 NPC[A].Location.SpeedX = 0;
         }
@@ -3216,7 +3216,7 @@ void SpecialNPC(int A)
                         if(NPC[A].Wet == 2)
                         {
                             if(NPC[A].Location.SpeedY > -3)
-                                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.1;
+                                NPC[A].Location.SpeedY -= 0.1;
                             NPC[A].Special3 = 1;
                         }
                     }
@@ -3242,7 +3242,7 @@ void SpecialNPC(int A)
         if(NPC[A].Special3 == 1)
         {
             tempLocation = NPC[A].Location;
-            tempLocation.Y = tempLocation.Y - 32;
+            tempLocation.Y -= 32;
             NewEffect(147, NPC[A].Location);
             NewEffect(147, tempLocation);
             NPC[A].Frame = 0;
@@ -3279,20 +3279,20 @@ void SpecialNPC(int A)
         if(NPC[A].Location.X != NPC[A].DefaultLocation.X)
         {
             NPC[A].Killed = 2;
-            NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.SpeedY;
+            NPC[A].Location.Y += -NPC[A].Location.SpeedY;
         }
         else
         {
             if(NPC[A].Special2 == 0 && !NPC[A].Inert)
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + NPCHeight[NPC[A].Type] + 1.5;
+                NPC[A].Location.Y += NPCHeight[NPC[A].Type] + 1.5;
                 NPC[A].Special2 = 4;
                 NPC[A].Special = 70;
             }
             if(NPC[A].Special2 == 1)
             {
-                NPC[A].Special = NPC[A].Special + 1;
-                NPC[A].Location.Y = NPC[A].Location.Y - 1.5;
+                NPC[A].Special += 1;
+                NPC[A].Location.Y -= 1.5;
                 if(NPC[A].Special >= NPCHeight[NPC[A].Type] * 0.65 + 1)
                 {
                     NPC[A].Special2 = 2;
@@ -3301,7 +3301,7 @@ void SpecialNPC(int A)
             }
             else if(fiEqual(NPC[A].Special2, 2))
             {
-                NPC[A].Special = NPC[A].Special + 1;
+                NPC[A].Special += 1;
                 if(NPC[A].Special >= 100)
                 {
                     NPC[A].Special2 = 3;
@@ -3346,20 +3346,20 @@ void SpecialNPC(int A)
                     else if(NPC[numNPCs].Location.SpeedY < -2)
                         NPC[numNPCs].Location.SpeedY = -2;
 
-                    NPC[numNPCs].Location.X = NPC[numNPCs].Location.X + NPC[numNPCs].Location.SpeedX * 4;
-                    NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y + NPC[numNPCs].Location.SpeedY * 4;
+                    NPC[numNPCs].Location.X += NPC[numNPCs].Location.SpeedX * 4;
+                    NPC[numNPCs].Location.Y += NPC[numNPCs].Location.SpeedY * 4;
                 }
             }
             else if(fiEqual(NPC[A].Special2, 3))
             {
-                NPC[A].Special = NPC[A].Special + 1;
-                NPC[A].Location.Y = NPC[A].Location.Y + 1.5;
+                NPC[A].Special += 1;
+                NPC[A].Location.Y += 1.5;
                 if(NPC[A].Special >= NPCHeight[NPC[A].Type] * 0.65 + 1)
                     NPC[A].Special2 = 4;
             }
             else if(fiEqual(NPC[A].Special2, 4))
             {
-                NPC[A].Special = NPC[A].Special + 1;
+                NPC[A].Special += 1;
                 if(NPC[A].Special >= 150)
                 {
                     tempTurn = true;
@@ -3404,7 +3404,7 @@ void SpecialNPC(int A)
     {
         if(NPC[A].Projectile)
         {
-            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity;
+            NPC[A].Location.SpeedY += Physics.NPCGravity;
             NPC[A].Location.SpeedX = NPC[A].Location.SpeedX * 0.98;
         }
         else
@@ -3413,7 +3413,7 @@ void SpecialNPC(int A)
             {
                 NPC[A].Location.Y = NPC[A].DefaultLocation.Y + NPCHeight[NPC[A].Type] + 1.5;
                 NPC[A].Location.Height = 0;
-                NPC[A].Special2 = NPC[A].Special2 - 1;
+                NPC[A].Special2 -= 1;
 
                 if(NPC[A].Special2 <= -30)
                 {
@@ -3450,15 +3450,15 @@ void SpecialNPC(int A)
                 if(NPC[A].Special2 == 0)
                     NPC[A].Location.SpeedY = -6;
                 else if(NPC[A].Location.SpeedY < -4)
-                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.2;
+                    NPC[A].Location.SpeedY += 0.2;
                 else if(NPC[A].Location.SpeedY < -3)
-                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.15;
+                    NPC[A].Location.SpeedY += 0.15;
                 else if(NPC[A].Location.SpeedY < -2)
-                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.1;
+                    NPC[A].Location.SpeedY += 0.1;
                 else if(NPC[A].Location.SpeedY < -1)
-                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.05;
+                    NPC[A].Location.SpeedY += 0.05;
                 else
-                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.02;
+                    NPC[A].Location.SpeedY += 0.02;
 
                 NPC[A].Special2 += 1;
 
@@ -3473,7 +3473,7 @@ void SpecialNPC(int A)
             {
                 NPC[A].Location.Height = NPCHeight[NPC[A].Type];
 
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.01;
+                NPC[A].Location.SpeedY += 0.01;
                 if(NPC[A].Location.SpeedY >= 0.75)
                     NPC[A].Location.SpeedY = 0.75;
 
@@ -3502,11 +3502,11 @@ void SpecialNPC(int A)
     else if(NPC[A].Type == 8 || NPC[A].Type == 74 || NPC[A].Type == 93 || NPC[A].Type == 256)
     {
         if(NPC[A].Special3 > 0)
-            NPC[A].Special3 = NPC[A].Special3 - 1;
+            NPC[A].Special3 -= 1;
         if(NPC[A].Location.X != NPC[A].DefaultLocation.X)
         {
             NPC[A].Killed = 2;
-            NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.SpeedY;
+            NPC[A].Location.Y += -NPC[A].Location.SpeedY;
         }
         else
         {
@@ -3518,7 +3518,7 @@ void SpecialNPC(int A)
             }
             if(NPC[A].Special2 == 1)
             {
-                NPC[A].Special = NPC[A].Special + 1;
+                NPC[A].Special += 1;
                 NPC[A].Location.Y -= 1.5;
                 if(NPC[A].Special >= NPCHeight[NPC[A].Type] * 0.65 + 1)
                 {
@@ -3531,7 +3531,7 @@ void SpecialNPC(int A)
             else if(NPC[A].Special2 == 2)
             {
                 if(NPC[A].Type != 256)
-                    NPC[A].Special = NPC[A].Special + 1;
+                    NPC[A].Special += 1;
                 if(NPC[A].Special >= 50)
                 {
                     NPC[A].Special2 = 3;
@@ -3551,7 +3551,7 @@ void SpecialNPC(int A)
             }
             else if(NPC[A].Special2 == 4)
             {
-                NPC[A].Special = NPC[A].Special + 1;
+                NPC[A].Special += 1;
                 if(NPC[A].Special >= 75)
                 {
                     tempTurn = true;
@@ -3603,7 +3603,7 @@ void SpecialNPC(int A)
         {
             if(NPC[A].Special2 == 0 && !NPC[A].Inert)
             {
-                // .Location.Y = .Location.Y - NPCHeight(.Type) - 1.5
+                // .Location.Y += -NPCHeight(.Type) - 1.5
                 NPC[A].Location.Height = 0;
                 NPC[A].Special2 = 1;
                 NPC[A].Special = 0;
@@ -3611,7 +3611,7 @@ void SpecialNPC(int A)
             else if(NPC[A].Special2 == 1)
             {
                 NPC[A].Special += 1;
-                // .Location.Y = .Location.Y + 1.5
+                // .Location.Y += 1.5
                 NPC[A].Location.Height += 1.5;
                 if(NPC[A].Special >= NPCHeight[NPC[A].Type] * 0.65 + 1)
                 {
@@ -3623,7 +3623,7 @@ void SpecialNPC(int A)
             else if(NPC[A].Special2 == 2)
             {
                 if(NPC[A].Type != 257)
-                    NPC[A].Special = NPC[A].Special + 1;
+                    NPC[A].Special += 1;
                 if(NPC[A].Special >= 50)
                 {
                     NPC[A].Special2 = 3;
@@ -3633,7 +3633,7 @@ void SpecialNPC(int A)
             else if(NPC[A].Special2 == 3)
             {
                 NPC[A].Special += 1;
-                // .Location.Y = .Location.Y - 1.5
+                // .Location.Y += -1.5
                 NPC[A].Location.Height -= 1.5;
                 if(NPC[A].Special >= NPCHeight[NPC[A].Type] * 0.65 + 1)
                 {
@@ -3662,7 +3662,7 @@ void SpecialNPC(int A)
         NPC[A].Direction = NPC[A].DefaultDirection;
         if(NPC[A].Location.Y != NPC[A].DefaultLocation.Y)
         {
-            NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.SpeedY;
+            NPC[A].Location.Y += -NPC[A].Location.SpeedY;
             NPCHit(A, 4);
         }
         else
@@ -3671,17 +3671,17 @@ void SpecialNPC(int A)
             {
                 if(NPC[A].Direction == 1)
                 {
-                    // .Location.x = .Location.X - NPCWidth(.Type) - 1.5
-                    NPC[A].Location.Width = NPC[A].Location.Width - NPCWidth[NPC[A].Type] - 1.5;
+                    // .Location.x += -NPCWidth(.Type) - 1.5
+                    NPC[A].Location.Width += -NPCWidth[NPC[A].Type] - 1.5;
                 }
                 else
-                    NPC[A].Location.X = NPC[A].Location.X + NPCWidth[NPC[A].Type] + 1.5;
+                    NPC[A].Location.X += NPCWidth[NPC[A].Type] + 1.5;
                 NPC[A].Special2 = 1;
                 NPC[A].Special = 0;
             }
             else if(NPC[A].Special2 == 1)
             {
-                NPC[A].Special = NPC[A].Special + 1;
+                NPC[A].Special += 1;
                 if(NPC[A].Direction == -1)
                     NPC[A].Location.X += 1.5 * NPC[A].Direction;
                 else
@@ -3695,7 +3695,7 @@ void SpecialNPC(int A)
             }
             else if(NPC[A].Special2 == 2)
             {
-                NPC[A].Special = NPC[A].Special + 1;
+                NPC[A].Special += 1;
                 if(NPC[A].Special >= 50)
                 {
                     NPC[A].Special2 = 3;
@@ -3704,7 +3704,7 @@ void SpecialNPC(int A)
             }
             else if(NPC[A].Special2 == 3)
             {
-                NPC[A].Special = NPC[A].Special + 1;
+                NPC[A].Special += 1;
                 if(NPC[A].Direction == -1)
                     NPC[A].Location.X -= 1.5 * NPC[A].Direction;
                 else
@@ -3717,7 +3717,7 @@ void SpecialNPC(int A)
             }
             else if(NPC[A].Special2 == 4)
             {
-                NPC[A].Special = NPC[A].Special + 1;
+                NPC[A].Special += 1;
                 if(NPC[A].Special >= 110)
                 {
                     NPC[A].Special2 = 1;
@@ -3749,7 +3749,7 @@ void SpecialNPC(int A)
     {
         if(NPC[A].Location.SpeedY == Physics.NPCGravity)
         {
-            NPC[A].Special = NPC[A].Special + 1;
+            NPC[A].Special += 1;
             NPC[A].Frame = 0;
             if(NPC[A].Special >= 100)
                 NPC[A].Special = 1;
@@ -3757,7 +3757,7 @@ void SpecialNPC(int A)
             {
                 NPC[A].Special = 0;
                 NPC[A].Frame = 1;
-                NPC[A].Location.Y = NPC[A].Location.Y - 1;
+                NPC[A].Location.Y -= 1;
                 NPC[A].Location.SpeedY = -4.6;
             }
         }
@@ -3765,7 +3765,7 @@ void SpecialNPC(int A)
         {
             if(NPC[A].Special <= 8)
             {
-                NPC[A].Special = NPC[A].Special + 1;
+                NPC[A].Special += 1;
                 NPC[A].Frame = 1;
             }
             else
@@ -3776,7 +3776,7 @@ void SpecialNPC(int A)
 
         }
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 3;
+            NPC[A].Frame += 3;
     }
     // Fireball code (Podoboo)
     else if(NPC[A].Type == 12)
@@ -3822,7 +3822,7 @@ void SpecialNPC(int A)
             if(fiEqual(NPC[A].Special, 61))
             {
                 tempLocation = NPC[A].Location;
-                tempLocation.Y = tempLocation.Y + 2;
+                tempLocation.Y += 2;
                 NewEffect(13, tempLocation);
                 PlaySound(SFX_Lava);
             }
@@ -3843,9 +3843,9 @@ void SpecialNPC(int A)
         {
             if(NPC[A].Special2 == 1)
             {
-                NPC[A].Special3 = NPC[A].Special3 + 1;
+                NPC[A].Special3 += 1;
                 NPC[A].Special2 = 0;
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Direction * 2;
+                NPC[A].Location.X += NPC[A].Direction * 2;
                 if(NPC[A].Location.X >= NPC[A].DefaultLocation.X + 2)
                     NPC[A].Direction = -1;
                 if(NPC[A].Location.X <= NPC[A].DefaultLocation.X - 2)
@@ -3854,7 +3854,7 @@ void SpecialNPC(int A)
             else
             {
                 if(NPC[A].Special3 > 0)
-                    NPC[A].Special3 = NPC[A].Special3 - 1;
+                    NPC[A].Special3 -= 1;
                 NPC[A].Location.X = NPC[A].DefaultLocation.X;
             }
             if((NPC[A].Special3 >= 5 && NPC[A].Type == 46) || (NPC[A].Special3 >= 30 && NPC[A].Type == 212))
@@ -3882,10 +3882,10 @@ void SpecialNPC(int A)
         {
             if(NPC[A].Location.Height != 54)
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - 54;
+                NPC[A].Location.Y += NPC[A].Location.Height - 54;
                 NPC[A].Location.Height = 54;
             }
-            NPC[A].Special2 = NPC[A].Special2 + dRand() * 2;
+            NPC[A].Special2 += dRand() * 2;
             if(NPC[A].Special2 >= 250 + (iRand() % 250))
             {
                 NPC[A].Special = 2;
@@ -3894,7 +3894,7 @@ void SpecialNPC(int A)
         }
         else if(NPC[A].Special == 2)
         {
-            NPC[A].Special2 = NPC[A].Special2 + 1;
+            NPC[A].Special2 += 1;
             if(NPC[A].Special2 >= 10)
             {
                 NPC[A].Special = 1;
@@ -3905,10 +3905,10 @@ void SpecialNPC(int A)
         {
             if(NPC[A].Location.Height != 40)
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - 40;
+                NPC[A].Location.Y += NPC[A].Location.Height - 40;
                 NPC[A].Location.Height = 40;
             }
-            NPC[A].Special2 = NPC[A].Special2 + dRand() * 2;
+            NPC[A].Special2 += dRand() * 2;
             if(NPC[A].Special2 >= 100 + (iRand() % 100))
             {
                 NPC[A].Special = 3;
@@ -3917,7 +3917,7 @@ void SpecialNPC(int A)
         }
         else if(NPC[A].Special == 3)
         {
-            NPC[A].Special2 = NPC[A].Special2 + 1;
+            NPC[A].Special2 += 1;
             if(NPC[A].Special2 >= 10)
             {
                 NPC[A].Special = 0;
@@ -3928,10 +3928,10 @@ void SpecialNPC(int A)
         {
             if(NPC[A].Location.Height != 34)
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - 34;
+                NPC[A].Location.Y += NPC[A].Location.Height - 34;
                 NPC[A].Location.Height = 34;
             }
-            NPC[A].Special2 = NPC[A].Special2 + 1;
+            NPC[A].Special2 += 1;
             if(NPC[A].Special2 >= 100)
             {
                 NPC[A].Special = 1;
@@ -4002,13 +4002,13 @@ void SpecialNPC(int A)
                 }
                 if(NPC[A].Wet == 2)
                 {
-                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.025 * E;
-                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.025 * F;
+                    NPC[A].Location.SpeedX += 0.025 * E;
+                    NPC[A].Location.SpeedY += 0.025 * F;
                 }
                 else
                 {
-                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.05 * E;
-                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.05 * F;
+                    NPC[A].Location.SpeedX += 0.05 * E;
+                    NPC[A].Location.SpeedY += 0.05 * F;
                 }
                 if(NPC[A].Location.SpeedX > 4)
                     NPC[A].Location.SpeedX = 4;
@@ -4022,7 +4022,7 @@ void SpecialNPC(int A)
         }
         else if(NPC[A].Special == 1)
         {
-            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity;
+            NPC[A].Location.SpeedY += Physics.NPCGravity;
             NPC[A].Location.SpeedX = Physics.NPCWalkingSpeed * NPC[A].Direction;
         }
         else if(NPC[A].Special == 2)
@@ -4030,13 +4030,13 @@ void SpecialNPC(int A)
 
             if(NPC[A].Special3 == 0)
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.05;
+                NPC[A].Location.SpeedY += 0.05;
                 if(NPC[A].Location.SpeedY > 1)
                     NPC[A].Special3 = 1;
             }
             else
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.05;
+                NPC[A].Location.SpeedY -= 0.05;
                 if(NPC[A].Location.SpeedY < -1)
                     NPC[A].Special3 = 0;
             }
@@ -4044,13 +4044,13 @@ void SpecialNPC(int A)
             if(NPC[A].Location.X == NPC[A].DefaultLocation.X && NPC[A].Location.SpeedX == 0)
                 NPC[A].Location.SpeedX = 2 * NPC[A].Direction;
             if(NPC[A].Location.X < NPC[A].DefaultLocation.X - 64)
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.02;
+                NPC[A].Location.SpeedX += 0.02;
             else if(NPC[A].Location.X > NPC[A].DefaultLocation.X + 64)
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.02;
+                NPC[A].Location.SpeedX -= 0.02;
             else if(NPC[A].Direction == -1)
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.02;
+                NPC[A].Location.SpeedX -= 0.02;
             else if(NPC[A].Direction == 1)
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.02;
+                NPC[A].Location.SpeedX += 0.02;
             if(NPC[A].Location.SpeedX > 2)
                 NPC[A].Location.SpeedX = 2;
             if(NPC[A].Location.SpeedX < -2)
@@ -4063,13 +4063,13 @@ void SpecialNPC(int A)
             if(NPC[A].Location.Y == NPC[A].DefaultLocation.Y && NPC[A].Location.SpeedY == 0)
                 NPC[A].Location.SpeedY = 2 * NPC[A].Direction;
             if(NPC[A].Location.Y < NPC[A].DefaultLocation.Y - 64)
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.02;
+                NPC[A].Location.SpeedY += 0.02;
             else if(NPC[A].Location.Y > NPC[A].DefaultLocation.Y + 64)
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.02;
+                NPC[A].Location.SpeedY -= 0.02;
             else if(NPC[A].Location.SpeedY < 0)
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.02;
+                NPC[A].Location.SpeedY -= 0.02;
             else
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.02;
+                NPC[A].Location.SpeedY += 0.02;
             if(NPC[A].Location.SpeedY > 2)
                 NPC[A].Location.SpeedY = 2;
             if(NPC[A].Location.SpeedY < -2)
@@ -4098,8 +4098,8 @@ void SpecialNPC(int A)
         if(NPC[A].Stuck && !NPC[A].Projectile)
             NPC[A].Location.SpeedX = 0;
 
-        NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.SpeedX;
-        NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.SpeedY;
+        NPC[A].Location.X += NPC[A].Location.SpeedX;
+        NPC[A].Location.Y += NPC[A].Location.SpeedY;
     // Jumpy bee thing
     }
     else if(NPC[A].Type == 54)
@@ -4107,11 +4107,11 @@ void SpecialNPC(int A)
         if(NPC[A].Location.SpeedY == Physics.NPCGravity || NPC[A].Slope > 0)
         {
             NPC[A].Location.SpeedX = 0;
-            NPC[A].Special = NPC[A].Special + 1;
+            NPC[A].Special += 1;
             if(NPC[A].Special == 30)
             {
                 NPC[A].Special = 0;
-                NPC[A].Location.Y = NPC[A].Location.Y - 1;
+                NPC[A].Location.Y -= 1;
                 NPC[A].Location.SpeedY = -6;
                 NPC[A].Location.SpeedX = 1.4 * NPC[A].Direction;
             }
@@ -4137,11 +4137,11 @@ void SpecialNPC(int A)
         }
         if(NPC[A].Location.SpeedY == Physics.NPCGravity || NPC[A].Slope > 0)
         {
-            NPC[A].Special = NPC[A].Special + 1;
+            NPC[A].Special += 1;
             if(NPC[A].Special == 8)
             {
                 NPC[A].Location.SpeedY = -7;
-                NPC[A].Location.Y = NPC[A].Location.Y - 1;
+                NPC[A].Location.Y -= 1;
                 NPC[A].Special = 0;
             }
         }
@@ -4151,7 +4151,7 @@ void SpecialNPC(int A)
     }
     else if(NPC[A].Type == 84 || NPC[A].Type == 181)
     {
-        NPC[A].Special = NPC[A].Special + 1;
+        NPC[A].Special += 1;
         if(NPC[A].Special >= 200 + dRand() * 200)
         {
             NPC[A].Special = 0;
@@ -4169,7 +4169,7 @@ void SpecialNPC(int A)
             NPC[numNPCs].Location.X = NPC[A].Location.X + 24 * NPC[numNPCs].Direction;
             if(NPC[A].Type == 181)
             {
-                NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y - 5;
+                NPC[numNPCs].Location.Y -= 5;
                 NPC[numNPCs].Location.X = NPC[A].Location.X + 6 + 30 * NPC[numNPCs].Direction;
             }
             NPC[numNPCs].Location.SpeedX = 4 * NPC[numNPCs].Direction;
@@ -4199,35 +4199,35 @@ void SpecialNPC(int A)
         }
         if(NPC[A].Special > 0)
         {
-            NPC[A].Special = NPC[A].Special + 1;
+            NPC[A].Special += 1;
             NPC[A].Location.SpeedX = 0.6;
             if(NPC[A].Special >= 100 && NPC[A].Location.SpeedY == Physics.NPCGravity)
                 NPC[A].Special = -1;
         }
         else
         {
-            NPC[A].Special = NPC[A].Special - 1;
+            NPC[A].Special -= 1;
             NPC[A].Location.SpeedX = -0.6;
             if(NPC[A].Special <= -100 && NPC[A].Location.SpeedY == Physics.NPCGravity)
                 NPC[A].Special = 1;
         }
         if(NPC[A].Location.SpeedY == Physics.NPCGravity)
         {
-            NPC[A].Special2 = NPC[A].Special2 + 1;
+            NPC[A].Special2 += 1;
             if(NPC[A].Special2 >= 250)
             {
                 NPC[A].Location.SpeedY = -7;
-                NPC[A].Location.Y = NPC[A].Location.Y - 1;
+                NPC[A].Location.Y -= 1;
                 NPC[A].Special2 = 0;
             }
         }
-        NPC[A].Special3 = NPC[A].Special3 + dRand() * 2;
+        NPC[A].Special3 += dRand() * 2;
         if(NPC[A].Special3 >= 50 + dRand() * 1000)
         {
             if(NPC[A].Location.SpeedY == Physics.NPCGravity)
             {
                 NPC[A].Location.SpeedY = -3;
-                NPC[A].Location.Y = NPC[A].Location.Y - 1;
+                NPC[A].Location.Y -= 1;
             }
             PlaySound(SFX_HammerToss);
             NPC[A].Special3 = -15;
@@ -4254,13 +4254,13 @@ void SpecialNPC(int A)
             NPC[A].Location.SpeedX = 0;
         else if(NPC[A].Stuck)
         {
-            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity;
+            NPC[A].Location.SpeedY += Physics.NPCGravity;
             if(NPC[A].Location.SpeedY >= 8)
                 NPC[A].Location.SpeedY = 8;
         }
         else if(NPC[A].Special == 0)
         {
-            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity;
+            NPC[A].Location.SpeedY += Physics.NPCGravity;
             if(NPC[A].Projectile)
             {
                 if(NPC[A].Location.SpeedY >= 2)
@@ -4278,15 +4278,15 @@ void SpecialNPC(int A)
         {
             if(NPC[A].Special == 1)
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.25;
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.3;
+                NPC[A].Location.SpeedY -= 0.25;
+                NPC[A].Location.SpeedX += 0.3;
                 if(NPC[A].Location.SpeedY <= 0)
                     NPC[A].Special = 2;
             }
             else if(NPC[A].Special == 2)
             {
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.3;
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.02;
+                NPC[A].Location.SpeedX -= 0.3;
+                NPC[A].Location.SpeedY -= 0.02;
                 if(NPC[A].Location.SpeedX <= 0)
                 {
                     NPC[A].Special = 3;
@@ -4295,22 +4295,22 @@ void SpecialNPC(int A)
             }
             else if(NPC[A].Special == 3)
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.4;
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.1;
+                NPC[A].Location.SpeedY += 0.4;
+                NPC[A].Location.SpeedX -= 0.1;
                 if(NPC[A].Location.SpeedY >= 3)
                     NPC[A].Special = 4;
             }
             else if(NPC[A].Special == 4)
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.25;
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.3;
+                NPC[A].Location.SpeedY -= 0.25;
+                NPC[A].Location.SpeedX -= 0.3;
                 if(NPC[A].Location.SpeedY <= 0)
                     NPC[A].Special = 5;
             }
             else if(NPC[A].Special == 5)
             {
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.3;
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.02;
+                NPC[A].Location.SpeedX += 0.3;
+                NPC[A].Location.SpeedY -= 0.02;
                 if(NPC[A].Location.SpeedX >= 0)
                 {
                     NPC[A].Special = 6;
@@ -4319,8 +4319,8 @@ void SpecialNPC(int A)
             }
             else if(NPC[A].Special == 6)
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.4;
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.1;
+                NPC[A].Location.SpeedY += 0.4;
+                NPC[A].Location.SpeedX += 0.1;
                 if(NPC[A].Location.SpeedY >= 3)
                     NPC[A].Special = 1;
             }
@@ -4350,21 +4350,21 @@ void SpecialNPC(int A)
         {
             if(NPC[A].Special == 0)
             {
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.2;
+                NPC[A].Location.SpeedX -= 0.2;
                 D = (float)SDL_fabs(NPC[A].Location.X + NPC[A].Location.Width / 2.0 - Player[C].Location.X + Player[C].Location.Width / 2.0) / 100;
                 D += (float)SDL_fabs(Player[C].Location.SpeedX) / 2;
                 if(NPC[A].Location.SpeedX < -5 - D)
-                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.2;
+                    NPC[A].Location.SpeedX += 0.2;
                 if(NPC[A].Location.X + NPC[A].Location.Width / 2.0 < Player[C].Location.X + Player[C].Location.Width / 2.0 - 50 + (Player[C].Location.SpeedX * 15))
                     NPC[A].Special = 1;
             }
             else
             {
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.2;
+                NPC[A].Location.SpeedX += 0.2;
                 D = (float)SDL_fabs(NPC[A].Location.X + NPC[A].Location.Width / 2.0 - Player[C].Location.X + Player[C].Location.Width / 2.0) / 100;
                 D += (float)SDL_fabs(Player[C].Location.SpeedX) / 2;
                 if(NPC[A].Location.SpeedX > 5 + D)
-                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.2;
+                    NPC[A].Location.SpeedX -= 0.2;
                 if(NPC[A].Location.X + NPC[A].Location.Width / 2.0 > Player[C].Location.X + Player[C].Location.Width / 2.0 + 50 + (Player[C].Location.SpeedX * 15))
                     NPC[A].Special = 0;
             }
@@ -4391,13 +4391,13 @@ void SpecialNPC(int A)
 
             if(NPC[A].Special2 == 0)
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.05;
+                NPC[A].Location.SpeedY += 0.05;
                 if(NPC[A].Location.SpeedY > 2)
                     NPC[A].Location.SpeedY = 2;
             }
             else
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.05;
+                NPC[A].Location.SpeedY -= 0.05;
                 if(NPC[A].Location.SpeedY < -2)
                     NPC[A].Location.SpeedY = -2;
             }
@@ -4410,45 +4410,45 @@ void SpecialNPC(int A)
 
             if(NPC[A].Special3 == 0)
             {
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].FrameCount >= 10)
                 {
                     NPC[A].FrameCount = 0;
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     if(NPC[A].Frame >= 2)
                         NPC[A].Special3 = 1;
                 }
             }
             else if(NPC[A].Special3 == 1)
             {
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].FrameCount >= 10)
                 {
                     NPC[A].FrameCount = 0;
-                    NPC[A].Frame = NPC[A].Frame - 1;
+                    NPC[A].Frame -= 1;
                     if(NPC[A].Frame <= 0)
                         NPC[A].Special3 = 0;
                 }
             }
             else if(NPC[A].Special3 == 2)
             {
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].FrameCount >= 16)
                 {
                     NPC[A].FrameCount = 10;
                     if(NPC[A].Frame < 5)
-                        NPC[A].Frame = NPC[A].Frame + 1;
+                        NPC[A].Frame += 1;
                     if(NPC[A].Frame <= 5)
-                        NPC[A].Special5 = NPC[A].Special5 + 1;
+                        NPC[A].Special5 += 1;
                 }
             }
             else if(NPC[A].Special3 == 3)
             {
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].FrameCount >= 2)
                 {
                     NPC[A].FrameCount = 0;
-                    NPC[A].Frame = NPC[A].Frame - 1;
+                    NPC[A].Frame -= 1;
                     if(NPC[A].Frame <= 0)
                     {
                         NPC[A].Special3 = 0;
@@ -4468,16 +4468,16 @@ void SpecialNPC(int A)
         }
 
         if(NPC[A].Special4 > 0)
-            NPC[A].Special4 = NPC[A].Special4 - 1;
+            NPC[A].Special4 -= 1;
 
         if(NPC[A].Special5 >= 20)
         {
             NPC[A].Special5 = 20;
             tempLocation = NPC[A].Location;
-            tempLocation.X = tempLocation.X - 16;
-            tempLocation.Y = tempLocation.Y - 16;
-            tempLocation.Width = tempLocation.Width + 32;
-            tempLocation.Height = tempLocation.Height + 32;
+            tempLocation.X -= 16;
+            tempLocation.Y -= 16;
+            tempLocation.Width += 32;
+            tempLocation.Height += 32;
             D = 0;
 
             if(NPC[A].Location.Y + NPC[A].Location.Height > Player[C].Location.Y)
@@ -4519,7 +4519,7 @@ void SpecialNPC(int A)
                     NPC[numNPCs].CantHurtPlayer = NPC[A].CantHurtPlayer;
                 }
 
-                NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y + 8;
+                NPC[numNPCs].Location.Y += 8;
                 NPC[numNPCs].Location.SpeedX = (1.5 + std::abs(Player[C].Location.SpeedX) * 0.75) * NPC[numNPCs].Direction;
                 NPC[numNPCs].Location.SpeedY = -8;
                 NPC[numNPCs].Active = true;
@@ -4535,7 +4535,7 @@ void SpecialNPC(int A)
     }
     else if(NPC[A].Type == 166) // smw goomba
     {
-        NPC[A].Special = NPC[A].Special + 1;
+        NPC[A].Special += 1;
         if(NPC[A].Special >= 400)
         {
             if(NPC[A].Slope > 0 || NPC[A].Location.SpeedY == Physics.NPCGravity || NPC[A].Location.SpeedY == 0)
@@ -4543,7 +4543,7 @@ void SpecialNPC(int A)
                 NPC[A].Location.SpeedY = -5;
                 NPC[A].Type = 165;
                 NPC[A].Special = 0;
-                NPC[A].Location.Y = NPC[A].Location.Y - 1;
+                NPC[A].Location.Y -= 1;
             }
         }
     }
@@ -4584,7 +4584,7 @@ void SpecialNPC(int A)
                     NewEffect(10, tempLocation);
                     Effect[numEffects].Location.SpeedX = -1.5;
 
-//                    tempLocation.X = tempLocation.X + tempLocation.Width - EffectWidth[10];
+//                    tempLocation.X += tempLocation.Width - EffectWidth[10];
                     tempLocation.X = (NPC[A].Location.X + NPC[A].Location.Width - EffectWidth[10]) - (NPC[A].Location.Width / 8);
                     NewEffect(10, tempLocation);
                     Effect[numEffects].Location.SpeedX = 1.5;
@@ -4592,11 +4592,11 @@ void SpecialNPC(int A)
                 }
                 NPC[A].Location.SpeedY = 0;
                 if(NPC[A].Slope > 0)
-                    NPC[A].Location.Y = NPC[A].Location.Y - 0.1;
-                NPC[A].Special2 = NPC[A].Special2 + 1;
+                    NPC[A].Location.Y -= 0.1;
+                NPC[A].Special2 += 1;
                 if(NPC[A].Special2 >= 100)
                 {
-                    NPC[A].Location.Y = NPC[A].Location.Y - 1;
+                    NPC[A].Location.Y -= 1;
                     NPC[A].Special = 3;
                     NPC[A].Special2 = 0;
                 }
@@ -4707,15 +4707,15 @@ void SpecialNPC(int A)
                     else if(NPC[A].Type == 44)
                         F = 0.02F;
                     if(D <= E && NPC[A].Location.SpeedX < 1.5)
-                        NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + F;
+                        NPC[A].Location.SpeedX += F;
                     else if(NPC[A].Location.SpeedX > -1.5)
-                        NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - F;
+                        NPC[A].Location.SpeedX += -F;
                     D = NPC[A].Location.Y + NPC[A].Location.Height / 2.0;
                     E = Player[C].Location.Y + Player[C].Location.Height / 2.0;
                     if(D <= E && NPC[A].Location.SpeedY < 1.5)
-                        NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + F;
+                        NPC[A].Location.SpeedY += F;
                     else if(NPC[A].Location.SpeedY > -1.5)
-                        NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - F;
+                        NPC[A].Location.SpeedY += -F;
                 }
             }
             else
@@ -4730,7 +4730,7 @@ void SpecialNPC(int A)
     {
         if(NPC[A].Special == 0)
         {
-            NPC[A].Special4 = NPC[A].Special4 + 1;
+            NPC[A].Special4 += 1;
             if(NPC[A].Special4 >= 5)
             {
                 NPC[A].Special4 = 0;
@@ -4741,7 +4741,7 @@ void SpecialNPC(int A)
         }
         else
         {
-            NPC[A].Special4 = NPC[A].Special4 + 1;
+            NPC[A].Special4 += 1;
             if(NPC[A].Special4 >= 10)
             {
                 NPC[A].Special4 = 0;
@@ -4753,25 +4753,25 @@ void SpecialNPC(int A)
         }
         if(NPC[A].Special2 == 0)
         {
-            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.04;
+            NPC[A].Location.SpeedY -= 0.04;
             if(NPC[A].Location.SpeedY <= -1.4)
                 NPC[A].Special2 = 1;
         }
         else
         {
-            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.04;
+            NPC[A].Location.SpeedY += 0.04;
             if(NPC[A].Location.SpeedY >= 1.4)
                 NPC[A].Special2 = 0;
         }
         if(NPC[A].Special3 == 0)
         {
-            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.03;
+            NPC[A].Location.SpeedX -= 0.03;
             if(NPC[A].Location.SpeedX <= -0.6)
                 NPC[A].Special3 = 1;
         }
         else
         {
-            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.03;
+            NPC[A].Location.SpeedX += 0.03;
             if(NPC[A].Location.SpeedX >= 0.6)
                 NPC[A].Special3 = 0;
         }
@@ -4806,10 +4806,10 @@ void SpecialNPC(int A)
                     }
                 }
             }
-            NPC[A].Special2 = NPC[A].Special2 + 1;
+            NPC[A].Special2 += 1;
             if(NPC[A].Special2 == 125)
             {
-                NPC[A].Location.Y = NPC[A].Location.Y - 1;
+                NPC[A].Location.Y -= 1;
                 NPC[A].Location.SpeedY = -5;
                 if(NPC[A].Inert)
                     NPC[A].Special2 = 0;
@@ -4848,7 +4848,7 @@ void SpecialNPC(int A)
             }
             if(NPC[A].Special == 0 && NPC[A].Location.SpeedY == Physics.NPCGravity)
             {
-                NPC[A].Special3 = NPC[A].Special3 + 1;
+                NPC[A].Special3 += 1;
                 if(NPC[A].Special3 <= 200)
                     NPC[A].Location.SpeedX = -1;
                 else if(NPC[A].Special3 > 500)
@@ -4863,7 +4863,7 @@ void SpecialNPC(int A)
         }
         else
         {
-            NPC[A].Special = NPC[A].Special + 1;
+            NPC[A].Special += 1;
             NPC[A].Location.SpeedX = 0;
         }
         if(NPC[A].Stuck)
@@ -4899,21 +4899,21 @@ void SpecialNPC(int A)
         {
             if(NPC[A].Special6 == 0)
             {
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.2;
+                NPC[A].Location.SpeedX -= 0.2;
                 D = (float)SDL_fabs(NPC[A].Location.X + NPC[A].Location.Width / 2.0 - Player[C].Location.X + Player[C].Location.Width / 2.0) / 100;
                 D += (float)SDL_fabs(Player[C].Location.SpeedX) / 2;
                 if(NPC[A].Location.SpeedX < -5 - D)
-                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.2;
+                    NPC[A].Location.SpeedX += 0.2;
                 if(NPC[A].Location.X + NPC[A].Location.Width / 2.0 < Player[C].Location.X + Player[C].Location.Width / 2.0 - 50 + (Player[C].Location.SpeedX * 15))
                     NPC[A].Special6 = 1;
             }
             else
             {
-                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.2;
+                NPC[A].Location.SpeedX += 0.2;
                 D = (float)SDL_fabs(NPC[A].Location.X + NPC[A].Location.Width / 2.0 - Player[C].Location.X + Player[C].Location.Width / 2.0) / 100;
                 D += (float)SDL_fabs(Player[C].Location.SpeedX) / 2;
                 if(NPC[A].Location.SpeedX > 5 + D)
-                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.2;
+                    NPC[A].Location.SpeedX -= 0.2;
                 if(NPC[A].Location.X + NPC[A].Location.Width / 2.0 > Player[C].Location.X + Player[C].Location.Width / 2.0 + 50 + (Player[C].Location.SpeedX * 15))
                     NPC[A].Special6 = 0;
             }
@@ -4940,13 +4940,13 @@ void SpecialNPC(int A)
 
             if(NPC[A].Special2 == 0)
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.05;
+                NPC[A].Location.SpeedY += 0.05;
                 if(NPC[A].Location.SpeedY > 2)
                     NPC[A].Location.SpeedY = 2;
             }
             else
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.05;
+                NPC[A].Location.SpeedY -= 0.05;
                 if(NPC[A].Location.SpeedY < -2)
                     NPC[A].Location.SpeedY = -2;
             }
@@ -4968,7 +4968,7 @@ void SpecialNPC(int A)
         }
 
         if(NPC[A].Special4 > 0)
-            NPC[A].Special4 = NPC[A].Special4 - 1;
+            NPC[A].Special4 -= 1;
 
 
 
@@ -4976,7 +4976,7 @@ void SpecialNPC(int A)
         NPC[A].Frame = 0;
         if(NPC[A].FrameCount < 100)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 8)
                 NPC[A].Frame = 0;
             else if(NPC[A].FrameCount < 16)
@@ -4993,7 +4993,7 @@ void SpecialNPC(int A)
         }
         else
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 108)
                 NPC[A].Frame = 6;
             else if(NPC[A].FrameCount < 116)
@@ -5010,18 +5010,18 @@ void SpecialNPC(int A)
         }
 
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 3;
+            NPC[A].Frame += 3;
 
-        NPC[A].Special5 = NPC[A].Special5 + 1;
+        NPC[A].Special5 += 1;
 
         if(NPC[A].Special5 >= 150)
         {
             NPC[A].Special5 = 150;
             tempLocation = NPC[A].Location;
-            tempLocation.X = tempLocation.X - 16;
-            tempLocation.Y = tempLocation.Y - 16;
-            tempLocation.Width = tempLocation.Width + 32;
-            tempLocation.Height = tempLocation.Height + 32;
+            tempLocation.X -= 16;
+            tempLocation.Y -= 16;
+            tempLocation.Width += 32;
+            tempLocation.Height += 32;
 
             D = 0;
 
@@ -5065,7 +5065,7 @@ void SpecialNPC(int A)
                     NPC[numNPCs].CantHurtPlayer = NPC[A].CantHurtPlayer;
                 }
 
-                NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y + 8;
+                NPC[numNPCs].Location.Y += 8;
                 NPC[numNPCs].Location.SpeedX = (1 + dRand() * 2) * double(NPC[numNPCs].Direction);
                 NPC[numNPCs].Location.SpeedY = -7;
                 NPC[numNPCs].Active = true;
@@ -5230,8 +5230,8 @@ void CharStuff(int WhatNPC, bool CheckEggs)
                     NPC[A].Frame = 0;
                     NPC[A].Type = 250;
                     NPC[A].Location.SpeedX = 0;
-                    NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - NPCHeight[NPC[A].Type] - 1;
-                    NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - NPCWidth[NPC[A].Type] / 2.0;
+                    NPC[A].Location.Y += NPC[A].Location.Height - NPCHeight[NPC[A].Type] - 1;
+                    NPC[A].Location.X += NPC[A].Location.Width / 2.0 - NPCWidth[NPC[A].Type] / 2.0;
                     NPC[A].Location.Width = 32;
                     NPC[A].Location.Height = 32;
                 }
@@ -5241,8 +5241,8 @@ void CharStuff(int WhatNPC, bool CheckEggs)
                         NPC[A].Type = 252;
                     else
                         NPC[A].Type = 251;
-                    NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - NPCHeight[NPC[A].Type];
-                    NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - NPCWidth[NPC[A].Type] / 2.0;
+                    NPC[A].Location.Y += NPC[A].Location.Height - NPCHeight[NPC[A].Type];
+                    NPC[A].Location.X += NPC[A].Location.Width / 2.0 - NPCWidth[NPC[A].Type] / 2.0;
                     NPC[A].Location.Width = NPCWidth[NPC[A].Type];
                     NPC[A].Location.Height = NPCHeight[NPC[A].Type];
                     NPC[A].Frame = 0;

--- a/src/npc/npc_bonus.cpp
+++ b/src/npc/npc_bonus.cpp
@@ -127,7 +127,7 @@ void TouchBonus(int A, int B)
         {
             if(NPC[B].Type == 34 || NPC[B].Type == 169 || NPC[B].Type == 170)
             {
-                Player[A].Hearts = Player[A].Hearts + 1;
+                Player[A].Hearts += 1;
                 if(Player[A].Hearts > 3)
                     Player[A].Hearts = 3;
             }
@@ -247,7 +247,7 @@ void TouchBonus(int A, int B)
                 Player[A].State = 2;
             if(Player[A].Character == 3 || Player[A].Character == 4 || Player[A].Character == 5)
             {
-                Player[A].Hearts = Player[A].Hearts + 1;
+                Player[A].Hearts += 1;
                 if(Player[A].Hearts > 3)
                     Player[A].Hearts = 3;
             }
@@ -275,7 +275,7 @@ void TouchBonus(int A, int B)
         {
             if(Player[A].Character == 3 || Player[A].Character == 4 || Player[A].Character == 5)
             {
-                Player[A].Hearts = Player[A].Hearts + 1;
+                Player[A].Hearts += 1;
                 if(Player[A].Hearts > 3)
                     Player[A].Hearts = 3;
             }
@@ -306,7 +306,7 @@ void TouchBonus(int A, int B)
         {
             if(Player[A].Character == 3 || Player[A].Character == 4 || Player[A].Character == 5)
             {
-                Player[A].Hearts = Player[A].Hearts + 1;
+                Player[A].Hearts += 1;
                 if(Player[A].Hearts > 3)
                     Player[A].Hearts = 3;
             }
@@ -421,18 +421,18 @@ void TouchBonus(int A, int B)
             else if(NPC[B].Type != 274)
                 PlaySound(SFX_Coin);
             if(NPC[B].Type == 252 || NPC[B].Type == 258)
-                Coins = Coins + 5;
+                Coins += 5;
             else if(NPC[B].Type == 253)
-                Coins = Coins + 20;
+                Coins += 20;
             else
-                Coins = Coins + 1;
+                Coins += 1;
             if(Coins >= 100)
             {
                 if(Lives < 99)
                 {
-                    Lives = Lives + 1;
+                    Lives += 1;
                     PlaySound(SFX_1up);
-                    Coins = Coins - 100;
+                    Coins -= 100;
                 }
                 else
                     Coins = 99;
@@ -441,7 +441,7 @@ void TouchBonus(int A, int B)
             {
                 PlaySound(SFX_DraginCoin);
                 MoreScore(NPCScore[NPC[B].Type], NPC[B].Location);
-                NPCScore[274] = NPCScore[274] + 1;
+                NPCScore[274] += 1;
                 if(NPCScore[274] > 14)
                     NPCScore[274] = 14;
             }

--- a/src/npc/npc_frames.cpp
+++ b/src/npc/npc_frames.cpp
@@ -34,15 +34,15 @@ void NPCFrames(int A)
 
     if(NPCFrame[NPC[A].Type] > 0) // custom frames
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPCFrameStyle[NPC[A].Type] == 2 && (NPC[A].Projectile || NPC[A].HoldingPlayer > 0))
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= NPCFrameSpeed[NPC[A].Type])
         {
             if(NPCFrameStyle[NPC[A].Type] == 0)
-                NPC[A].Frame = NPC[A].Frame + 1 * NPC[A].Direction;
+                NPC[A].Frame += 1 * NPC[A].Direction;
             else
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
             NPC[A].FrameCount = 0;
         }
         if(NPCFrameStyle[NPC[A].Type] == 0)
@@ -147,11 +147,11 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 278 || NPC[A].Type == 279) // fly block
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].HoldingPlayer > 0)
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
         if(NPC[A].Location.SpeedY != 0)
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount <= 6)
             NPC[A].Frame = 0;
         else if(NPC[A].FrameCount <= 12)
@@ -170,13 +170,13 @@ void NPCFrames(int A)
             NPC[A].FrameCount = 0;
         }
         if(NPC[A].Type == 279 && NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 4;
+            NPC[A].Frame += 4;
     }
     else if(NPC[A].Type == 275) // fire plant thing
     {
         if(NPC[A].Special == 0)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 8)
                 NPC[A].Frame = 0;
             else if(NPC[A].FrameCount < 16)
@@ -189,7 +189,7 @@ void NPCFrames(int A)
         }
         else if(NPC[A].Special == 1)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 4)
                 NPC[A].Frame = 0;
             else if(NPC[A].FrameCount < 8)
@@ -205,10 +205,10 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 288) // potion
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 8)
         {
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             NPC[A].FrameCount = 0;
         }
         if(NPC[A].Frame >= 4)
@@ -216,7 +216,7 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 283) // bubble
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount < 6)
             NPC[A].Frame = 0;
         else if(NPC[A].FrameCount < 12)
@@ -237,11 +237,11 @@ void NPCFrames(int A)
             NPC[A].Frame = 0;
         else
             NPC[A].Frame = 2;
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount > 15)
             NPC[A].FrameCount = 0;
         else if(NPC[A].FrameCount >= 8)
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
     }
     else if(NPC[A].Type == 271) // bat thing
     {
@@ -250,23 +250,23 @@ void NPCFrames(int A)
         else
         {
             NPC[A].Frame = 1;
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount > 15)
                 NPC[A].FrameCount = 0;
             else if(NPC[A].FrameCount >= 8)
                 NPC[A].Frame = 2;
         }
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 3;
+            NPC[A].Frame += 3;
 
 
     }
     else if(NPC[A].Type == 270) // jumping plant
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 4)
         {
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             NPC[A].FrameCount = 0;
         }
         if(NPC[A].Frame >= 4)
@@ -277,7 +277,7 @@ void NPCFrames(int A)
     {
         if(NPC[A].Location.SpeedY != 0)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 4)
                 NPC[A].Frame = 10;
             else if(NPC[A].FrameCount < 8)
@@ -292,7 +292,7 @@ void NPCFrames(int A)
         {
             if(NPC[A].Special == 0)
             {
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].Location.SpeedX == 0)
                     NPC[A].FrameCount = 10;
                 if(NPC[A].FrameCount < 4)
@@ -312,7 +312,7 @@ void NPCFrames(int A)
             else if(NPC[A].Special == 2)
                 NPC[A].Frame = 4;
             if(NPC[A].Direction == 1)
-                NPC[A].Frame = NPC[A].Frame + 5;
+                NPC[A].Frame += 5;
         }
 
 
@@ -327,10 +327,10 @@ void NPCFrames(int A)
         }
         else
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount >= 4)
             {
-                NPC[A].Frame = NPC[A].Frame + NPC[A].Direction;
+                NPC[A].Frame += NPC[A].Direction;
                 NPC[A].FrameCount = 0;
             }
             if(NPC[A].Frame < 0)
@@ -342,14 +342,14 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 282) // ludwig fire
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         NPC[A].Frame = 0;
         if(NPC[A].FrameCount > 8)
             NPC[A].FrameCount = 0;
         else if(NPC[A].FrameCount >= 4)
             NPC[A].Frame = 1;
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 2;
+            NPC[A].Frame += 2;
 
     }
     else if(NPC[A].Type == 269) // larry magic
@@ -363,10 +363,10 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 268) // larry shell
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 4)
         {
-            NPC[A].Frame = NPC[A].Frame + NPC[A].Direction;
+            NPC[A].Frame += NPC[A].Direction;
             NPC[A].FrameCount = 0;
         }
         if(NPC[A].Frame < 0)
@@ -386,7 +386,7 @@ void NPCFrames(int A)
                     NPC[A].Frame = 0;
                 else
                 {
-                    NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                    NPC[A].FrameCount += 1;
                     if(NPC[A].FrameCount < 8)
                         NPC[A].Frame = 0;
                     else if(NPC[A].FrameCount < 16)
@@ -403,7 +403,7 @@ void NPCFrames(int A)
         }
         else if(NPC[A].Special == 1)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 2)
                 NPC[A].Frame = 2;
             else if(NPC[A].FrameCount < 4)
@@ -420,7 +420,7 @@ void NPCFrames(int A)
         }
         else if(NPC[A].Special == 2)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 2)
                 NPC[A].Frame = 6;
             else if(NPC[A].FrameCount < 4)
@@ -436,7 +436,7 @@ void NPCFrames(int A)
             }
         }
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 10;
+            NPC[A].Frame += 10;
 
 
     }
@@ -445,16 +445,16 @@ void NPCFrames(int A)
         NPC[A].Frame = 0;
         if(NPC[A].Direction == 1)
             NPC[A].Frame = 4;
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount < 2)
         {
         }
         else if(NPC[A].FrameCount < 4)
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
         else if(NPC[A].FrameCount < 6)
-            NPC[A].Frame = NPC[A].Frame + 2;
+            NPC[A].Frame += 2;
         else if(NPC[A].FrameCount < 8)
-            NPC[A].Frame = NPC[A].Frame + 3;
+            NPC[A].Frame += 3;
         else
             NPC[A].FrameCount = 0;
 
@@ -464,7 +464,7 @@ void NPCFrames(int A)
     {
         if(NPC[A].Immune > 0)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 4)
                 NPC[A].Frame = 3;
             else if(NPC[A].FrameCount < 8)
@@ -479,11 +479,11 @@ void NPCFrames(int A)
                 NPC[A].FrameCount = 0;
             }
             if(NPC[A].Direction == 1)
-                NPC[A].Frame = NPC[A].Frame + 7;
+                NPC[A].Frame += 7;
         }
         else if(NPC[A].Special <= 0)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 8)
                 NPC[A].Frame = 1;
             else if(NPC[A].FrameCount < 15)
@@ -494,19 +494,19 @@ void NPCFrames(int A)
                 NPC[A].FrameCount = 0;
             }
             if(NPC[A].Direction == 1)
-                NPC[A].Frame = NPC[A].Frame + 7;
+                NPC[A].Frame += 7;
         }
         else
         {
             NPC[A].Frame = 0;
             if(NPC[A].Direction == 1)
-                NPC[A].Frame = NPC[A].Frame + 7;
+                NPC[A].Frame += 7;
         }
 
     }
     else if(NPC[A].Type == 261)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount < 8)
             NPC[A].Frame = 0;
         else if(NPC[A].FrameCount < 15)
@@ -517,9 +517,9 @@ void NPCFrames(int A)
             NPC[A].Frame = 1;
         }
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 4;
+            NPC[A].Frame += 4;
         if(NPC[A].Special > 0 && NPC[A].Location.SpeedY <= 0)
-            NPC[A].Frame = NPC[A].Frame + 2;
+            NPC[A].Frame += 2;
 
     }
     else if(NPC[A].Type == 260)
@@ -535,7 +535,7 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 259)
     {
-        NPC[A].Frame = NPC[A].Frame + 1;
+        NPC[A].Frame += 1;
         if(NPC[A].Frame >= 5)
             NPC[A].Frame = 0;
     }
@@ -543,11 +543,11 @@ void NPCFrames(int A)
         NPC[A].Frame = SpecialFrame[8];
     else if(NPC[A].Type == 238)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 4)
         {
             NPC[A].FrameCount = 0;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
         }
         if(NPC[A].Frame >= 3)
             NPC[A].Frame = 0;
@@ -566,7 +566,7 @@ void NPCFrames(int A)
             else
                 NPC[A].Frame = 0;
         }
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 16)
             NPC[A].FrameCount = 0;
         else if(NPC[A].FrameCount > 8)
@@ -583,26 +583,26 @@ void NPCFrames(int A)
         if(Player[NPC[A].Special4].Location.X + Player[NPC[A].Special4].Location.Width / 2.0 > NPC[A].Location.X + NPC[A].Location.Width / 2.0)
             NPC[A].Frame = 2;
         if(Player[NPC[A].Special4].Location.Y + Player[NPC[A].Special4].Location.Height / 2.0 < NPC[A].Location.Y + 16)
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
     }
     else if(NPC[A].Type == 243)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 4)
         {
             NPC[A].FrameCount = 0;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Frame >= 2)
                 NPC[A].Frame = 0;
         }
     }
     else if(NPC[A].Type == 241) // POW block
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 8)
         {
             NPC[A].FrameCount = 0;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Frame >= 7)
                 NPC[A].Frame = 0;
         }
@@ -616,7 +616,7 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 211)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount <= 6)
             NPC[A].Frame = 0;
         else if(NPC[A].FrameCount <= 12)
@@ -642,7 +642,7 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 210)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount <= 8)
             NPC[A].Frame = 0;
         else if(NPC[A].FrameCount <= 16)
@@ -664,7 +664,7 @@ void NPCFrames(int A)
         if(NPC[A].Special > 0 && NPC[A].Special < 15)
             NPC[A].Frame = 1;
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 2;
+            NPC[A].Frame += 2;
     }
     else if(NPC[A].Type == 208)
     {
@@ -679,30 +679,30 @@ void NPCFrames(int A)
         else
             NPC[A].Frame = 4;
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 5;
+            NPC[A].Frame += 5;
     }
     else if(NPC[A].Type == 207)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         NPC[A].Frame = 0;
         if(NPC[A].FrameCount >= 16)
             NPC[A].FrameCount = 0;
         else if(NPC[A].FrameCount > 8)
             NPC[A].Frame = 1;
         if(NPC[A].Special == 4)
-            NPC[A].Frame = NPC[A].Frame + 4;
+            NPC[A].Frame += 4;
         else if(NPC[A].Special == 3)
-            NPC[A].Frame = NPC[A].Frame + 8;
+            NPC[A].Frame += 8;
         else if(NPC[A].Special == 2)
-            NPC[A].Frame = NPC[A].Frame + 12;
+            NPC[A].Frame += 12;
         if(NPC[A].Special2 == 1)
-            NPC[A].Frame = NPC[A].Frame + 2;
+            NPC[A].Frame += 2;
 
 
     }
     else if(NPC[A].Type == 205)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         NPC[A].Frame = 0;
         if(NPC[A].FrameCount <= 6)
             NPC[A].Frame = 0;
@@ -717,17 +717,17 @@ void NPCFrames(int A)
         else
             NPC[A].FrameCount = 0;
         if(NPC[A].Special == 4)
-            NPC[A].Frame = NPC[A].Frame + 5;
+            NPC[A].Frame += 5;
         else if(NPC[A].Special == 3)
-            NPC[A].Frame = NPC[A].Frame + 10;
+            NPC[A].Frame += 10;
         else if(NPC[A].Special == 2)
-            NPC[A].Frame = NPC[A].Frame + 15;
+            NPC[A].Frame += 15;
 
 
     }
     else if(NPC[A].Type == 203 || NPC[A].Type == 204)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         NPC[A].Frame = 0;
         if(NPC[A].FrameCount <= 6)
             NPC[A].Frame = 0;
@@ -740,14 +740,14 @@ void NPCFrames(int A)
         else
             NPC[A].FrameCount = 0;
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 4;
+            NPC[A].Frame += 4;
     }
     else if(NPC[A].Type == 201)
     {
         NPC[A].Frame = 0;
         if(NPC[A].Special == 0)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 8)
                 NPC[A].Frame = 0;
             else if(NPC[A].FrameCount < 16)
@@ -763,7 +763,7 @@ void NPCFrames(int A)
         }
         else if(NPC[A].Special == 2)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 8)
                 NPC[A].Frame = 3;
             else if(NPC[A].FrameCount < 16)
@@ -778,7 +778,7 @@ void NPCFrames(int A)
         if(NPC[A].Special == 3 || NPC[A].Special == 2)
         {
             NPC[A].Frame = 0;
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 4)
                 NPC[A].Frame = 5;
             else if(NPC[A].FrameCount < 8)
@@ -792,14 +792,14 @@ void NPCFrames(int A)
             }
         }
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 8;
+            NPC[A].Frame += 8;
     }
     else if(NPC[A].Type == 200) // King Koopa
     {
         NPC[A].Frame = 0;
         if(NPC[A].Special == 0)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount <= 8)
                 NPC[A].Frame = 1;
             else if(NPC[A].FrameCount <= 16)
@@ -822,15 +822,15 @@ void NPCFrames(int A)
             NPC[A].Frame = 4;
         }
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 5;
+            NPC[A].Frame += 5;
     }
     else if(NPC[A].Type == 196)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 4)
         {
             NPC[A].FrameCount = 0;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Frame >= 2)
                 NPC[A].Frame = 0;
         }
@@ -865,34 +865,34 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 292) // toad boomerang
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 6)
         {
             NPC[A].FrameCount = 0;
 
             if(NPC[A].Location.SpeedX > 0)
             {
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame == 1)
-                    NPC[A].Location.X = NPC[A].Location.X + 4;
+                    NPC[A].Location.X += 4;
                 else if(NPC[A].Frame == 3)
-                    NPC[A].Location.X = NPC[A].Location.X - 4;
+                    NPC[A].Location.X -= 4;
                 else if(NPC[A].Frame == 2)
-                    NPC[A].Location.Y = NPC[A].Location.Y + 4;
+                    NPC[A].Location.Y += 4;
                 else
-                    NPC[A].Location.Y = NPC[A].Location.Y - 4;
+                    NPC[A].Location.Y -= 4;
             }
             else
             {
-                NPC[A].Frame = NPC[A].Frame - 1;
+                NPC[A].Frame -= 1;
                 if(NPC[A].Frame == 0)
-                    NPC[A].Location.X = NPC[A].Location.X - 4;
+                    NPC[A].Location.X -= 4;
                 else if(NPC[A].Frame == 1)
-                    NPC[A].Location.Y = NPC[A].Location.Y - 4;
+                    NPC[A].Location.Y -= 4;
                 else if(NPC[A].Frame == 2)
-                    NPC[A].Location.X = NPC[A].Location.X + 4;
+                    NPC[A].Location.X += 4;
                 else
-                    NPC[A].Location.Y = NPC[A].Location.Y + 4;
+                    NPC[A].Location.Y += 4;
             }
 
             if(NPC[A].Frame > 3)
@@ -913,33 +913,33 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 171) // Mario Hammer
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 4)
         {
             NPC[A].FrameCount = 0;
             if(NPC[A].Location.SpeedX > 0)
             {
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame == 1)
-                    NPC[A].Location.X = NPC[A].Location.X + 8;
+                    NPC[A].Location.X += 8;
                 else if(NPC[A].Frame == 3)
-                    NPC[A].Location.X = NPC[A].Location.X - 8;
+                    NPC[A].Location.X -= 8;
                 else if(NPC[A].Frame == 2)
-                    NPC[A].Location.Y = NPC[A].Location.Y + 12;
+                    NPC[A].Location.Y += 12;
                 else
-                    NPC[A].Location.Y = NPC[A].Location.Y - 12;
+                    NPC[A].Location.Y -= 12;
             }
             else
             {
-                NPC[A].Frame = NPC[A].Frame - 1;
+                NPC[A].Frame -= 1;
                 if(NPC[A].Frame == 0)
-                    NPC[A].Location.X = NPC[A].Location.X - 8;
+                    NPC[A].Location.X -= 8;
                 else if(NPC[A].Frame == 1)
-                    NPC[A].Location.Y = NPC[A].Location.Y - 12;
+                    NPC[A].Location.Y -= 12;
                 else if(NPC[A].Frame == 2)
-                    NPC[A].Location.X = NPC[A].Location.X + 8;
+                    NPC[A].Location.X += 8;
                 else
-                    NPC[A].Location.Y = NPC[A].Location.Y + 12;
+                    NPC[A].Location.Y += 12;
             }
             if(NPC[A].Frame > 3)
                 NPC[A].Frame = 0;
@@ -954,7 +954,7 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 167) // smw paragoomba
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].Direction == 1)
             NPC[A].Frame = 4;
         else
@@ -962,40 +962,40 @@ void NPCFrames(int A)
         if(NPC[A].FrameCount >= 16)
             NPC[A].FrameCount = 0;
         else if(NPC[A].FrameCount >= 8)
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
 
         if(NPC[A].Effect == 0)
         {
             if(NPC[A].Special == 0)
-                NPC[A].Special2 = NPC[A].Special2 + 2;
+                NPC[A].Special2 += 2;
             else if(NPC[A].Special <= 60)
                 NPC[A].Special2 = 0;
             else if(NPC[A].Special < 65)
-                NPC[A].Special2 = NPC[A].Special2 + 1;
+                NPC[A].Special2 += 1;
             else
-                NPC[A].Special2 = NPC[A].Special2 + 2;
+                NPC[A].Special2 += 2;
             if(NPC[A].Special2 >= 16)
                 NPC[A].Special2 = 0;
             else if(NPC[A].Special2 >= 8)
-                NPC[A].Frame = NPC[A].Frame + 2;
+                NPC[A].Frame += 2;
         }
     }
     else if(NPC[A].Type == 3 || NPC[A].Type == 244) // Flying Goomba
     {
         if(NPC[A].Location.SpeedY == 0 || NPC[A].Slope > 0)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount >= 8)
             {
                 NPC[A].FrameCount = 0;
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame >= 2)
                     NPC[A].Frame = 0;
             }
         }
         else
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount >= 4)
             {
                 NPC[A].FrameCount = 0;
@@ -1012,7 +1012,7 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 134) // bomb
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount < 4)
             NPC[A].Frame = 0;
         else if(NPC[A].FrameCount < 8)
@@ -1023,23 +1023,23 @@ void NPCFrames(int A)
             NPC[A].FrameCount = 0;
         if(NPC[A].Special2 == 1)
         {
-            NPC[A].Special3 = NPC[A].Special3 + 1;
+            NPC[A].Special3 += 1;
             if(NPC[A].Special3 < 4)
             {
             }
             else if(NPC[A].Special3 < 8)
-                NPC[A].Frame = NPC[A].Frame + 9;
+                NPC[A].Frame += 9;
             else if(NPC[A].Special3 < 12)
-                NPC[A].Frame = NPC[A].Frame + 3;
+                NPC[A].Frame += 3;
             else if(NPC[A].Special3 < 15)
-                NPC[A].Frame = NPC[A].Frame + 6;
+                NPC[A].Frame += 6;
             else
                 NPC[A].Special3 = 0;
         }
     }
     else if(NPC[A].Type == 291) // heart bomb
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount < 4)
             NPC[A].Frame = 0;
         else if(NPC[A].FrameCount < 8)
@@ -1051,13 +1051,13 @@ void NPCFrames(int A)
             NPC[A].FrameCount = 0;
             NPC[A].Frame = 0;
         }
-        NPC[A].Special3 = NPC[A].Special3 + 1;
+        NPC[A].Special3 += 1;
         if(NPC[A].Special3 < 4)
         {}
         else if(NPC[A].Special3 < 8)
-            NPC[A].Frame = NPC[A].Frame + 3;
+            NPC[A].Frame += 3;
         else if(NPC[A].Special3 < 12)
-            NPC[A].Frame = NPC[A].Frame + 6;
+            NPC[A].Frame += 6;
         else // If .Special3 >= 16 Then
             NPC[A].Special3 = 0;
         if(fRand() * 10 > 9.2)
@@ -1089,22 +1089,22 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 194 || NPC[A].Type == 195) // Glowy Shell
     {
-        NPC[A].Special5 = NPC[A].Special5 + 1;
+        NPC[A].Special5 += 1;
         if(NPC[A].Special5 >= 16)
             NPC[A].Special5 = 0;
         if(NPC[A].Location.SpeedX > 0)
         {
             if(NPC[A].Type == 194)
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
             else
-                NPC[A].FrameCount = NPC[A].FrameCount - 1;
+                NPC[A].FrameCount -= 1;
         }
         else if(NPC[A].Location.SpeedX < 0)
         {
             if(NPC[A].Type == 194)
-                NPC[A].FrameCount = NPC[A].FrameCount - 1;
+                NPC[A].FrameCount -= 1;
             else
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
         }
         else
         {
@@ -1129,11 +1129,11 @@ void NPCFrames(int A)
         {
         }
         else if(NPC[A].Special5 < 8)
-            NPC[A].Frame = NPC[A].Frame + 4;
+            NPC[A].Frame += 4;
         else if(NPC[A].Special5 < 12)
-            NPC[A].Frame = NPC[A].Frame + 8;
+            NPC[A].Frame += 8;
         else if(NPC[A].Special5 < 16)
-            NPC[A].Frame = NPC[A].Frame + 12;
+            NPC[A].Frame += 12;
     }
     else if(NPCIsAShell[NPC[A].Type]) // Turtle shell
     {
@@ -1141,11 +1141,11 @@ void NPCFrames(int A)
             NPC[A].Frame = 0;
         else
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount >= 4)
             {
                 NPC[A].FrameCount = 0;
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame >= 4)
                     NPC[A].Frame = 0;
             }
@@ -1156,7 +1156,7 @@ void NPCFrames(int A)
         if(NPC[A].Location.SpeedY == 0 || NPC[A].Slope > 0)
         {
             NPC[A].Frame = 0;
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount >= 12)
                 NPC[A].FrameCount = 0;
             else if(NPC[A].FrameCount >= 6)
@@ -1173,7 +1173,7 @@ void NPCFrames(int A)
             NPC[A].FrameCount = 0;
         }
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 2;
+            NPC[A].Frame += 2;
     }
     else if(NPC[A].Type == 57) // smb3 belt
     {
@@ -1192,27 +1192,27 @@ void NPCFrames(int A)
     {
         NPC[A].Frame = 0;
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 3;
+            NPC[A].Frame += 3;
 
         if(NPC[A].Projectile || NPC[A].Special2 != 0)
         {
-            NPC[A].Frame = NPC[A].Frame + 2;
+            NPC[A].Frame += 2;
             NPC[A].FrameCount = 0;
         }
         else
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount >= 16)
                 NPC[A].FrameCount = 0;
             else if(NPC[A].FrameCount >= 8)
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
         }
 
 
     }
     else if(NPC[A].Type == 78) // tank treads
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 8)
             NPC[A].Frame = 2;
         else if(NPC[A].FrameCount >= 4)
@@ -1222,7 +1222,7 @@ void NPCFrames(int A)
         if(NPC[A].FrameCount > 12)
             NPC[A].FrameCount = 0;
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 3;
+            NPC[A].Frame += 3;
     }
     else if(NPC[A].Type == 55) // nekkid koopa
     {
@@ -1231,11 +1231,11 @@ void NPCFrames(int A)
             NPC[A].Frame = 0;
             if(NPC[A].Direction == 1)
                 NPC[A].Frame = 3;
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount >= 15)
                 NPC[A].FrameCount = 0;
             else if(NPC[A].FrameCount >= 8)
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
         }
         else
         {
@@ -1254,7 +1254,7 @@ void NPCFrames(int A)
             else
             {
                 NPC[A].Frame = 3;
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].FrameCount >= 15)
                     NPC[A].FrameCount = 0;
                 else if(NPC[A].FrameCount >= 8)
@@ -1266,7 +1266,7 @@ void NPCFrames(int A)
             if(NPC[A].Special == 0)
             {
                 NPC[A].Frame = 0;
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].FrameCount >= 15)
                     NPC[A].FrameCount = 0;
                 else if(NPC[A].FrameCount >= 8)
@@ -1276,7 +1276,7 @@ void NPCFrames(int A)
                 NPC[A].Frame = 2;
         }
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 5;
+            NPC[A].Frame += 5;
     }
     else if(NPC[A].Type == 54) // bouncy bee
     {
@@ -1287,10 +1287,10 @@ void NPCFrames(int A)
         }
         else
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount >= 3)
             {
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame >= 2)
                     NPC[A].Frame = 0;
                 NPC[A].FrameCount = 0;
@@ -1301,7 +1301,7 @@ void NPCFrames(int A)
     {
         NPC[A].Frame = SpecialFrame[2];
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 4;
+            NPC[A].Frame += 4;
     }
     else if(NPC[A].Type == 45) // ice block
     {
@@ -1311,11 +1311,11 @@ void NPCFrames(int A)
         {
             if(NPC[A].Frame < 4)
                 NPC[A].Frame = 4;
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount >= 4)
             {
                 NPC[A].FrameCount = 0;
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame >= 6)
                     NPC[A].Frame = 4;
             }
@@ -1324,27 +1324,27 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 87)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 20)
             NPC[A].FrameCount = 0;
         NPC[A].Frame = static_cast<int>(floor(static_cast<double>(NPC[A].FrameCount / 5)));
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 4;
+            NPC[A].Frame += 4;
         // statue fireball
     }
     else if(NPC[A].Type == 85)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 8)
             NPC[A].FrameCount = 0;
         NPC[A].Frame = static_cast<int>(floor(static_cast<double>(NPC[A].FrameCount / 2)));
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 4;
+            NPC[A].Frame += 4;
         // winged koopa
     }
     else if(NPC[A].Type == 76 || NPC[A].Type == 161)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].Direction == -1 && NPC[A].Frame >= 4)
             NPC[A].Frame = 0;
         else if(NPC[A].Direction == 1 && NPC[A].Frame < 4)
@@ -1354,13 +1354,13 @@ void NPCFrames(int A)
             NPC[A].FrameCount = 0;
             if(NPC[A].Direction == -1)
             {
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame >= 4)
                     NPC[A].Frame = 0;
             }
             else
             {
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame >= 8)
                     NPC[A].Frame = 4;
             }
@@ -1368,7 +1368,7 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 137) // SMB3 Bomb
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount < 8)
             NPC[A].Frame = 0;
         else if(NPC[A].FrameCount < 15)
@@ -1379,27 +1379,27 @@ void NPCFrames(int A)
             NPC[A].FrameCount = 0;
         }
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 6;
+            NPC[A].Frame += 6;
         if(NPC[A].Special2 == 1)
         {
-            NPC[A].Special3 = NPC[A].Special3 + 1;
+            NPC[A].Special3 += 1;
             if(NPC[A].Special3 < 4)
             {
             }
             else if(NPC[A].Special3 < 8)
-                NPC[A].Frame = NPC[A].Frame + 2;
+                NPC[A].Frame += 2;
             else if(NPC[A].Special3 < 11)
-                NPC[A].Frame = NPC[A].Frame + 4;
+                NPC[A].Frame += 4;
             else
             {
-                NPC[A].Frame = NPC[A].Frame + 4;
+                NPC[A].Frame += 4;
                 NPC[A].Special3 = 0;
             }
         }
     }
     else if(NPC[A].Type == 160) // Airship Jet
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].Direction == -1 && NPC[A].Frame >= 4)
             NPC[A].Frame = 0;
         else if(NPC[A].Direction == 1 && NPC[A].Frame < 4)
@@ -1409,13 +1409,13 @@ void NPCFrames(int A)
             NPC[A].FrameCount = 0;
             if(NPC[A].Direction == -1)
             {
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame >= 4)
                     NPC[A].Frame = 0;
             }
             else
             {
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame >= 8)
                     NPC[A].Frame = 4;
             }
@@ -1423,20 +1423,20 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 178)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 8)
         {
             NPC[A].FrameCount = 0;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Frame >= 3)
                 NPC[A].Frame = 0;
         }
     }
     else if(NPC[A].Type == 4 || NPC[A].Type == 6 || NPC[A].Type == 23 || NPC[A].Type == 36 || NPC[A].Type == 285 || NPC[A].Type == 42 || NPC[A].Type == 52 || NPC[A].Type == 72 || (NPC[A].Type >= 109 && NPC[A].Type <= 112) || (NPC[A].Type >= 121 && NPC[A].Type <= 124) || NPC[A].Type == 136 || NPC[A].Type == 159 || NPC[A].Type == 162 || NPC[A].Type == 163 || NPC[A].Type == 164 || NPC[A].Type == 165 || NPC[A].Type == 166 || NPC[A].Type == 173 || NPC[A].Type == 175 || NPC[A].Type == 176 || NPC[A].Type == 177 || NPC[A].Type == 199 || NPC[A].Type == 229 || NPC[A].Type == 236 || NPC[A].Type == 230 || NPC[A].Type == 232 || NPC[A].Type == 233) // Walking koopa troopa / hard thing / spiney
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].Type == 166 && NPC[A].Special > 360)
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
         if(NPC[A].Direction == -1 && NPC[A].Frame >= 2)
             NPC[A].Frame = 0;
         else if(NPC[A].Direction == 1 && NPC[A].Frame < 2)
@@ -1446,13 +1446,13 @@ void NPCFrames(int A)
             NPC[A].FrameCount = 0;
             if(NPC[A].Direction == -1)
             {
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame >= 2)
                     NPC[A].Frame = 0;
             }
             else
             {
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 if(NPC[A].Frame >= 4)
                     NPC[A].Frame = 2;
             }
@@ -1461,18 +1461,18 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 234)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         NPC[A].Frame = 0;
         if(NPC[A].Direction == 1)
             NPC[A].Frame = 3;
 
         if(NPC[A].FrameCount > 8)
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
 
         if(NPC[A].FrameCount > 16)
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
         if(NPC[A].FrameCount > 24)
-            NPC[A].Frame = NPC[A].Frame - 1;
+            NPC[A].Frame -= 1;
         if(NPC[A].FrameCount > 32)
             NPC[A].FrameCount = 0;
 
@@ -1481,9 +1481,9 @@ void NPCFrames(int A)
     {
         if(NPC[A].Special == 0)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].Type == 166 && NPC[A].Special > 360)
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
             if(NPC[A].Direction == -1 && NPC[A].Frame >= 2)
                 NPC[A].Frame = 0;
             else if(NPC[A].Direction == 1 && NPC[A].Frame < 2)
@@ -1493,13 +1493,13 @@ void NPCFrames(int A)
                 NPC[A].FrameCount = 0;
                 if(NPC[A].Direction == -1)
                 {
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     if(NPC[A].Frame >= 2)
                         NPC[A].Frame = 0;
                 }
                 else
                 {
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     if(NPC[A].Frame >= 4)
                         NPC[A].Frame = 2;
                 }
@@ -1512,12 +1512,12 @@ void NPCFrames(int A)
             else
                 NPC[A].Frame = 5;
             if(NPC[A].Direction == 1)
-                NPC[A].Frame = NPC[A].Frame + 2;
+                NPC[A].Frame += 2;
         }
     }
     else if(NPC[A].Type == 274) // dragon coin
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount < 6)
             NPC[A].Frame = 0;
         else if(NPC[A].FrameCount < 12)
@@ -1546,11 +1546,11 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 11) // Frame finder for Star/Flower/Mushroom Exit
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 8)
         {
             NPC[A].FrameCount = 0;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Frame == 3)
                 NPC[A].Frame = 0;
         }
@@ -1561,9 +1561,9 @@ void NPCFrames(int A)
         NPC[A].Frame = 0;
         if(NPC[A].Direction == 1)
             NPC[A].Frame = 2;
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 8)
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
         if(NPC[A].FrameCount >= 16)
             NPC[A].FrameCount = 0;
     }
@@ -1571,10 +1571,10 @@ void NPCFrames(int A)
     {
         if(NPC[A].HoldingPlayer == 0 && !Player[NPC[A].standingOnPlayer].Controls.Run && !NPC[A].Projectile)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount >= 4)
             {
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
                 NPC[A].FrameCount = 0;
             }
             if(NPC[A].Frame >= 5)
@@ -1584,10 +1584,10 @@ void NPCFrames(int A)
         {
             if(NPC[A].Direction == -1)
             {
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].FrameCount >= 4)
                 {
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     NPC[A].FrameCount = 0;
                 }
                 if(NPC[A].Frame >= 10 || NPC[A].Frame < 5)
@@ -1595,10 +1595,10 @@ void NPCFrames(int A)
             }
             else
             {
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].FrameCount >= 4)
                 {
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     NPC[A].FrameCount = 0;
                 }
                 if(NPC[A].Frame >= 15 || NPC[A].Frame < 10)
@@ -1608,11 +1608,11 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 12) // Frame finder for big fireball
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 4)
         {
             NPC[A].FrameCount = 0;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Location.SpeedY < 0)
             {
                 if(NPC[A].Frame >= 2)
@@ -1718,11 +1718,11 @@ void NPCFrames(int A)
                     NewEffect(77, NPC[A].Location, static_cast<float>(NPC[A].Special), 0, NPC[A].Shadow);
             }
         }
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 4)
         {
             NPC[A].FrameCount = 0;
-            NPC[A].Frame = NPC[A].Frame - NPC[A].Direction;
+            NPC[A].Frame += -NPC[A].Direction;
         }
         if(NPC[A].Special < 2 || (NPC[A].Type == 265 && NPC[A].Special != 5))
         {
@@ -1769,19 +1769,19 @@ void NPCFrames(int A)
             else
             {
                 if(NPC[A].FrameCount >= 0)
-                    NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                    NPC[A].FrameCount += 1;
                 else
-                    NPC[A].FrameCount = NPC[A].FrameCount - 1;
+                    NPC[A].FrameCount -= 1;
                 if(NPC[A].FrameCount >= 5 || NPC[A].FrameCount <= -5)
                 {
                     if(NPC[A].FrameCount >= 0)
                     {
-                        NPC[A].Frame = NPC[A].Frame + 1;
+                        NPC[A].Frame += 1;
                         NPC[A].FrameCount = 1;
                     }
                     else
                     {
-                        NPC[A].Frame = NPC[A].Frame - 1;
+                        NPC[A].Frame -= 1;
                         NPC[A].FrameCount = -1;
                     }
                     if(NPC[A].Frame >= 5)
@@ -1801,7 +1801,7 @@ void NPCFrames(int A)
             NPC[A].Frame = 6;
         else if(NPC[A].Special == 4)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].Frame < 7)
                 NPC[A].Frame = 7;
             if(NPC[A].FrameCount >= 8)
@@ -1837,7 +1837,7 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 135 && NPC[A].Special2 == 1)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount < 4)
             NPC[A].Frame = 8;
         else if(NPC[A].FrameCount < 8)
@@ -1850,15 +1850,15 @@ void NPCFrames(int A)
             NPC[A].FrameCount = 0;
         }
         if(NPC[A].HoldingPlayer > 0 || NPC[A].Projectile)
-            NPC[A].Frame = NPC[A].Frame + 6;
+            NPC[A].Frame += 6;
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 3;
+            NPC[A].Frame += 3;
     }
     else if(NPC[A].Type == 19 || NPC[A].Type == 20 || NPC[A].Type == 28 || (NPC[A].Type >= 129 && NPC[A].Type <= 132) || NPC[A].Type == 135 || NPC[A].Type == 158) // Shy guys / Jumping Fish
     {
         if(NPC[A].HoldingPlayer == 0 && !NPC[A].Projectile)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].Direction == -1 && NPC[A].Frame >= 2)
                 NPC[A].Frame = 0;
             else if(NPC[A].Direction == 1 && NPC[A].Frame < 2)
@@ -1868,13 +1868,13 @@ void NPCFrames(int A)
                 NPC[A].FrameCount = 0;
                 if(NPC[A].Direction == -1)
                 {
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     if(NPC[A].Frame >= 2)
                         NPC[A].Frame = 0;
                 }
                 else
                 {
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     if(NPC[A].Frame >= 4)
                         NPC[A].Frame = 2;
                 }
@@ -1884,7 +1884,7 @@ void NPCFrames(int A)
         {
             if(NPC[A].Frame < 4)
                 NPC[A].Frame = 4;
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].Direction == -1 && NPC[A].Frame >= 6)
                 NPC[A].Frame = 4;
             else if(NPC[A].Direction == 1 && NPC[A].Frame < 6)
@@ -1894,13 +1894,13 @@ void NPCFrames(int A)
                 NPC[A].FrameCount = 0;
                 if(NPC[A].Direction == -1)
                 {
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     if(NPC[A].Frame >= 6)
                         NPC[A].Frame = 4;
                 }
                 else
                 {
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     if(NPC[A].Frame >= 8)
                         NPC[A].Frame = 6;
                 }
@@ -1928,7 +1928,7 @@ void NPCFrames(int A)
         }
         else
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].Direction == -1 && NPC[A].Frame >= 6)
                 NPC[A].Frame = 4;
             else if(NPC[A].Direction == 1 && NPC[A].Frame < 6)
@@ -1938,13 +1938,13 @@ void NPCFrames(int A)
                 NPC[A].FrameCount = 0;
                 if(NPC[A].Direction == -1)
                 {
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     if(NPC[A].Frame >= 6)
                         NPC[A].Frame = 4;
                 }
                 else
                 {
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
                     if(NPC[A].Frame >= 8)
                         NPC[A].Frame = 6;
                 }
@@ -1953,11 +1953,11 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 22) // Bullet bill Gun
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 4)
         {
             NPC[A].FrameCount = 1;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Frame == 5)
                 NPC[A].Frame = 0;
         }
@@ -1966,7 +1966,7 @@ void NPCFrames(int A)
     {
         if(NPC[A].Location.SpeedX == 0)
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 4)
                 NPC[A].Frame = 0;
             else if(NPC[A].FrameCount < 7)
@@ -1979,7 +1979,7 @@ void NPCFrames(int A)
         }
         else
         {
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount < 4)
                 NPC[A].Frame = 0;
             else if(NPC[A].FrameCount < 8)
@@ -1995,7 +1995,7 @@ void NPCFrames(int A)
             }
         }
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 4;
+            NPC[A].Frame += 4;
     }
     else if(NPC[A].Type == 26) // Spring thing
     {
@@ -2004,7 +2004,7 @@ void NPCFrames(int A)
             if(NPC[A].Location.Height == 32)
             {
                 NPC[A].Location.Height = 16;
-                NPC[A].Location.Y = NPC[A].Location.Y + 16;
+                NPC[A].Location.Y += 16;
             }
             if(NPC[A].HoldingPlayer > 0)
                 NPC[A].Frame = 0;
@@ -2013,7 +2013,7 @@ void NPCFrames(int A)
                 C = 0;
                 tempLocation = NPC[A].Location;
                 tempLocation.Height = 24;
-                tempLocation.Y = tempLocation.Y - 8;
+                tempLocation.Y -= 8;
                 for(B = 1; B <= numPlayers; ++B)
                 {
                     if(CheckCollision(tempLocation, Player[B].Location) && Player[B].Mount != 2 && (Player[B].Location.SpeedY > 0 || Player[B].Location.SpeedY < Physics.PlayerJumpVelocity))
@@ -2026,7 +2026,7 @@ void NPCFrames(int A)
                 {
                     tempLocation = NPC[A].Location;
                     tempLocation.Height = 32;
-                    tempLocation.Y = tempLocation.Y - 16;
+                    tempLocation.Y -= 16;
                     for(B = 1; B <= numPlayers; ++B)
                     {
                         if(CheckCollision(tempLocation, Player[B].Location) && Player[B].Mount != 2 && (Player[B].Location.SpeedY > 0 || Player[B].Location.SpeedY < Physics.PlayerJumpVelocity))
@@ -2049,30 +2049,30 @@ void NPCFrames(int A)
         {
             if(NPC[A].Location.SpeedX != 0)
             {
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].FrameCount > 12)
                     NPC[A].FrameCount = 0;
                 else if(NPC[A].FrameCount >= 6)
-                    NPC[A].Frame = NPC[A].Frame + 1;
+                    NPC[A].Frame += 1;
             }
         }
         else if(NPC[A].Special < 0)
         {
-            NPC[A].Frame = NPC[A].Frame + 3;
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].Frame += 3;
+            NPC[A].FrameCount += 1;
             if(NPC[A].FrameCount > 8)
                 NPC[A].FrameCount = 0;
             else if(NPC[A].FrameCount >= 4)
-                NPC[A].Frame = NPC[A].Frame + 1;
+                NPC[A].Frame += 1;
         }
         else
-            NPC[A].Frame = NPC[A].Frame + 2;
+            NPC[A].Frame += 2;
     }
     else if(NPC[A].Type == 125) // Rat Head
     {
         NPC[A].Frame = NPC[A].FrameCount;
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 2;
+            NPC[A].Frame += 2;
     }
     else if(NPC[A].Type == 29) // SMB Hammer Bro
     {
@@ -2080,7 +2080,7 @@ void NPCFrames(int A)
         {
             if((NPC[A].Location.SpeedY < 1 && NPC[A].Location.SpeedY >= 0) || NPC[A].Slope > 0 || NPC[A].HoldingPlayer > 0)
             {
-                NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                NPC[A].FrameCount += 1;
                 if(NPC[A].Direction == -1 && NPC[A].Frame >= 2)
                     NPC[A].Frame = 0;
                 else if(NPC[A].Direction == 1 && NPC[A].Frame < 3)
@@ -2090,13 +2090,13 @@ void NPCFrames(int A)
                     NPC[A].FrameCount = 0;
                     if(NPC[A].Direction == -1)
                     {
-                        NPC[A].Frame = NPC[A].Frame + 1;
+                        NPC[A].Frame += 1;
                         if(NPC[A].Frame >= 2)
                             NPC[A].Frame = 0;
                     }
                     else
                     {
-                        NPC[A].Frame = NPC[A].Frame + 1;
+                        NPC[A].Frame += 1;
                         if(NPC[A].Frame >= 5)
                             NPC[A].Frame = 3;
                     }
@@ -2120,7 +2120,7 @@ void NPCFrames(int A)
     }
     else if(NPC[A].Type == 108) // Yoshi Fireball
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 8)
         {
             NPC[A].Frame = 1;
@@ -2131,7 +2131,7 @@ void NPCFrames(int A)
         else
             NPC[A].Frame = 0;
         if(NPC[A].Direction == 1)
-            NPC[A].Frame = NPC[A].Frame + 2;
+            NPC[A].Frame += 2;
     }
     else if(NPC[A].Type == 35 || NPC[A].Type == 191 || NPC[A].Type == 193) // Goombas Shoe
     {
@@ -2146,22 +2146,22 @@ void NPCFrames(int A)
         if(NPC[A].Direction == 1)
             NPC[A].Frame = 2;
         if(NPC[A].Special == 1 || NPC[A].HoldingPlayer > 0)
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
     }
     else if(NPC[A].Type == 41) // smb2 birdo exit
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 8)
         {
             NPC[A].FrameCount = 1;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Frame == 8)
                 NPC[A].Frame = 0;
         }
     }
     else if(NPC[A].Type == 97) // SMB3 Star
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].Special == 0)
         {
             if(NPC[A].FrameCount < 8)
@@ -2187,35 +2187,35 @@ void NPCFrames(int A)
     }
     else if(!(NPCIsABonus[NPC[A].Type] || NPC[A].Type == 21 || NPC[A].Type == 32)) // Frame finder for everything else
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].Type == 48 || NPC[A].Type == 206)
-            NPC[A].FrameCount = NPC[A].FrameCount + 1;
+            NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 8)
         {
             NPC[A].FrameCount = 1;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Frame == 2)
                 NPC[A].Frame = 0;
         }
     }
     else if(NPC[A].Type == 183 || NPC[A].Type == 277)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 12)
         {
             NPC[A].FrameCount = 1;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Frame == 2)
                 NPC[A].Frame = 0;
         }
     }
     else if(NPC[A].Type == 182)
     {
-        NPC[A].FrameCount = NPC[A].FrameCount + 1;
+        NPC[A].FrameCount += 1;
         if(NPC[A].FrameCount >= 4)
         {
             NPC[A].FrameCount = 1;
-            NPC[A].Frame = NPC[A].Frame + 1;
+            NPC[A].Frame += 1;
             if(NPC[A].Frame == 4)
                 NPC[A].Frame = 0;
         }

--- a/src/npc/npc_hit.cpp
+++ b/src/npc/npc_hit.cpp
@@ -188,7 +188,7 @@ void NPCHit(int A, int B, int C)
 
 
     // Safety
-    StopHit = StopHit + 1;
+    StopHit += 1;
     if(NPC[A].Killed > 0)
         return;
     if(B == 3 || B == 4)
@@ -274,9 +274,9 @@ void NPCHit(int A, int B, int C)
     else if(B == 10 && NPC[A].Type == 134 && NPC[A].CantHurt == 0 && !NPC[A].Projectile) // link picks up bombs
     {
         if(Player[C].Bombs < 9)
-            Player[C].Bombs = Player[C].Bombs + 1;
-        // .Location.X = .Location.X + .Location.Width / 2 - EffectWidth(10) / 2
-        // .Location.Y = .Location.Y + .Location.Height / 2 - EffectHeight(10) / 2
+            Player[C].Bombs += 1;
+        // .Location.X += .Location.Width / 2 - EffectWidth(10) / 2
+        // .Location.Y += .Location.Height / 2 - EffectHeight(10) / 2
         // NewEffect 10, .Location
         NPC[A].Killed = 9;
         PlaySound(SFX_ZeldaHeart);
@@ -307,7 +307,7 @@ void NPCHit(int A, int B, int C)
     {
         if(NPC[A].Type == 91)
         {
-            NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.Height;
+            NPC[A].Location.Y += -NPC[A].Location.Height;
             NPC[A].Type = NPC[A].Special;
         }
         PlaySound(SFX_ZeldaGrass);
@@ -316,7 +316,7 @@ void NPCHit(int A, int B, int C)
         {
             PlaySound(SFX_Bullet);
             NPC[A].Location.SpeedX = 5 * Player[C].Direction;
-            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height;
+            NPC[A].Location.Y += NPC[A].Location.Height;
         }
         NPC[A].Direction = Player[C].Direction;
         NPC[A].Generator = false;
@@ -336,7 +336,7 @@ void NPCHit(int A, int B, int C)
         }
         NPC[A].Location.Height = NPCHeight[NPC[A].Type];
         NPC[A].Location.Width = NPCWidth[NPC[A].Type];
-        NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.Height;
+        NPC[A].Location.Y += -NPC[A].Location.Height;
         NPC[A].Location.SpeedX = (3 + dRand() * 1) * Player[C].Direction;
         if(NPC[A].Type == 17)
             NPC[A].Location.SpeedX = 5 * Player[C].Direction;
@@ -353,12 +353,12 @@ void NPCHit(int A, int B, int C)
                 NPC[A].Type = 252;
             if(dRand() * 40 < 3)
                 NPC[A].Type = 253;
-            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0;
-            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height;
+            NPC[A].Location.X += NPC[A].Location.Width / 2.0;
+            NPC[A].Location.Y += NPC[A].Location.Height;
             NPC[A].Location.Width = NPCWidth[NPC[A].Type];
             NPC[A].Location.Height = NPCHeight[NPC[A].Type];
-            NPC[A].Location.X = NPC[A].Location.X - NPC[A].Location.Width / 2.0;
-            NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.Height;
+            NPC[A].Location.X += -NPC[A].Location.Width / 2.0;
+            NPC[A].Location.Y += -NPC[A].Location.Height;
         }
         if(NPCIsAShell[NPC[A].Type])
             NPC[A].Location.SpeedX = Physics.NPCShellSpeed * Player[C].Direction;
@@ -396,7 +396,7 @@ void NPCHit(int A, int B, int C)
         {
             if(NPC[C].Type == 13 || NPC[C].Type == 108)
             {
-                NPC[A].Damage = NPC[A].Damage + 1;
+                NPC[A].Damage += 1;
                 PlaySound(SFX_ShellHit);
             }
             else
@@ -424,16 +424,16 @@ void NPCHit(int A, int B, int C)
             NPC[A].Special4 = 0;
             NPC[A].Special5 = 0;
             NPC[A].Special6 = 0;
-            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0;
-            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height;
+            NPC[A].Location.X += NPC[A].Location.Width / 2.0;
+            NPC[A].Location.Y += NPC[A].Location.Height;
             if(NPC[A].Type == 267)
                 NPC[A].Type = 268;
             else
                 NPC[A].Type = 281;
             NPC[A].Location.Width = NPCWidth[NPC[A].Type];
             NPC[A].Location.Height = NPCHeight[NPC[A].Type];
-            NPC[A].Location.X = NPC[A].Location.X - NPC[A].Location.Width / 2.0;
-            NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.Height;
+            NPC[A].Location.X += -NPC[A].Location.Width / 2.0;
+            NPC[A].Location.Y += -NPC[A].Location.Height;
             NPC[A].Location.SpeedX = 0;
             NPC[A].Location.SpeedY = 0;
             oldNPC = NPC[A];
@@ -451,9 +451,9 @@ void NPCHit(int A, int B, int C)
             {
 
                 if(Player[C].Location.X + Player[C].Location.Width / 2.0 < NPC[A].Location.X + NPC[A].Location.Width / 2.0)
-                    Player[C].Location.SpeedX = Player[C].Location.SpeedX - 3;
+                    Player[C].Location.SpeedX -= 3;
                 else
-                    Player[C].Location.SpeedX = Player[C].Location.SpeedX + 3;
+                    Player[C].Location.SpeedX += 3;
 
             }
             PlaySound(SFX_Stomp);
@@ -462,20 +462,20 @@ void NPCHit(int A, int B, int C)
         {
             if(NPC[C].Type == 13 || NPC[C].Type == 108)
             {
-                NPC[A].Damage = NPC[A].Damage + 1;
+                NPC[A].Damage += 1;
                 PlaySound(SFX_ShellHit);
             }
             else
             {
                 NPCHit(C, 3, B);
                 NPC[A].Special = 5;
-                NPC[A].Damage = NPC[A].Damage + 5;
+                NPC[A].Damage += 5;
                 PlaySound(SFX_BirdoHit);
             }
         }
         else if(B == 10)
         {
-            NPC[A].Damage = NPC[A].Damage + 2;
+            NPC[A].Damage += 2;
             PlaySound(SFX_ZeldaHit);
         }
         else if(B == 6)
@@ -507,10 +507,10 @@ void NPCHit(int A, int B, int C)
         {
             if(NPC[A].Type == 162)
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height;
+                NPC[A].Location.Y += NPC[A].Location.Height;
                 NPC[A].Location.Height = 32;
                 NPC[A].Type = 163;
-                NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.Height;
+                NPC[A].Location.Y += -NPC[A].Location.Height;
                 PlaySound(SFX_Stomp);
             }
             else if(NPC[A].Type != 234)
@@ -574,7 +574,7 @@ void NPCHit(int A, int B, int C)
                         NPC[A].Immune = 20;
                     NPC[A].Special = 1;
                     PlaySound(SFX_SMBossHit);
-                    NPC[A].Damage = NPC[A].Damage + 1;
+                    NPC[A].Damage += 1;
                     if(NPC[A].Damage >= 10)
                         NPC[A].Killed = 3;
                 }
@@ -602,12 +602,12 @@ void NPCHit(int A, int B, int C)
                     NPC[A].Immune = 60;
                 else
                     NPC[A].Immune = 20;
-                NPC[A].Damage = NPC[A].Damage + 3;
+                NPC[A].Damage += 3;
             }
         }
         else if(B == 10)
         {
-            NPC[A].Damage = NPC[A].Damage + 3;
+            NPC[A].Damage += 3;
             NPC[A].Immune = 10;
         }
         if(NPC[A].Damage >= 15)
@@ -641,9 +641,9 @@ void NPCHit(int A, int B, int C)
         if(B == 3)
         {
             if(NPC[C].Type == 13)
-                NPC[A].Damage = NPC[A].Damage + 1;
+                NPC[A].Damage += 1;
             else
-                NPC[A].Damage = NPC[A].Damage + 3;
+                NPC[A].Damage += 3;
             if(NPC[A].Damage >= 3)
                 NPC[A].Killed = B;
             else
@@ -651,7 +651,7 @@ void NPCHit(int A, int B, int C)
         }
         else if(B == 8)
         {
-            NPC[A].Damage = NPC[A].Damage + 1;
+            NPC[A].Damage += 1;
             if(NPC[A].Damage >= 3)
                 NPC[A].Killed = B;
             else
@@ -672,11 +672,11 @@ void NPCHit(int A, int B, int C)
         {
             if(NPC[C].Type != 13)
             {
-                NPC[A].Damage = NPC[A].Damage + 5;
+                NPC[A].Damage += 5;
                 NPC[A].Immune = 60;
             }
             else
-                NPC[A].Damage = NPC[A].Damage + 1;
+                NPC[A].Damage += 1;
         }
         else if(B == 6)
         {
@@ -685,7 +685,7 @@ void NPCHit(int A, int B, int C)
         }
         else if(B == 10)
         {
-            NPC[A].Damage = NPC[A].Damage + 2;
+            NPC[A].Damage += 2;
             NPC[A].Immune = 20;
         }
         if(NPC[A].Damage >= 20)
@@ -716,7 +716,7 @@ void NPCHit(int A, int B, int C)
                 if(NPC[A].Special == 1)
                 {
                     PlaySound(SFX_BirdoHit);
-                    NPC[A].Damage = NPC[A].Damage + 5;
+                    NPC[A].Damage += 5;
                     NPC[A].Immune = 20;
                     NPC[C].Killed = 9;
                 }
@@ -726,13 +726,13 @@ void NPCHit(int A, int B, int C)
                 if(NPC[C].Type != 13)
                 {
                     PlaySound(SFX_BirdoHit);
-                    NPC[A].Damage = NPC[A].Damage + 5;
+                    NPC[A].Damage += 5;
                     NPC[A].Immune = 20;
                 }
                 else
                 {
                     PlaySound(SFX_ShellHit);
-                    NPC[A].Damage = NPC[A].Damage + 1;
+                    NPC[A].Damage += 1;
                 }
             }
         }
@@ -744,7 +744,7 @@ void NPCHit(int A, int B, int C)
         else if(B == 10)
         {
             PlaySound(SFX_BirdoHit);
-            NPC[A].Damage = NPC[A].Damage + 5;
+            NPC[A].Damage += 5;
             NPC[A].Immune = 20;
         }
         // King Koopa
@@ -760,19 +760,19 @@ void NPCHit(int A, int B, int C)
             if(NPC[C].Type != 13)
             {
                 PlaySound(SFX_BirdoHit);
-                NPC[A].Damage = NPC[A].Damage + 3;
+                NPC[A].Damage += 3;
             }
             else
             {
                 PlaySound(SFX_ShellHit);
-                NPC[A].Damage = NPC[A].Damage + 1;
+                NPC[A].Damage += 1;
             }
         }
         else if(B == 10)
         {
             PlaySound(SFX_BirdoHit);
             NPC[A].Immune = 20;
-            NPC[A].Damage = NPC[A].Damage + 1;
+            NPC[A].Damage += 1;
         }
         else if(B == 6)
             NPC[A].Killed = B;
@@ -810,7 +810,7 @@ void NPCHit(int A, int B, int C)
         {
             if(B == 3 && NPC[C].Type == 45)
                 NPCHit(C, 3, C);
-            NPC[A].Damage = NPC[A].Damage + 1;
+            NPC[A].Damage += 1;
             NPC[A].Immune = 30;
             if(NPC[A].Damage >= 3)
                 NPC[A].Killed = B;
@@ -1216,8 +1216,8 @@ void NPCHit(int A, int B, int C)
                 {
                     NPC[A].Killed = B;
                     NewEffect(75, NPC[A].Location);
-                    Effect[numEffects].Location.X = Effect[numEffects].Location.X + NPC[A].Location.SpeedX;
-                    Effect[numEffects].Location.Y = Effect[numEffects].Location.Y + NPC[A].Location.SpeedY;
+                    Effect[numEffects].Location.X += NPC[A].Location.SpeedX;
+                    Effect[numEffects].Location.Y += NPC[A].Location.SpeedY;
                 }
             }
             else if(B == 3)
@@ -1236,7 +1236,7 @@ void NPCHit(int A, int B, int C)
     {
         if(B == 2)
         {
-            NPC[A].Location.Y = NPC[A].Location.Y - 1;
+            NPC[A].Location.Y -= 1;
             NPC[A].Location.SpeedY = -1;
         }
         // Things With Shells (Koopa Troopa, Buzzy Beetle, Etc.)
@@ -1276,7 +1276,7 @@ void NPCHit(int A, int B, int C)
                 NPC[A].Type = 24;
             else if(NPC[A].Type >= 121 && NPC[A].Type <= 124) // smw winged koopas
             {
-                NPC[A].Type = NPC[A].Type - 12;
+                NPC[A].Type -= 12;
                 NPC[A].Special = 0;
             }
             else
@@ -1290,7 +1290,7 @@ void NPCHit(int A, int B, int C)
                 NPC[numNPCs].Direction = Player[C].Direction;
                 NPC[numNPCs].Location.SpeedY = 0;
                 NPC[numNPCs].Location.SpeedX = double(Physics.NPCShellSpeed * NPC[numNPCs].Direction);
-                NPC[numNPCs].Location.X = NPC[numNPCs].Location.X - 16.0 + NPC[numNPCs].Location.SpeedX;
+                NPC[numNPCs].Location.X += -16.0 + NPC[numNPCs].Location.SpeedX;
                 CheckSectionNPC(numNPCs);
                 NPC[numNPCs].CantHurtPlayer = C;
                 NPC[numNPCs].CantHurt = 6;
@@ -1301,7 +1301,7 @@ void NPCHit(int A, int B, int C)
             NPC[A].Location.Height = NPCHeight[NPC[A].Type];
             NPC[A].Location.Width = NPCWidth[NPC[A].Type];
             NPC[A].Location.Y -= NPC[A].Location.Height;
-            NPC[A].Location.X = NPC[A].Location.X - (NPC[A].Location.Width / 2.0) - double(NPC[A].Direction * 2.f);
+            NPC[A].Location.X += -(NPC[A].Location.Width / 2.0) - double(NPC[A].Direction * 2.f);
             NPC[A].Location.SpeedX = 0;
             NPC[A].Location.SpeedY = 0;
             NPC[A].RealSpeedX = 0;
@@ -1315,8 +1315,8 @@ void NPCHit(int A, int B, int C)
         {
             PlaySound(SFX_ShellHit);
             NPC[A].Projectile = true;
-            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height;
-            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0;
+            NPC[A].Location.Y += NPC[A].Location.Height;
+            NPC[A].Location.X += NPC[A].Location.Width / 2.0;
             if(NPC[A].Type == 4 || NPC[A].Type == 76)
                 NPC[A].Type = 5;
             else if(NPC[A].Type == 6 || NPC[A].Type == 161)
@@ -1349,11 +1349,11 @@ void NPCHit(int A, int B, int C)
                 NPC[A].Type = 24;
             else if(NPC[A].Type >= 121 && NPC[A].Type <= 124)
             {
-                NPC[A].Type = NPC[A].Type - 12;
+                NPC[A].Type -= 12;
                 NPC[A].Special = 0;
             }
             else
-                NPC[A].Type = NPC[A].Type + 4;
+                NPC[A].Type += 4;
             if(B == 7 && NPC[A].Type >= 113 && NPC[A].Type <= 117)
             {
                 numNPCs++;
@@ -1365,7 +1365,7 @@ void NPCHit(int A, int B, int C)
                 NPC[numNPCs].Direction = Player[C].Direction;
                 NPC[numNPCs].Location.SpeedY = 0;
                 NPC[numNPCs].Location.SpeedX = double(Physics.NPCShellSpeed * NPC[numNPCs].Direction);
-                NPC[numNPCs].Location.X = NPC[numNPCs].Location.X - (16.0 + double(32.0f * NPC[numNPCs].Direction));
+                NPC[numNPCs].Location.X += -(16.0 + double(32.0f * NPC[numNPCs].Direction));
                 CheckSectionNPC(numNPCs);
                 NPC[numNPCs].CantHurtPlayer = C;
                 NPC[numNPCs].CantHurt = 6;
@@ -1375,7 +1375,7 @@ void NPCHit(int A, int B, int C)
             NPC[A].Location.Height = NPCHeight[NPC[A].Type];
             NPC[A].Location.Width = NPCWidth[NPC[A].Type];
             NPC[A].Location.Y -= NPC[A].Location.Height;
-            NPC[A].Location.X = NPC[A].Location.X - (NPC[A].Location.Width / 2.0) - double(NPC[A].Direction * 2.f);
+            NPC[A].Location.X += -(NPC[A].Location.Width / 2.0) - double(NPC[A].Direction * 2.f);
             NPC[A].Location.SpeedX = 0;
             NPC[A].Special = 0;
             NPC[A].Frame = 0;
@@ -1427,12 +1427,12 @@ void NPCHit(int A, int B, int C)
                 if(NPC[C].Type != 13)
                 {
                     PlaySound(SFX_BirdoHit);
-                    NPC[A].Damage = NPC[A].Damage + 10;
+                    NPC[A].Damage += 10;
                 }
                 else
                 {
                     PlaySound(SFX_ShellHit);
-                    NPC[A].Damage = NPC[A].Damage + 1;
+                    NPC[A].Damage += 1;
                 }
             }
         }
@@ -1442,7 +1442,7 @@ void NPCHit(int A, int B, int C)
         {
             NPC[A].Immune = 10;
             PlaySound(SFX_BirdoHit);
-            NPC[A].Damage = NPC[A].Damage + 10;
+            NPC[A].Damage += 10;
         }
         if(NPC[A].Damage >= 200)
         {
@@ -1565,7 +1565,7 @@ void NPCHit(int A, int B, int C)
             {
                 PlaySound(SFX_ShellHit);
                 NPC[A].Location.SpeedX = Physics.NPCShellSpeed * -NPC[A].Direction;
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.SpeedX;
+                NPC[A].Location.X += NPC[A].Location.SpeedX;
                 NPC[A].CantHurt = Physics.NPCCanHurtWait;
                 NPC[A].CantHurtPlayer = C;
                 NPC[A].Projectile = true;
@@ -1587,14 +1587,14 @@ void NPCHit(int A, int B, int C)
                     if(NPC[C].Type == 13)
                     {
                         PlaySound(SFX_BirdoHit);
-                        NPC[A].Damage = NPC[A].Damage + 1;
+                        NPC[A].Damage += 1;
                         NPC[A].Special3 = 10;
                         if(NPC[A].Special2 == 2)
                             NPC[A].Special = 50;
                     }
                     else
                     {
-                        NPC[A].Damage = NPC[A].Damage + 3;
+                        NPC[A].Damage += 3;
                         PlaySound(SFX_BirdoHit);
                         NPC[A].Special3 = 30;
                         if(NPC[A].Special2 == 2)
@@ -1603,7 +1603,7 @@ void NPCHit(int A, int B, int C)
                 }
                 else if(B == 10)
                 {
-                    NPC[A].Damage = NPC[A].Damage + 2;
+                    NPC[A].Damage += 2;
                     PlaySound(SFX_BirdoHit);
                     NPC[A].Special3 = 10;
                     if(NPC[A].Special2 == 2)
@@ -1765,7 +1765,7 @@ void NPCHit(int A, int B, int C)
                 if(NPC[C].Type != 13)
                 {
                     NPC[A].Special = -30;
-                    NPC[A].Damage = NPC[A].Damage + 1;
+                    NPC[A].Damage += 1;
                     NPC[A].Direction = -NPC[A].Direction;
                     PlaySound(SFX_BirdoHit);
                 }
@@ -1775,7 +1775,7 @@ void NPCHit(int A, int B, int C)
             else if(B == 10)
             {
                 NPC[A].Special = -30;
-                NPC[A].Damage = NPC[A].Damage + 1;
+                NPC[A].Damage += 1;
                 NPC[A].Direction = -NPC[A].Direction;
                 PlaySound(SFX_BirdoHit);
             }
@@ -1865,7 +1865,7 @@ void NPCHit(int A, int B, int C)
                 else
                 {
                     if(NPC[A].Type == 26)
-                        NPC[A].Location.Y = NPC[A].Location.Y - 16;
+                        NPC[A].Location.Y -= 16;
                     NewEffect(10, NPC[A].Location);
                     if(NPC[A].NoLavaSplash == false)
                         NewEffect(13, NPC[A].Location);
@@ -2003,7 +2003,7 @@ void NPCHit(int A, int B, int C)
             }
             else
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height;
+                NPC[A].Location.Y += NPC[A].Location.Height;
                 // useless self-assignment code [PVS-Studio]
                 //NPC[A].Location.X = NPC[A].Location.X; // - (32 - .Location.Width) / 2
                 NPC[A].Location.Height = 0;
@@ -2012,18 +2012,18 @@ void NPCHit(int A, int B, int C)
             }
             NPC[A].Killed = 9;
             if(NPC[A].Type == 252 || NPC[A].Type == 258)
-                Coins = Coins + 5;
+                Coins += 5;
             else if(NPC[A].Type == 253)
-                Coins = Coins + 20;
+                Coins += 20;
             else
-                Coins = Coins + 1;
+                Coins += 1;
             if(Coins >= 100)
             {
                 if(Lives < 99)
                 {
-                    Lives = Lives + 1;
+                    Lives += 1;
                     PlaySound(SFX_1up);
-                    Coins = Coins - 100;
+                    Coins -= 100;
                 }
                 else
                     Coins = 99;

--- a/src/npc/npc_kill.cpp
+++ b/src/npc/npc_kill.cpp
@@ -249,9 +249,9 @@ void KillNPC(int A, int B)
             else if(B == 6)
             {
                 PlaySound(SFX_Lava);
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - 16;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - 16;
                 NPC[A].Location.Width = 32;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - 32;
+                NPC[A].Location.Y += NPC[A].Location.Height - 32;
                 NPC[A].Location.Height = 32;
                 NewEffect(10, NPC[A].Location);
                 if(NPC[A].NoLavaSplash == false)
@@ -259,9 +259,9 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - 16;
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - 16;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10, NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -392,8 +392,8 @@ void KillNPC(int A, int B)
             if(B == 6)
             {
                 PlaySound(SFX_Lava);
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - EffectHeight[10];
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height - EffectHeight[10];
                 NPC[A].Location.Width = 32;
                 NPC[A].Location.Height = 32;
                 NewEffect(10, NPC[A].Location);
@@ -402,8 +402,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -420,9 +420,9 @@ void KillNPC(int A, int B)
         }
         else if(NPCIsVeggie[NPC[A].Type])
         {
-            NPC[A].Location.Y = NPC[A].Location.Y - (32 - NPC[A].Location.Height);
-            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+            NPC[A].Location.Y += -(32 - NPC[A].Location.Height);
+            NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+            NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
             NPC[A].Location.Height = 32;
             NPC[A].Location.Width = 32;
             if(NPC[A].Killed == 6)
@@ -437,7 +437,7 @@ void KillNPC(int A, int B)
         {
             if(B == 1)
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + 2;
+                NPC[A].Location.Y += 2;
                 NewEffect(81 , NPC[A].Location);
             }
             else if(B == 2)
@@ -450,7 +450,7 @@ void KillNPC(int A, int B)
         {
             if(B == 1)
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + 2;
+                NPC[A].Location.Y += 2;
                 NewEffect(123 , NPC[A].Location);
             }
             else if(B == 2)
@@ -463,7 +463,7 @@ void KillNPC(int A, int B)
         {
             if(B == 1)
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + 2;
+                NPC[A].Location.Y += 2;
                 NewEffect(124 , NPC[A].Location);
             }
             else if(B == 2)
@@ -474,8 +474,8 @@ void KillNPC(int A, int B)
         }
         else if((NPC[A].Type == 84 || NPC[A].Type == 181) && B == 6) // lava only
         {
-            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - 32;
+            NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+            NPC[A].Location.Y += NPC[A].Location.Height - 32;
             NPC[A].Location.Height = 32;
             NPC[A].Location.Width = 32;
             PlaySound(SFX_Lava);
@@ -495,8 +495,8 @@ void KillNPC(int A, int B)
                 {
                     NPC[A].Location.Width = 64;
                     NPC[A].Location.Height = 64;
-                    NPC[A].Location.X = NPC[A].Location.X - 8;
-                    NPC[A].Location.Y = NPC[A].Location.Y - 8;
+                    NPC[A].Location.X -= 8;
+                    NPC[A].Location.Y -= 8;
                     NewEffect(99 , NPC[A].Location);
                 }
                 else if(NPC[A].Type == 180)
@@ -504,8 +504,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 6)
             {
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - 32;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height - 32;
                 NPC[A].Location.Height = 32;
                 NPC[A].Location.Width = 32;
                 PlaySound(SFX_Lava);
@@ -519,8 +519,8 @@ void KillNPC(int A, int B)
                 NPC[A].Location.SpeedY = -10;
                 NPC[A].Location.Width = 64;
                 NPC[A].Location.Height = 64;
-                NPC[A].Location.X = NPC[A].Location.X - 8;
-                NPC[A].Location.Y = NPC[A].Location.Y - 8;
+                NPC[A].Location.X -= 8;
+                NPC[A].Location.Y -= 8;
                 NewEffect(99 , NPC[A].Location);
             }
         }
@@ -535,8 +535,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -560,8 +560,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -597,8 +597,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -632,9 +632,9 @@ void KillNPC(int A, int B)
             if(B == 6)
             {
                 PlaySound(SFX_Lava);
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + 24;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                NPC[A].Location.Y += 24;
                 NPC[A].Location.Width = 32;
                 NPC[A].Location.Height = 32;
                 NewEffect(10 , NPC[A].Location);
@@ -659,9 +659,9 @@ void KillNPC(int A, int B)
             if(B == 6)
             {
                 PlaySound(SFX_Lava);
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + 24;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                NPC[A].Location.Y += 24;
                 NPC[A].Location.Width = 32;
                 NPC[A].Location.Height = 32;
                 NewEffect(10 , NPC[A].Location);
@@ -670,8 +670,8 @@ void KillNPC(int A, int B)
             }
             else
             {
-                // .Location.Width = .Location.Width + 2
-                // .Location.X = .Location.X - 1
+                // .Location.Width += 2
+                // .Location.X += -1
                 NewEffect(105, NPC[A].Location, NPC[A].Direction);
             }
             PlaySound(SFX_BowserKilled);
@@ -681,9 +681,9 @@ void KillNPC(int A, int B)
             if(B == 6)
             {
                 PlaySound(SFX_Lava);
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + 24;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                NPC[A].Location.Y += 24;
                 NPC[A].Location.Width = 32;
                 NPC[A].Location.Height = 32;
                 NewEffect(10 , NPC[A].Location);
@@ -692,8 +692,8 @@ void KillNPC(int A, int B)
             }
             else
             {
-                NPC[A].Location.Width = NPC[A].Location.Width + 2;
-                NPC[A].Location.X = NPC[A].Location.X - 1;
+                NPC[A].Location.Width += 2;
+                NPC[A].Location.X -= 1;
                 NewEffect(50, NPC[A].Location, NPC[A].Direction);
             }
             PlaySound(SFX_BowserKilled);
@@ -728,8 +728,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -745,7 +745,7 @@ void KillNPC(int A, int B)
             {
                 if(B == 6)
                 {
-                    NPC[A].Location.Y = NPC[A].Location.Y + (NPC[A].Location.Height - 32);
+                    NPC[A].Location.Y += (NPC[A].Location.Height - 32);
                     PlaySound(SFX_Lava);
                     NewEffect(10 , NPC[A].Location);
                     if(NPC[A].NoLavaSplash == false)
@@ -766,19 +766,19 @@ void KillNPC(int A, int B)
                 NPC[A].Special = RandomBonus();
             NewEffect(56, NPC[A].Location, 1, static_cast<int>(floor(static_cast<double>(NPC[A].Special))));
             if(C == 98)
-                Effect[numEffects].Frame = Effect[numEffects].Frame + 3;
+                Effect[numEffects].Frame += 3;
             else if(C == 99)
-                Effect[numEffects].Frame = Effect[numEffects].Frame + 5;
+                Effect[numEffects].Frame += 5;
             else if(C == 100)
-                Effect[numEffects].Frame = Effect[numEffects].Frame + 7;
+                Effect[numEffects].Frame += 7;
             else if(C == 148)
-                Effect[numEffects].Frame = Effect[numEffects].Frame + 9;
+                Effect[numEffects].Frame += 9;
             else if(C == 149)
-                Effect[numEffects].Frame = Effect[numEffects].Frame + 11;
+                Effect[numEffects].Frame += 11;
             else if(C == 150)
-                Effect[numEffects].Frame = Effect[numEffects].Frame + 13;
+                Effect[numEffects].Frame += 13;
             else if(C == 228)
-                Effect[numEffects].Frame = Effect[numEffects].Frame + 15;
+                Effect[numEffects].Frame += 15;
         }
         else if(NPC[A].Type == 71) // giagnormous goomba
         {
@@ -786,8 +786,8 @@ void KillNPC(int A, int B)
                 NewEffect(45 , NPC[A].Location);
             else if(B == 6)
             {
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - 32;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height - 32;
                 NPC[A].Location.Height = 32;
                 NPC[A].Location.Width = 32;
                 PlaySound(SFX_Lava);
@@ -797,8 +797,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -821,8 +821,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -847,8 +847,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -863,11 +863,11 @@ void KillNPC(int A, int B)
         else if(NPC[A].Type == 189) // Dry Bones
         {
             NPC[A].Location.Width = 48;
-            NPC[A].Location.X = NPC[A].Location.X - 8;
+            NPC[A].Location.X -= 8;
             if(B == 6)
             {
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - 32;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height - 32;
                 NPC[A].Location.Height = 32;
                 NPC[A].Location.Width = 32;
                 PlaySound(SFX_Lava);
@@ -897,8 +897,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -910,13 +910,13 @@ void KillNPC(int A, int B)
                 NewEffect(61, NPC[A].Location, NPC[A].Direction);
                 Effect[numEffects].Frame = (NPC[A].Type - 117) * 4;
                 if(NPC[A].Direction == 1)
-                    Effect[numEffects].Frame = Effect[numEffects].Frame + 2;
+                    Effect[numEffects].Frame += 2;
             }
         }
         else if(NPC[A].Type == 4 || NPC[A].Type == 5 || NPC[A].Type == 76) // Green Koopa
         {
-             NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[8] / 2.0;
-             NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[8] / 2.0;
+             NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[8] / 2.0;
+             NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[8] / 2.0;
             if(B == 6)
             {
                 PlaySound(SFX_Lava);
@@ -926,8 +926,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -941,8 +941,8 @@ void KillNPC(int A, int B)
         {
             if(B == 6)
             {
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[8] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[8] / 2.0;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[8] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[8] / 2.0;
                 PlaySound(SFX_Lava);
                 NewEffect(10 , NPC[A].Location);
                 if(NPC[A].NoLavaSplash == false)
@@ -950,8 +950,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -963,8 +963,8 @@ void KillNPC(int A, int B)
         }
         else if(NPC[A].Type == 172 || NPC[A].Type == 173 || NPC[A].Type == 176) // smb1 Green Koopa
         {
-             NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[8] / 2.0;
-             NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[8] / 2.0;
+             NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[8] / 2.0;
+             NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[8] / 2.0;
             if(B == 6)
             {
                 PlaySound(SFX_Lava);
@@ -974,8 +974,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -987,8 +987,8 @@ void KillNPC(int A, int B)
         }
         else if(NPC[A].Type == 174 || NPC[A].Type == 175 || NPC[A].Type == 177) // smb1 red Koopa
         {
-             NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[8] / 2.0;
-             NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[8] / 2.0;
+             NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[8] / 2.0;
+             NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[8] / 2.0;
             if(B == 6)
             {
                 PlaySound(SFX_Lava);
@@ -998,8 +998,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -1025,12 +1025,12 @@ void KillNPC(int A, int B)
         }
         else if(NPC[A].Type == 72 || NPC[A].Type == 73) // giant Green Koopa
         {
-             NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[8] / 2.0;
-             NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[8] / 2.0;
+             NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[8] / 2.0;
+             NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[8] / 2.0;
             if(B == 6)
             {
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height - 32;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height - 32;
                 NPC[A].Location.Height = 32;
                 NPC[A].Location.Width = 32;
                 PlaySound(SFX_Lava);
@@ -1040,8 +1040,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -1092,8 +1092,8 @@ void KillNPC(int A, int B)
                     }
                 }
             }
-             NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.Height / 2.0 + 32;
-             NPC[A].Location.X = NPC[A].Location.X - NPC[A].Location.Width / 2.0 + 20;
+             NPC[A].Location.Y += -NPC[A].Location.Height / 2.0 + 32;
+             NPC[A].Location.X += -NPC[A].Location.Width / 2.0 + 20;
              NewEffect(29, NPC[A].Location, NPC[A].Direction);
         }
         else if(NPC[A].Type == 40) // Egg
@@ -1104,8 +1104,8 @@ void KillNPC(int A, int B)
         }
         else if(NPC[A].Type == 6 || NPC[A].Type == 7 || NPC[A].Type == 161) // Red Koopa
         {
-             NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[9] / 2.0;
-             NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[9] / 2.0;
+             NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[9] / 2.0;
+             NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[9] / 2.0;
             if(B == 6)
             {
                 PlaySound(SFX_Lava);
@@ -1115,8 +1115,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -1155,8 +1155,8 @@ void KillNPC(int A, int B)
         }
         else if(NPC[A].Type == 23 || NPC[A].Type == 24 || NPC[A].Type == 36 || NPC[A].Type == 53 || NPC[A].Type == 54 || NPC[A].Type == 285 || NPC[A].Type == 286) // Hard thing / Spiney
         {
-             NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[9] / 2.0;
-             NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[9] / 2.0;
+             NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[9] / 2.0;
+             NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[9] / 2.0;
             if(B == 6)
             {
                 PlaySound(SFX_Lava);
@@ -1166,8 +1166,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -1196,7 +1196,7 @@ void KillNPC(int A, int B)
         }
         else if(NPC[A].Type == 256 || NPC[A].Type == 257)
         {
-            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+            NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
             tempLocation = NPC[A].Location;
             if(NPC[A].Type == 257)
             {
@@ -1226,8 +1226,8 @@ void KillNPC(int A, int B)
         }
         else if(NPC[A].Type == 8 || NPC[A].Type == 275 || NPC[A].Type == 93 || NPC[A].Type == 12 || NPC[A].Type == 51 || NPC[A].Type == 52 || NPC[A].Type == 74 || NPC[A].Type == 37 || NPC[A].Type == 38 || NPC[A].Type == 42 || NPC[A].Type == 43 || NPC[A].Type == 44 || NPC[A].Type == 245 || NPC[A].Type == 270) // Piranha Plant / Fireball
         {
-            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+            NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+            NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
             NewEffect(10 , NPC[A].Location);
             if(B == 8)
                 PlaySound(SFX_Smash);
@@ -1238,12 +1238,12 @@ void KillNPC(int A, int B)
         {
             if(B == 6)
             {
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[9] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[9] / 2.0;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[9] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[9] / 2.0;
                 NPC[A].Location.Width = 32;
                 PlaySound(SFX_Lava);
                 NewEffect(10, NPC[A].Location, 1, 0, NPC[A].Shadow);
-                NPC[A].Location.X = NPC[A].Location.X + 2;
+                NPC[A].Location.X += 2;
                 if(NPC[A].NoLavaSplash == false)
                     NewEffect(13 , NPC[A].Location);
             }
@@ -1258,8 +1258,8 @@ void KillNPC(int A, int B)
                     Effect[numEffects].Location.SpeedX = dRand() * 3 - 1.5 + NPC[A].Location.SpeedX * 0.1;
                     Effect[numEffects].Location.SpeedY = dRand() * 3 - 1.5 - NPC[A].Location.SpeedY * 0.1;
                 }
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 if((NPC[A].Type == 13 && NPC[A].Special == 5) || NPC[A].Type == 108)
                     NewEffect(10, NPC[A].Location, 1, 0, NPC[A].Shadow);
                 else
@@ -1268,7 +1268,7 @@ void KillNPC(int A, int B)
         }
         else if(NPC[A].Type == 15) // Big Koopa
         {
-            NPC[A].Location.Y = NPC[A].Location.Y - (NPCHeight[NPC[A].Type] - NPC[A].Location.Height);
+            NPC[A].Location.Y += -(NPCHeight[NPC[A].Type] - NPC[A].Location.Height);
             NPC[A].Location.Height = NPCHeight[NPC[A].Type];
             if(NPC[A].Legacy == true)
             {
@@ -1313,8 +1313,8 @@ void KillNPC(int A, int B)
                 NPC[A].Location.SpeedY = -9;
             if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -1332,7 +1332,7 @@ void KillNPC(int A, int B)
         {
             if(B == 6)
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + (NPC[A].Location.Height - 32);
+                NPC[A].Location.Y += (NPC[A].Location.Height - 32);
                 PlaySound(SFX_Lava);
                 NewEffect(10 , NPC[A].Location);
                 if(NPC[A].NoLavaSplash == false)
@@ -1340,8 +1340,8 @@ void KillNPC(int A, int B)
             }
             else if(B == 8)
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }
@@ -1437,7 +1437,7 @@ void KillNPC(int A, int B)
                         NewEffect(145 , NPC[A].Location);
                     else
                     {
-                        NPC[A].Location.Y = NPC[A].Location.Y - 14;
+                        NPC[A].Location.Y -= 14;
                         NewEffect(32 , NPC[A].Location);
                     }
                 }
@@ -1466,15 +1466,15 @@ void KillNPC(int A, int B)
             {
                 if(!NPCIsACoin[NPC[A].Type] || LevelEditor || TestLevel) // Shell hit sound
                     PlaySound(SFX_ShellHit);
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
             }
             else if(B == 6)
             {
                 PlaySound(SFX_Lava);
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 if(NPC[A].NoLavaSplash == false)
                     NewEffect(13 , NPC[A].Location);
@@ -1484,8 +1484,8 @@ void KillNPC(int A, int B)
         {
             if(!(NPC[A].Type == 32 && B == 1))
             {
-                 NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                 NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                 NPC[A].Location.X += NPC[A].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                 NPC[A].Location.Y += NPC[A].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                 NewEffect(10 , NPC[A].Location);
                 PlaySound(SFX_Smash);
             }

--- a/src/npc/npc_update.cpp
+++ b/src/npc/npc_update.cpp
@@ -125,7 +125,7 @@ void UpdateNPCs()
         }
         if(PSwitchTime > 2)
             PSwitchTime = 2;
-        PSwitchStop = PSwitchStop - 1;
+        PSwitchStop -= 1;
         if(PSwitchStop <= 0)
         {
             FreezeNPCs = false;
@@ -143,15 +143,15 @@ void UpdateNPCs()
             {
                 if(NPC[A].CantHurt > 0)
                 {
-                    NPC[A].CantHurt = NPC[A].CantHurt - 1;
+                    NPC[A].CantHurt -= 1;
                     if(NPC[A].CantHurt == 0)
                         NPC[A].CantHurtPlayer = 0;
                 }
             }
             if(NPC[A].TimeLeft > 0)
-                NPC[A].TimeLeft = NPC[A].TimeLeft - 1;
+                NPC[A].TimeLeft -= 1;
             if(NPC[A].Immune > 0)
-                NPC[A].Immune = NPC[A].Immune - 1;
+                NPC[A].Immune -= 1;
             NPC[A].JustActivated = 0;
             NPC[A].Chat = false;
             if(NPC[A].TimeLeft == 0)
@@ -166,9 +166,9 @@ void UpdateNPCs()
                 {
                     NPC[A].Location.SpeedX = dRand() * 2 - 1;
                     if(NPC[A].Location.SpeedX < 0)
-                        NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.5;
+                        NPC[A].Location.SpeedX -= 0.5;
                     else
-                        NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.5;
+                        NPC[A].Location.SpeedX += 0.5;
                 }
                 KillNPC(A, NPC[A].Killed);
             }
@@ -185,14 +185,14 @@ void UpdateNPCs()
         else
         {
             PlaySound(SFX_Coin);
-            Coins = Coins + 1;
+            Coins += 1;
             if(Coins >= 100)
             {
                 if(Lives < 99)
                 {
-                    Lives = Lives + 1;
+                    Lives += 1;
                     PlaySound(SFX_1up);
-                    Coins = Coins - 100;
+                    Coins -= 100;
                 }
                 else
                     Coins = 99;
@@ -208,14 +208,14 @@ void UpdateNPCs()
         {
             NPC[A].Reset[1] = false;
             NPC[A].Reset[2] = false;
-            NPC[A].RespawnDelay = NPC[A].RespawnDelay - 1;
+            NPC[A].RespawnDelay -= 1;
         }
 
         if(NPC[A].Hidden == true)
             Deactivate(A);
 
         if(NPC[A].TailCD > 0)
-            NPC[A].TailCD = NPC[A].TailCD - 1;
+            NPC[A].TailCD -= 1;
 
         if(A > maxNPCs - 100)
             NPC[A].Killed = 9;
@@ -227,7 +227,7 @@ void UpdateNPCs()
             if(NPC[A].Hidden == false)
             {
                 NPC[A].TimeLeft = 0;
-                NPC[A].GeneratorTime = NPC[A].GeneratorTime + 1;
+                NPC[A].GeneratorTime += 1;
 
                 if(NPC[A].GeneratorTime >= NPC[A].GeneratorTimeMax * 6.5f)
                     NPC[A].GeneratorTime = NPC[A].GeneratorTimeMax * 6.5f;
@@ -315,13 +315,13 @@ void UpdateNPCs()
                                 }
                                 else if(NPC[A].GeneratorDirection == 2)
                                 {
-                                    NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y - 4;
+                                    NPC[numNPCs].Location.Y -= 4;
                                     NPC[numNPCs].Location.X = NPC[A].Location.X + NPC[A].Location.Width;
                                     NPC[numNPCs].Effect2 = NPC[numNPCs].Location.X;
                                 }
                                 else if(NPC[A].GeneratorDirection == 4)
                                 {
-                                    NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y - 4;
+                                    NPC[numNPCs].Location.Y -= 4;
                                     NPC[numNPCs].Location.X = NPC[A].Location.X - NPC[A].Location.Width;
                                     NPC[numNPCs].Effect2 = NPC[numNPCs].Location.X + NPC[A].Location.Width;
                                 }
@@ -463,17 +463,17 @@ void UpdateNPCs()
                        NPCIsACoin[NPC[newAct[C]].Type] == false)
                     {
                         tempLocation = NPC[newAct[C]].Location;
-                        tempLocation.Y = tempLocation.Y - 32;
-                        tempLocation.X = tempLocation.X - 32;
-                        tempLocation.Width = tempLocation.Width + 64;
-                        tempLocation.Height = tempLocation.Height + 64;
+                        tempLocation.Y -= 32;
+                        tempLocation.X -= 32;
+                        tempLocation.Width += 64;
+                        tempLocation.Height += 64;
                         for(B = 1; B <= numNPCs; B++)
                         {
                             if((NPC[B].Active == false) && B != A && NPC[B].Reset[1] == true && NPC[B].Reset[2] == true)
                             {
                                 if(CheckCollision(tempLocation, NPC[B].Location) == true)
                                 {
-                                    numAct = numAct + 1;
+                                    numAct += 1;
                                     SDL_assert_release(numAct <= maxNPCs);
                                     newAct[numAct] = B;
                                     NPC[B].Active = true;
@@ -557,7 +557,7 @@ void UpdateNPCs()
                     NPC[A].Special2 = 0;
                 else
                 {
-                    NPC[A].Special2 = NPC[A].Special2 + 1;
+                    NPC[A].Special2 += 1;
                     if(NPC[A].Special2 >= 450)
                     {
                         NewEffect(10, NPC[A].Location);
@@ -577,7 +577,7 @@ void UpdateNPCs()
                     NPC[A].Type == 69 || NPC[A].Type == 70
                 )
                 {
-                    numBlock = numBlock + 1;
+                    numBlock += 1;
                     Block[numBlock] = blankBlock;
                     Block[numBlock].Type = 0;
                     Block[numBlock].Location = NPC[A].Location;
@@ -593,10 +593,10 @@ void UpdateNPCs()
                         Block[numBlock].noProjClipping = true;
                     if(NPC[A].Type == 26 && Block[numBlock].Location.Height != 32)
                     {
-                        Block[numBlock].Location.Y = Block[numBlock].Location.Y - 16;
-                        Block[numBlock].Location.Height = Block[numBlock].Location.Height + 16;
+                        Block[numBlock].Location.Y -= 16;
+                        Block[numBlock].Location.Height += 16;
                     }
-                    Block[numBlock].Location.SpeedX = Block[numBlock].Location.SpeedX + NPC[A].BeltSpeed;
+                    Block[numBlock].Location.SpeedX += NPC[A].BeltSpeed;
                     Block[numBlock].IsNPC = NPC[A].Type;
                     numTempBlock++;
                     NPC[A].tempBlock = numBlock;
@@ -608,7 +608,7 @@ void UpdateNPCs()
     {
         if(Player[A].Mount == 2)
         {
-            numBlock = numBlock + 1;
+            numBlock += 1;
             Block[numBlock] = blankBlock;
             Block[numBlock].Type = 25;
             Block[numBlock].Location = Player[A].Location;
@@ -616,7 +616,7 @@ void UpdateNPCs()
             Block[numBlock].Location.Y = static_cast<int>(floor(static_cast<double>(Block[numBlock].Location.Y))) + 1;
             Block[numBlock].Location.Width = static_cast<int>(floor(static_cast<double>(Block[numBlock].Location.Width))) + 1;
             Block[numBlock].IsPlayer = A;
-            numTempBlock = numTempBlock + 1;
+            numTempBlock += 1;
         }
     }
     if(numTempBlock > 1)
@@ -642,7 +642,7 @@ void UpdateNPCs()
         if(NPC[A].Projectile == false || NPC[A].Type == 50 || NPC[A].Type == 78)
             NPC[A].Multiplier = 0;
         if(NPC[A].Immune > 0)
-            NPC[A].Immune = NPC[A].Immune - 1;
+            NPC[A].Immune -= 1;
         if(NPC[A].Type == 56 && NPC[A].TimeLeft > 1)
             NPC[A].TimeLeft = 100;
         if(NPC[A].JustActivated != 0)
@@ -770,10 +770,10 @@ void UpdateNPCs()
             else
             {
                 if(NPC[A].Wet > 0)
-                    NPC[A].Wet = NPC[A].Wet - 1;
+                    NPC[A].Wet -= 1;
 
                 if(NPC[A].Quicksand > 0)
-                    NPC[A].Quicksand = NPC[A].Quicksand - 1;
+                    NPC[A].Quicksand -= 1;
 
                 if(UnderWater[NPC[A].Section])
                     NPC[A].Wet = 2;
@@ -858,7 +858,7 @@ void UpdateNPCs()
             }
             else if(!(NPC[A].Type != 190 && NPCIsCheep[NPC[A].Type] == false))
             {
-                NPC[A].WallDeath = NPC[A].WallDeath + 2;
+                NPC[A].WallDeath += 2;
 
                 if(NPC[A].WallDeath >= 10)
                     NPC[A].WallDeath = 10;
@@ -866,7 +866,7 @@ void UpdateNPCs()
 
             if(NPC[A].Quicksand > 0 && NPCNoClipping[NPC[A].Type] == false)
             {
-                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 1;
+                NPC[A].Location.SpeedY += 1;
 
                 if(NPC[A].Location.SpeedY < -1)
                     NPC[A].Location.SpeedY = -1;
@@ -885,21 +885,21 @@ void UpdateNPCs()
                 NPC[A].Type = 139 + B;
                 if(NPC[A].Type == 147)
                     NPC[A].Type = 92;
-                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0;
+                NPC[A].Location.X += NPC[A].Location.Width / 2.0;
+                NPC[A].Location.Y += NPC[A].Location.Height / 2.0;
                 NPC[A].Location.Width = NPCWidth[NPC[A].Type];
                 NPC[A].Location.Height = NPCHeight[NPC[A].Type];
-                NPC[A].Location.X = NPC[A].Location.X - NPC[A].Location.Width / 2.0;
-                NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.Height / 2.0;
+                NPC[A].Location.X += -NPC[A].Location.Width / 2.0;
+                NPC[A].Location.Y += -NPC[A].Location.Height / 2.0;
             }
             if(NPC[A].Text != "")
             {
                 NPC[A].Chat = false;
                 tempLocation = NPC[A].Location;
-                tempLocation.Y = tempLocation.Y - 25;
-                tempLocation.Height = tempLocation.Height + 50;
-                tempLocation.X = tempLocation.X - 25;
-                tempLocation.Width = tempLocation.Width + 50;
+                tempLocation.Y -= 25;
+                tempLocation.Height += 50;
+                tempLocation.X -= 25;
+                tempLocation.Width += 50;
                 for(B = 1; B <= numPlayers; B++)
                 {
                     if(CheckCollision(tempLocation, Player[B].Location) == true)
@@ -952,7 +952,7 @@ void UpdateNPCs()
                 NPC[A].TurnBackWipe = true;
             if(NPC[A].TimeLeft < 1)
                 Deactivate(A);
-            NPC[A].TimeLeft = NPC[A].TimeLeft - 1;
+            NPC[A].TimeLeft -= 1;
             if(NPC[A].Effect == 0)
             {
 
@@ -1016,25 +1016,25 @@ void UpdateNPCs()
                                 NPC[A].Type = 139 + B;
                                 if(NPC[A].Type == 147)
                                     NPC[A].Type = 92;
-                                NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0;
-                                NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0;
+                                NPC[A].Location.X += NPC[A].Location.Width / 2.0;
+                                NPC[A].Location.Y += NPC[A].Location.Height / 2.0;
                                 NPC[A].Location.Width = NPCWidth[NPC[A].Type];
                                 NPC[A].Location.Height = NPCHeight[NPC[A].Type];
-                                NPC[A].Location.X = NPC[A].Location.X - NPC[A].Location.Width / 2.0;
-                                NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.Height / 2.0;
+                                NPC[A].Location.X += -NPC[A].Location.Width / 2.0;
+                                NPC[A].Location.Y += -NPC[A].Location.Height / 2.0;
                             }
                         }
                         if(NPC[A].Type == 45)
                             NPC[A].Special = 1;
                         if(NPC[A].Type == 133)
                         {
-                            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.Width / 2.0;
-                            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height / 2.0;
+                            NPC[A].Location.X += NPC[A].Location.Width / 2.0;
+                            NPC[A].Location.Y += NPC[A].Location.Height / 2.0;
                             NPC[A].Type = 138;
                             NPC[A].Location.Height = NPCHeight[NPC[A].Type];
                             NPC[A].Location.Width = NPCWidth[NPC[A].Type];
-                            NPC[A].Location.X = NPC[A].Location.X - NPC[A].Location.Width / 2.0;
-                            NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.Height / 2.0;
+                            NPC[A].Location.X += -NPC[A].Location.Width / 2.0;
+                            NPC[A].Location.Y += -NPC[A].Location.Height / 2.0;
                         }
                         NPC[A].TimeLeft = 100;
                         NPC[A].BeltSpeed = 0;
@@ -1158,7 +1158,7 @@ void UpdateNPCs()
                     if(NPC[A].CantHurt > 0)
                     {
                         if(!(NPC[A].Type == 21))
-                            NPC[A].CantHurt = NPC[A].CantHurt - 1;
+                            NPC[A].CantHurt -= 1;
                     }
                     else
                         NPC[A].CantHurtPlayer = 0;
@@ -1171,7 +1171,7 @@ void UpdateNPCs()
                         NPC[A].BattleOwner = 0;
                     if(NPCIsAShell[NPC[A].Type])
                     {
-                        NPC[A].Special4 = NPC[A].Special4 - 1;
+                        NPC[A].Special4 -= 1;
                         if(NPC[A].Special4 < 0)
                             NPC[A].Special4 = 0;
                     }
@@ -1182,13 +1182,13 @@ void UpdateNPCs()
                             if(Player[NPC[A].Special5].Location.X + Player[NPC[A].Special5].Location.Width / 2.0 < NPC[A].Location.X + NPC[A].Location.Width / 2.0)
                             {
                                 if(NPC[A].Special2 < 0)
-                                    NPC[A].Special3 = NPC[A].Special3 + 30;
+                                    NPC[A].Special3 += 30;
                                 NPC[A].Special2 = -1;
                             }
                             else
                             {
                                 if(NPC[A].Special2 > 0)
-                                    NPC[A].Special3 = NPC[A].Special3 + 30;
+                                    NPC[A].Special3 += 30;
                                 NPC[A].Special2 = 1;
                             }
 
@@ -1247,15 +1247,15 @@ void UpdateNPCs()
                             }
                             if(NPC[A].Location.SpeedX > Physics.NPCWalkingOnSpeed)
                             {
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.05;
+                                NPC[A].Location.SpeedX -= 0.05;
                                 if(NPC[A].Projectile == false)
-                                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.1;
+                                    NPC[A].Location.SpeedX -= 0.1;
                             }
                             else if(NPC[A].Location.SpeedX < -Physics.NPCWalkingOnSpeed)
                             {
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.05;
+                                NPC[A].Location.SpeedX += 0.05;
                                 if(NPC[A].Projectile == false)
-                                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.1;
+                                    NPC[A].Location.SpeedX += 0.1;
                             }
                         }
                         else if(NPC[A].Type == 125)
@@ -1266,9 +1266,9 @@ void UpdateNPCs()
                                     NPC[A].Location.SpeedX = 2 * NPC[A].Direction;
                             }
                             if(NPC[A].Location.SpeedX > 2)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.05;
+                                NPC[A].Location.SpeedX -= 0.05;
                             else if(NPC[A].Location.SpeedX < -2)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.05;
+                                NPC[A].Location.SpeedX += 0.05;
                         }
                         else if(!(NPC[A].Type >= 117 && NPC[A].Type <= 120 && NPC[A].Projectile == true))
                         {
@@ -1278,9 +1278,9 @@ void UpdateNPCs()
                                     NPC[A].Location.SpeedX = Physics.NPCWalkingSpeed * NPC[A].Direction;
                             }
                             if(NPC[A].Location.SpeedX > Physics.NPCWalkingSpeed)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.05;
+                                NPC[A].Location.SpeedX -= 0.05;
                             else if(NPC[A].Location.SpeedX < -Physics.NPCWalkingSpeed)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.05;
+                                NPC[A].Location.SpeedX += 0.05;
                         }
                     }
                     else if(NPC[A].Type == 203)
@@ -1313,17 +1313,17 @@ void UpdateNPCs()
                             NPC[A].Type == 264 || NPC[A].Type == 288 || NPC[A].Type == 275)
                     {
                         if(NPC[A].Location.SpeedX > 0)
-                            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.05;
+                            NPC[A].Location.SpeedX -= 0.05;
                         else if(NPC[A].Location.SpeedX < 0)
-                            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.05;
+                            NPC[A].Location.SpeedX += 0.05;
                         if(NPC[A].Location.SpeedX >= -0.05 && NPC[A].Location.SpeedX <= 0.05)
                             NPC[A].Location.SpeedX = 0;
                         if(NPC[A].Location.SpeedY >= -Physics.NPCGravity && NPC[A].Location.SpeedY <= Physics.NPCGravity)
                         {
                             if(NPC[A].Location.SpeedX > 0)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.3;
+                                NPC[A].Location.SpeedX -= 0.3;
                             else if(NPC[A].Location.SpeedX < 0)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.3;
+                                NPC[A].Location.SpeedX += 0.3;
                             if(NPC[A].Location.SpeedX >= -0.3 && NPC[A].Location.SpeedX <= 0.3)
                                 NPC[A].Location.SpeedX = 0;
                         }
@@ -1370,9 +1370,9 @@ void UpdateNPCs()
                                 NPC[A].Location.SpeedX = Physics.NPCMushroomSpeed * NPC[A].Direction;
                         }
                         if(NPC[A].Location.SpeedX > Physics.NPCMushroomSpeed)
-                            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.05;
+                            NPC[A].Location.SpeedX -= 0.05;
                         else if(NPC[A].Location.SpeedX < -Physics.NPCMushroomSpeed)
-                            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.05;
+                            NPC[A].Location.SpeedX += 0.05;
                     }
                     else if(NPC[A].Type == 194)
                     {
@@ -1393,7 +1393,7 @@ void UpdateNPCs()
                                 }
                             }
                         }
-                        NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.1 * double(NPC[A].Direction);
+                        NPC[A].Location.SpeedX += 0.1 * double(NPC[A].Direction);
                         if(NPC[A].Location.SpeedX < -4)
                             NPC[A].Location.SpeedX = -4;
                         if(NPC[A].Location.SpeedX > 4)
@@ -1427,7 +1427,7 @@ void UpdateNPCs()
                                 }
                             }
 
-                            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.05 * double(NPC[A].Direction);
+                            NPC[A].Location.SpeedX += 0.05 * double(NPC[A].Direction);
                             if(NPC[A].Location.SpeedX >= 3)
                                 NPC[A].Location.SpeedX = 3;
                             if(NPC[A].Location.SpeedX <= -3)
@@ -1436,9 +1436,9 @@ void UpdateNPCs()
                         else
                         {
                             if(NPC[A].Location.SpeedX > 0.1)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.075;
+                                NPC[A].Location.SpeedX -= 0.075;
                             else if(NPC[A].Location.SpeedX < -0.1)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.075;
+                                NPC[A].Location.SpeedX += 0.075;
                             if(NPC[A].Location.SpeedX >= -0.1 && NPC[A].Location.SpeedX <= 0.1)
                                 NPC[A].Special2 = 0;
                         }
@@ -1459,24 +1459,24 @@ void UpdateNPCs()
                         if(NPC[A].Special == 0 || NPC[A].Special == 3)
                         {
                             if(NPC[A].Location.SpeedX < 3.5 && NPC[A].Location.SpeedX > -3.5)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + (0.1 * NPC[A].Direction);
+                                NPC[A].Location.SpeedX += (0.1 * NPC[A].Direction);
                             if(NPC[A].Location.SpeedX > 3.5)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.05;
+                                NPC[A].Location.SpeedX -= 0.05;
                             else if(NPC[A].Location.SpeedX < -3.5)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.05;
+                                NPC[A].Location.SpeedX += 0.05;
                             if(NPC[A].Special == 3)
                                 NPC[A].Location.SpeedY = -6;
                         }
                         else if(NPC[A].Special == 2)
-                            NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + (0.2 * NPC[A].Direction);
+                            NPC[A].Location.SpeedX += (0.2 * NPC[A].Direction);
                         else if(NPC[A].Special == 3)
                             NPC[A].Location.SpeedY = -6;
                         else
                         {
                             if(NPC[A].Location.SpeedX > 0)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.05;
+                                NPC[A].Location.SpeedX -= 0.05;
                             else if(NPC[A].Location.SpeedX < 0)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.05;
+                                NPC[A].Location.SpeedX += 0.05;
                             if(NPC[A].Location.SpeedX > -0.5 && NPC[A].Location.SpeedX < 0.5)
                                 NPC[A].Location.SpeedX = 0.0001 * NPC[A].Direction;
                         }
@@ -1507,9 +1507,9 @@ void UpdateNPCs()
                                 }
                             }
                             if(NPC[A].Direction == 1 && NPC[A].Location.SpeedX < 4)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.04;
+                                NPC[A].Location.SpeedX += 0.04;
                             if(NPC[A].Direction == -1 && NPC[A].Location.SpeedX > -4)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.04;
+                                NPC[A].Location.SpeedX -= 0.04;
                         }
                     }
                     else if(NPC[A].Type == 17 || NPC[A].Type == 18)
@@ -1567,7 +1567,7 @@ void UpdateNPCs()
                                 if(NPC[A].Wet == 0)
                                 {
                                     if(NPC[A].Special5 >= 0)
-                                        NPC[A].Special2 = NPC[A].Special2 - 1;
+                                        NPC[A].Special2 -= 1;
                                 }
                                 else
                                 {
@@ -1602,31 +1602,31 @@ void UpdateNPCs()
                         {
                             NPC[A].CantHurt = 100;
                             if(NPC[A].Special < 2)
-                                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity * 1.5;
+                                NPC[A].Location.SpeedY += Physics.NPCGravity * 1.5;
                             else if(NPC[A].Special == 3)
                             {
                                 // peach fireball changes
-                                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity * 0.9;
+                                NPC[A].Location.SpeedY += Physics.NPCGravity * 0.9;
                                 if(NPC[A].Location.SpeedX > 3)
-                                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.04;
+                                    NPC[A].Location.SpeedX -= 0.04;
                                 else if(NPC[A].Location.SpeedX < -3)
-                                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.04;
+                                    NPC[A].Location.SpeedX += 0.04;
                             }
                             else if(NPC[A].Special == 4)
                             {
 
                                 // toad fireball changes
-                                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity * 1.3;
+                                NPC[A].Location.SpeedY += Physics.NPCGravity * 1.3;
                                 if(NPC[A].Location.SpeedX < 8 && NPC[A].Location.SpeedX > 0)
-                                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.03;
+                                    NPC[A].Location.SpeedX += 0.03;
                                 else if(NPC[A].Location.SpeedX > -8 && NPC[A].Location.SpeedX < 0)
-                                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.03;
+                                    NPC[A].Location.SpeedX -= 0.03;
                             }
                             else if(NPC[A].Special == 5) // link fireballs float
                             {
                             }
                             else
-                                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity * 1.3;
+                                NPC[A].Location.SpeedY += Physics.NPCGravity * 1.3;
 
                         }
                         else if(NPC[A].Type == 17 || NPC[A].Type == 18)
@@ -1644,7 +1644,7 @@ void UpdateNPCs()
                             else
                             {
                                 // If .Location.SpeedY < 2 + (.Location.Y - .DefaultLocation.Y) * 0.02 Then
-                                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity * 0.4;
+                                NPC[A].Location.SpeedY += Physics.NPCGravity * 0.4;
                                 // End If
                             }
                         }
@@ -1655,7 +1655,7 @@ void UpdateNPCs()
                                 if(NPCIsCheep[NPC[A].Type] && NPC[A].Special == 4 && NPC[A].Projectile == false)
                                     NPC[A].Location.SpeedX = 0;
                                 if(NPC[A].Wet == 2 && (NPC[A].Type == 190))
-                                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - Physics.NPCGravity * 0.5;
+                                    NPC[A].Location.SpeedY += -Physics.NPCGravity * 0.5;
                                 else if(NPC[A].Wet == 2 && NPCIsCheep[NPC[A].Type] && NPC[A].Special != 2 && NPC[A].Projectile == false) // Fish cheep
                                 {
                                     if((NPC[A].Location.X < NPC[A].DefaultLocation.X - 100 && NPC[A].Direction == -1) || (NPC[A].Location.X > NPC[A].DefaultLocation.X + 100 && NPC[A].Direction == 1))
@@ -1682,15 +1682,15 @@ void UpdateNPCs()
                                         else if(NPC[A].Location.Y < NPC[A].DefaultLocation.Y - 25)
                                             NPC[A].Special4 = 0;
                                         if(NPC[A].Special4 == 0)
-                                            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.05;
+                                            NPC[A].Location.SpeedY += 0.05;
                                         else
-                                            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.05;
+                                            NPC[A].Location.SpeedY -= 0.05;
                                     }
                                     else
                                     {
                                         if(NPC[A].Special4 == 0)
                                         {
-                                            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.025;
+                                            NPC[A].Location.SpeedY -= 0.025;
                                             if(NPC[A].Location.SpeedY <= -1)
                                                 NPC[A].Special4 = 1;
                                             if(NPC[A].Special == 3 && NPC[A].Location.SpeedY <= -0.5)
@@ -1698,7 +1698,7 @@ void UpdateNPCs()
                                         }
                                         else
                                         {
-                                            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.025;
+                                            NPC[A].Location.SpeedY += 0.025;
                                             if(NPC[A].Location.SpeedY >= 1)
                                                 NPC[A].Special4 = 0;
                                             if(NPC[A].Special == 3 && NPC[A].Location.SpeedY >= 0.5)
@@ -1707,27 +1707,27 @@ void UpdateNPCs()
                                     }
                                 }
                                 else if(NPCIsCheep[NPC[A].Type] && NPC[A].Special == 1 && NPC[A].Special5 == 1)
-                                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity * 0.6;
+                                    NPC[A].Location.SpeedY += Physics.NPCGravity * 0.6;
                                 else if(NPC[A].Type == 278 || NPC[A].Type == 278)
                                 {
-                                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity * 0.75;
+                                    NPC[A].Location.SpeedY += Physics.NPCGravity * 0.75;
                                     if(NPC[A].Location.SpeedY > Physics.NPCGravity * 15)
                                         NPC[A].Location.SpeedY = Physics.NPCGravity * 15;
                                 }
                                 else if(NPC[A].Type != 259 && NPC[A].Type != 260)
-                                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity;
+                                    NPC[A].Location.SpeedY += Physics.NPCGravity;
                             }
                         }
 
 
                         if(NPC[A].Type == 291)
                         {
-                            NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + Physics.NPCGravity * 0.8;
+                            NPC[A].Location.SpeedY += Physics.NPCGravity * 0.8;
                             // If .Location.SpeedY >= 5 Then .Location.SpeedY = 5
                             if(NPC[A].Location.SpeedX < -0.005)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.02;
+                                NPC[A].Location.SpeedX += 0.02;
                             else if(NPC[A].Location.SpeedX > 0.005)
-                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.02;
+                                NPC[A].Location.SpeedX -= 0.02;
                             else
                                 NPC[A].Location.SpeedX = 0;
 
@@ -1891,8 +1891,8 @@ void UpdateNPCs()
                     {
                         if(!NPCIsAParaTroopa[NPC[A].Type] && !(NPC[A].Type == 91))
                         {
-                            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.SpeedX * speedVar;
-                            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.SpeedY;
+                            NPC[A].Location.X += NPC[A].Location.SpeedX * speedVar;
+                            NPC[A].Location.Y += NPC[A].Location.SpeedY;
                         }
                     }
                     else
@@ -1900,8 +1900,8 @@ void UpdateNPCs()
                         if(!(NPC[A].Location.X == NPC[A].DefaultLocation.X && NPC[A].Location.Y == NPC[A].DefaultLocation.Y) || NPC[A].Type == 14)
                         {
                             NPC[A].Location.SpeedX = NPC[A].Location.SpeedX * 0.99;
-                            NPC[A].Location.X = NPC[A].Location.X + NPC[A].Location.SpeedX;
-                            NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.SpeedY;
+                            NPC[A].Location.X += NPC[A].Location.SpeedX;
+                            NPC[A].Location.Y += NPC[A].Location.SpeedY;
                             if(NPC[A].Projectile == false)
                                 NPC[A].Location.SpeedX = 0;
                         }
@@ -1936,15 +1936,15 @@ void UpdateNPCs()
                         NPC[A].Location.Height = 24;
 
                     if(NPC[A].Pinched1 > 0)
-                        NPC[A].Pinched1 = NPC[A].Pinched1 - 1;
+                        NPC[A].Pinched1 -= 1;
                     if(NPC[A].Pinched2 > 0)
-                        NPC[A].Pinched2 = NPC[A].Pinched2 - 1;
+                        NPC[A].Pinched2 -= 1;
                     if(NPC[A].Pinched3 > 0)
-                        NPC[A].Pinched3 = NPC[A].Pinched3 - 1;
+                        NPC[A].Pinched3 -= 1;
                     if(NPC[A].Pinched4 > 0)
-                        NPC[A].Pinched4 = NPC[A].Pinched4 - 1;
+                        NPC[A].Pinched4 -= 1;
                     if(NPC[A].MovingPinched > 0)
-                        NPC[A].MovingPinched = NPC[A].MovingPinched - 1;
+                        NPC[A].MovingPinched -= 1;
 
                     newY = 0;
                     UNUSED(newY);
@@ -2313,7 +2313,7 @@ void UpdateNPCs()
                                                                     NPC[A].Location.Y = Block[B].Location.Y + Block[B].Location.Height - (Block[B].Location.Height * Slope);
                                                                     if(NPC[A].Type == 205 || NPC[A].Type == 206 || NPC[A].Type == 207)
                                                                     {
-                                                                        NPC[A].Location.Y = NPC[A].Location.Y + 1;
+                                                                        NPC[A].Location.Y += 1;
                                                                         tempBlockHit[1] = 0;
                                                                         tempBlockHit[2] = 0;
                                                                     }
@@ -2321,7 +2321,7 @@ void UpdateNPCs()
                                                                         NPC[A].Location.SpeedY = -0.01 + Block[B].Location.SpeedY;
 
                                                                     if(NPCIsAParaTroopa[NPC[A].Type] == true)
-                                                                        NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 2;
+                                                                        NPC[A].Location.SpeedY += 2;
 
                                                                 }
                                                             }
@@ -2461,7 +2461,7 @@ void UpdateNPCs()
                                                                     NPC[Block[B].IsReally].Special = 1;
                                                                     NPC[A].Special = 10;
                                                                     Player[numPlayers + 1].Direction = NPC[A].Direction;
-                                                                    NPC[A].Location.X = NPC[A].Location.X - NPC[A].Direction;
+                                                                    NPC[A].Location.X += -NPC[A].Direction;
                                                                     NPCHit(Block[B].IsReally, 1, numPlayers + 1);
                                                                     HitSpot = 0;
                                                                 }
@@ -2486,7 +2486,7 @@ void UpdateNPCs()
                                                             {
                                                                 NPCHit(Block[B].IsReally, 3, Block[B].IsReally);
                                                                 NPC[Block[B].IsReally].Location.SpeedX = -NPC[A].Location.SpeedX;
-                                                                NPC[A].Multiplier = NPC[A].Multiplier + 1;
+                                                                NPC[A].Multiplier += 1;
                                                             }
                                                             NPCHit(A, 3, A);
                                                         }
@@ -2572,7 +2572,7 @@ void UpdateNPCs()
                                                                 {
                                                                     if(HitSpot > 1)
                                                                         HitSpot = 0;
-                                                                    NPC[A].Damage = NPC[A].Damage + 10000;
+                                                                    NPC[A].Damage += 10000;
                                                                     NPC[A].Immune = 0;
                                                                     NPC[0].Multiplier = 0;
                                                                     NPCHit(A, 3, 0);
@@ -2682,9 +2682,9 @@ void UpdateNPCs()
                                                                 if(Block[B].IsPlayer == 0)
                                                                 {
                                                                     if(Block[B].IsNPC > 0)
-                                                                        NPC[A].BeltSpeed = NPC[A].BeltSpeed + float(Block[B].Location.SpeedX * C) * NPCSpeedvar[Block[B].IsNPC];
+                                                                        NPC[A].BeltSpeed += float(Block[B].Location.SpeedX * C) * NPCSpeedvar[Block[B].IsNPC];
                                                                     else
-                                                                        NPC[A].BeltSpeed = NPC[A].BeltSpeed + float(Block[B].Location.SpeedX * C);
+                                                                        NPC[A].BeltSpeed += float(Block[B].Location.SpeedX * C);
                                                                     beltCount += static_cast<float>(C);
                                                                 }
                                                             }
@@ -2738,7 +2738,7 @@ void UpdateNPCs()
                                                                         tempHit = 0;
                                                                         tempHitOld = 0;
                                                                         if(Block[B].Slippy == false)
-                                                                            NPC[A].Special5 = NPC[A].Special5 + 1;
+                                                                            NPC[A].Special5 += 1;
                                                                         if(NPC[A].Special5 >= 3)
                                                                             NPCHit(A, 3, A);
                                                                     }
@@ -2842,7 +2842,7 @@ void UpdateNPCs()
                                                                 if(!(NPC[A].Type == 13 || NPC[A].Type == 78 || NPC[A].Type == 17))
                                                                     NPC[A].TurnAround = true;
                                                                 if(NPCIsAParaTroopa[NPC[A].Type] == true)
-                                                                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - Block[B].Location.SpeedX * 1.2;
+                                                                    NPC[A].Location.SpeedX += -Block[B].Location.SpeedX * 1.2;
                                                                 if(NPCIsAShell[NPC[A].Type] == true)
                                                                     NPC[A].Location.SpeedX = -NPC[A].Location.SpeedX;
                                                                 addBelt = NPC[A].Location.X - addBelt;
@@ -2874,7 +2874,7 @@ void UpdateNPCs()
                                                             if(!(NPC[A].Type == 13 || NPC[A].Type == 78 || NPC[A].Type == 17))
                                                                 NPC[A].TurnAround = true;
                                                             if(NPCIsAParaTroopa[NPC[A].Type] == true)
-                                                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - Block[B].Location.SpeedX * 1.2;
+                                                                NPC[A].Location.SpeedX += -Block[B].Location.SpeedX * 1.2;
                                                             if(NPCIsAShell[NPC[A].Type] == true)
                                                                 NPC[A].Location.SpeedX = -NPC[A].Location.SpeedX;
                                                             addBelt = NPC[A].Location.X - addBelt;
@@ -3077,9 +3077,9 @@ void UpdateNPCs()
                                 NPC[A].BeltSpeed = oldBeltSpeed - NPC[A].oldAddBelt;
                                 beltCount = 1;
                                 if(NPC[A].BeltSpeed >= 2.1)
-                                    NPC[A].BeltSpeed = NPC[A].BeltSpeed - 0.1;
+                                    NPC[A].BeltSpeed -= 0.1;
                                 else if(NPC[A].BeltSpeed <= -2.1)
-                                    NPC[A].BeltSpeed = NPC[A].BeltSpeed + 0.1;
+                                    NPC[A].BeltSpeed += 0.1;
                             }
                         }
 
@@ -3088,11 +3088,11 @@ void UpdateNPCs()
                             preBeltLoc = NPC[A].Location;
                             NPC[A].BeltSpeed = NPC[A].BeltSpeed / beltCount;
                             NPC[A].BeltSpeed = NPC[A].BeltSpeed * speedVar;
-                            NPC[A].Location.X = NPC[A].Location.X + double(NPC[A].BeltSpeed);
+                            NPC[A].Location.X += double(NPC[A].BeltSpeed);
 //                            D = NPC[A].BeltSpeed; // Idk why this is needed as this value gets been overriden and never re-used
                             tempLocation = NPC[A].Location;
-                            tempLocation.Y = tempLocation.Y + 1;
-                            tempLocation.Height = tempLocation.Height - 2;
+                            tempLocation.Y += 1;
+                            tempLocation.Height -= 2;
                             tempLocation.Width = tempLocation.Width / 2;
 
                             if(NPC[A].BeltSpeed > 0)
@@ -3107,8 +3107,8 @@ void UpdateNPCs()
                                         if(NPC[C].Killed == 0 && NPC[C].standingOnPlayer == 0 && NPC[C].HoldingPlayer == 0 && NPCNoClipping[NPC[C].Type] == false && NPC[C].Effect == 0 && NPC[C].Inert == false) // And Not NPCIsABlock(NPC(C).Type) Then
                                         {
                                             tempLocation2 = preBeltLoc;
-                                            tempLocation2.Width = tempLocation2.Width - 4;
-                                            tempLocation2.X = tempLocation2.X + 2;
+                                            tempLocation2.Width -= 4;
+                                            tempLocation2.X += 2;
                                             if(CheckCollision(tempLocation, NPC[C].Location))
                                             {
                                                 if(!CheckCollision(tempLocation2, NPC[C].Location))
@@ -3138,7 +3138,7 @@ void UpdateNPCs()
                             }
                         }
                         if(NPC[A].onWall == false)
-                            NPC[A].BeltSpeed = NPC[A].BeltSpeed + addBelt;
+                            NPC[A].BeltSpeed += addBelt;
                         NPC[A].oldAddBelt = addBelt;
                         if(beltClear == true)
                             NPC[A].BeltSpeed = 0;
@@ -3226,7 +3226,7 @@ void UpdateNPCs()
 
                                                                         if(CheckCollision(tempLocation, tempLocation2))
                                                                         {
-                                                                            NPC[B].Type = NPC[B].Type - 4;
+                                                                            NPC[B].Type -= 4;
                                                                             if(NPC[B].Type == 112)
                                                                                 NPC[B].Type = 194;
                                                                             NPC[A].Killed = 9;
@@ -3395,13 +3395,13 @@ void UpdateNPCs()
                                                                         if(NPCIsAParaTroopa[NPC[A].Type] && NPCIsAParaTroopa[NPC[B].Type])
                                                                         {
                                                                             if(NPC[A].Location.X + NPC[A].Location.Width / 2.0 > NPC[B].Location.X + NPC[B].Location.Width / 2.0)
-                                                                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.05;
+                                                                                NPC[A].Location.SpeedX += 0.05;
                                                                             else
-                                                                                NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.05;
+                                                                                NPC[A].Location.SpeedX -= 0.05;
                                                                             if(NPC[A].Location.Y + NPC[A].Location.Height / 2.0 > NPC[B].Location.Y + NPC[B].Location.Height / 2.0)
-                                                                                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + 0.05;
+                                                                                NPC[A].Location.SpeedY += 0.05;
                                                                             else
-                                                                                NPC[A].Location.SpeedY = NPC[A].Location.SpeedY - 0.05;
+                                                                                NPC[A].Location.SpeedY -= 0.05;
                                                                             HitSpot = 0;
                                                                         }
 
@@ -3421,7 +3421,7 @@ void UpdateNPCs()
                                                                                             {
                                                                                                 NPC[A].Special = 10;
                                                                                                 Player[numPlayers + 1].Direction = NPC[A].Direction;
-                                                                                                NPC[A].Location.X = NPC[A].Location.X - NPC[A].Direction;
+                                                                                                NPC[A].Location.X += -NPC[A].Direction;
                                                                                                 NPCHit(B, 1, numPlayers + 1);
                                                                                             }
                                                                                         }
@@ -3470,7 +3470,7 @@ void UpdateNPCs()
                         if(NPC[A].WallDeath > 0)
                         {
                             if(NPCIsCheep[NPC[A].Type])
-                                NPC[A].WallDeath = NPC[A].WallDeath - 1;
+                                NPC[A].WallDeath -= 1;
                             else
                                 NPC[A].WallDeath = 0;
                         }
@@ -3481,7 +3481,7 @@ void UpdateNPCs()
                             {
                                 if(NPC[A].Special <= 30)
                                 {
-                                    NPC[A].Special = NPC[A].Special + 1;
+                                    NPC[A].Special += 1;
                                     NPC[A].Location.SpeedY = 0;
                                     if(NPC[A].Slope > 0)
                                     {
@@ -3494,17 +3494,17 @@ void UpdateNPCs()
                                 }
                                 else if(NPC[A].Special == 31)
                                 {
-                                    NPC[A].Special = NPC[A].Special + 1;
+                                    NPC[A].Special += 1;
                                     NPC[A].Location.SpeedY = -4;
                                 }
                                 else if(NPC[A].Special == 32)
                                 {
-                                    NPC[A].Special = NPC[A].Special + 1;
+                                    NPC[A].Special += 1;
                                     NPC[A].Location.SpeedY = -4;
                                 }
                                 else if(NPC[A].Special == 33)
                                 {
-                                    NPC[A].Special = NPC[A].Special + 1;
+                                    NPC[A].Special += 1;
                                     NPC[A].Location.SpeedY = -4;
                                 }
                                 else if(NPC[A].Special == 34)
@@ -3517,7 +3517,7 @@ void UpdateNPCs()
                             {
                                 if(NPC[A].Special <= 60)
                                 {
-                                    NPC[A].Special = NPC[A].Special + 1;
+                                    NPC[A].Special += 1;
                                     NPC[A].Location.SpeedY = 0;
                                     if(NPC[A].Slope > 0)
                                     {
@@ -3530,22 +3530,22 @@ void UpdateNPCs()
                                 }
                                 else if(NPC[A].Special == 61)
                                 {
-                                    NPC[A].Special = NPC[A].Special + 1;
+                                    NPC[A].Special += 1;
                                     NPC[A].Location.SpeedY = -3;
                                 }
                                 else if(NPC[A].Special == 62)
                                 {
-                                    NPC[A].Special = NPC[A].Special + 1;
+                                    NPC[A].Special += 1;
                                     NPC[A].Location.SpeedY = -3;
                                 }
                                 else if(NPC[A].Special == 63)
                                 {
-                                    NPC[A].Special = NPC[A].Special + 1;
+                                    NPC[A].Special += 1;
                                     NPC[A].Location.SpeedY = -3;
                                 }
                                 else if(NPC[A].Special == 64)
                                 {
-                                    NPC[A].Special = NPC[A].Special + 1;
+                                    NPC[A].Special += 1;
                                     NPC[A].Location.SpeedY = -3;
                                 }
                                 else if(NPC[A].Special == 65)
@@ -3574,14 +3574,14 @@ void UpdateNPCs()
                                     tempLocation.X += NPC[A].Location.Width - 20;
                                     if(isPokeyHead)
                                         tempLocation.X += 16;
-                                    // If .Type = 189 Then tempLocation.X = tempLocation.X - 10
+                                    // If .Type = 189 Then tempLocation.X += -10
                                 }
                                 else
                                 {
                                     tempLocation.X += -tempLocation.Width + 20;
                                     if(isPokeyHead)
                                         tempLocation.X -= 16;
-                                    // If .Type = 189 Then tempLocation.X = tempLocation.X + 10
+                                    // If .Type = 189 Then tempLocation.X += 10
                                 }
 
                                 for(bCheck2 = 1; bCheck2 <= 2; bCheck2++)
@@ -3684,7 +3684,7 @@ void UpdateNPCs()
                                 tempLocation.SpeedX = 0;
                                 tempLocation.SpeedY = 0;
                                 tempLocation.Y = NPC[A].Location.Y + 8;
-                                tempLocation.Height = tempLocation.Height - 16;
+                                tempLocation.Height -= 16;
                                 tempLocation.Width = 32;
                                 if(NPC[A].Location.SpeedX > 0)
                                     tempLocation.X = NPC[A].Location.X + NPC[A].Location.Width;
@@ -3722,7 +3722,7 @@ void UpdateNPCs()
                                 }
                                 if(tempTurn == true)
                                 {
-                                    NPC[A].Location.Y = NPC[A].Location.Y - 0.1;
+                                    NPC[A].Location.Y -= 0.1;
                                     NPC[A].Location.SpeedY = -6.55;
                                 }
                                 else
@@ -3736,7 +3736,7 @@ void UpdateNPCs()
                                     }
                                 }
                                 if(tempSpeedA != 0)
-                                    NPC[A].Location.SpeedY = NPC[A].Location.SpeedY + tempSpeedA;
+                                    NPC[A].Location.SpeedY += tempSpeedA;
                             }
                             else // Walking code for everything else
                             {
@@ -3762,7 +3762,7 @@ void UpdateNPCs()
                                 }
                                 if(NPC[A].Type == 129)
                                 {
-                                    NPC[A].Special = NPC[A].Special + 1;
+                                    NPC[A].Special += 1;
                                     if(NPC[A].Special <= 3)
                                         NPC[A].Location.SpeedY = -3.5;
                                     else
@@ -3773,7 +3773,7 @@ void UpdateNPCs()
                                 }
                                 if(NPC[A].Type == 125)
                                 {
-                                    NPC[A].FrameCount = NPC[A].FrameCount + 1;
+                                    NPC[A].FrameCount += 1;
                                     if(NPC[A].FrameCount > 1)
                                         NPC[A].FrameCount = 0;
                                     NPC[A].Location.SpeedY = -3;
@@ -3804,8 +3804,8 @@ void UpdateNPCs()
                         Block[NPC[A].tempBlock].Location = NPC[A].Location;
                         if(NPC[A].Type == 26)
                         {
-                            Block[NPC[A].tempBlock].Location.Y = Block[NPC[A].tempBlock].Location.Y - 16;
-                            Block[NPC[A].tempBlock].Location.Height = Block[NPC[A].tempBlock].Location.Height + 16;
+                            Block[NPC[A].tempBlock].Location.Y -= 16;
+                            Block[NPC[A].tempBlock].Location.Height += 16;
                         }
                         while(Block[NPC[A].tempBlock].Location.X < Block[NPC[A].tempBlock - 1].Location.X && NPC[A].tempBlock > numBlock + 1 - numTempBlock)
                         {
@@ -3815,7 +3815,7 @@ void UpdateNPCs()
                             Block[NPC[A].tempBlock] = tmpBlock;
 
                             NPC[Block[NPC[A].tempBlock].IsReally].tempBlock = NPC[A].tempBlock;
-                            NPC[A].tempBlock = NPC[A].tempBlock - 1;
+                            NPC[A].tempBlock -= 1;
 
                         }
                         while(Block[NPC[A].tempBlock].Location.X > Block[NPC[A].tempBlock + 1].Location.X && NPC[A].tempBlock < numBlock)
@@ -3827,7 +3827,7 @@ void UpdateNPCs()
                             Block[NPC[A].tempBlock] = tmpBlock;
 
                             NPC[Block[NPC[A].tempBlock].IsReally].tempBlock = NPC[A].tempBlock;
-                            NPC[A].tempBlock = NPC[A].tempBlock + 1;
+                            NPC[A].tempBlock += 1;
 
 
 
@@ -3847,11 +3847,11 @@ void UpdateNPCs()
                 }
                 // Pinched code
                 // If .Direction <> oldDirection Then
-                // .PinchCount = .PinchCount + 10
+                // .PinchCount += 10
                 // Else
                 // If .PinchCount > 0 Then
-                // .PinchCount = .PinchCount - 1
-                // If .Pinched = False Then .PinchCount = .PinchCount - 1
+                // .PinchCount += -1
+                // If .Pinched = False Then .PinchCount += -1
                 // End If
                 // End If
                 // If .PinchCount >= 14 And .Pinched = False Then
@@ -3867,7 +3867,7 @@ void UpdateNPCs()
                 if(NPC[A].Type == 134) // SMB2 Bomb
                 {
                     // If .Location.SpeedX < -2 Or .Location.SpeedX > 2 Or .Location.SpeedY < -2 Or .Location.SpeedY > 5 Then .Projectile = True
-                    NPC[A].Special = NPC[A].Special + 1;
+                    NPC[A].Special += 1;
                     if(NPC[A].Special > 250)
                         NPC[A].Special2 = 1;
                     if(NPC[A].Special >= 350 || NPC[A].Special < 0)
@@ -3878,7 +3878,7 @@ void UpdateNPCs()
                 }
                 else if(NPC[A].Type == 135) // SMB2 Bob-om
                 {
-                    NPC[A].Special = NPC[A].Special + 1;
+                    NPC[A].Special += 1;
                     if(NPC[A].Special > 450)
                         NPC[A].Special2 = 1;
                     if(NPC[A].Special >= 550 || NPC[A].Special < 0)
@@ -3890,7 +3890,7 @@ void UpdateNPCs()
                 else if(NPC[A].Type == 137) // SMB3 Bomb
                 {
                     if(NPC[A].Inert == false)
-                        NPC[A].Special = NPC[A].Special + 1;
+                        NPC[A].Special += 1;
                     if(NPC[A].Special > 250)
                         NPC[A].Special2 = 1;
                     if(NPC[A].Special >= 350 || NPC[A].Special < 0)
@@ -3900,7 +3900,7 @@ void UpdateNPCs()
                 {
                     if(NPC[A].Special > 0)
                     {
-                        NPC[A].Special2 = NPC[A].Special2 + 1;
+                        NPC[A].Special2 += 1;
                         if(NPC[A].Special2 >= 400 && NPC[A].Special3 == 0)
                         {
                             NPC[A].Special = 0;
@@ -3912,12 +3912,12 @@ void UpdateNPCs()
                         {
                             if(NPC[A].Special3 == 0)
                             {
-                                NPC[A].Location.X = NPC[A].Location.X + 2;
+                                NPC[A].Location.X += 2;
                                 NPC[A].Special3 = 1;
                             }
                             else
                             {
-                                NPC[A].Location.X = NPC[A].Location.X - 2;
+                                NPC[A].Location.X -= 2;
                                 NPC[A].Special3 = 0;
                             }
                         }
@@ -4043,7 +4043,7 @@ void UpdateNPCs()
 
                     if(fiEqual(NPC[A].Special4, -1)) // turn left
                     {
-                        NPC[A].Special3 = NPC[A].Special3 - 1;
+                        NPC[A].Special3 -= 1;
                         if(NPC[A].Special3 > -5)
                             NPC[A].Frame = 9;
                         else if(NPC[A].Special3 > -10)
@@ -4062,7 +4062,7 @@ void UpdateNPCs()
                     }
                     else if(fiEqual(NPC[A].Special4, 1)) // turn right
                     {
-                        NPC[A].Special3 = NPC[A].Special3 + 1;
+                        NPC[A].Special3 += 1;
                         if(NPC[A].Special3 < 5)
                             NPC[A].Frame = 4;
                         else if(NPC[A].Special3 < 10)
@@ -4081,7 +4081,7 @@ void UpdateNPCs()
                     }
                     else if(fiEqual(NPC[A].Special4, -10)) // look left
                     {
-                        NPC[A].Special3 = NPC[A].Special3 - 1;
+                        NPC[A].Special3 -= 1;
                         if(NPC[A].Special3 > -5)
                             NPC[A].Frame = 3;
                         else if(NPC[A].Special3 > -10)
@@ -4094,7 +4094,7 @@ void UpdateNPCs()
                     }
                     else if(fiEqual(NPC[A].Special4, 10)) // look right
                     {
-                        NPC[A].Special3 = NPC[A].Special3 + 1;
+                        NPC[A].Special3 += 1;
                         if(NPC[A].Special3 < 5)
                             NPC[A].Frame = 8;
                         else if(NPC[A].Special3 < 10)
@@ -4111,7 +4111,7 @@ void UpdateNPCs()
                         {
                             if(NPC[A].Special3 < 5)
                             {
-                                NPC[A].Special3 = NPC[A].Special3 + 1;
+                                NPC[A].Special3 += 1;
                                 if(NPC[A].Direction < 0)
                                     NPC[A].Frame = 1;
                                 else
@@ -4119,9 +4119,9 @@ void UpdateNPCs()
                             }
                             else if(fiEqual(NPC[A].Special3, 5))
                             {
-                                NPC[A].Special3 = NPC[A].Special3 + 1;
+                                NPC[A].Special3 += 1;
                                 NPC[A].Location.SpeedY = -3;
-                                NPC[A].Location.Y = NPC[A].Location.Y - 0.1;
+                                NPC[A].Location.Y -= 0.1;
                                 if(NPC[A].Direction < 0)
                                     NPC[A].Frame = 0;
                                 else
@@ -4129,7 +4129,7 @@ void UpdateNPCs()
                             }
                             else if(NPC[A].Special3 < 10)
                             {
-                                NPC[A].Special3 = NPC[A].Special3 + 1;
+                                NPC[A].Special3 += 1;
                                 if(NPC[A].Direction < 0)
                                     NPC[A].Frame = 1;
                                 else
@@ -4144,14 +4144,14 @@ void UpdateNPCs()
                         if(NPC[A].Special3 < -1)
                         {
                             if(NPC[A].Special > 1)
-                                NPC[A].Special = NPC[A].Special - 1;
-                            NPC[A].Special3 = NPC[A].Special3 + 1;
+                                NPC[A].Special -= 1;
+                            NPC[A].Special3 += 1;
                             if(fiEqual(NPC[A].Special3, -1))
                                 NPC[A].Special3 = 6;
                         }
                         else if(NPC[A].Special3 < 5)
                         {
-                            NPC[A].Special3 = NPC[A].Special3 + 1;
+                            NPC[A].Special3 += 1;
                             if(NPC[A].Direction < 0)
                                 NPC[A].Frame = 1;
                             else
@@ -4161,10 +4161,10 @@ void UpdateNPCs()
                         {
                             auto &sx = NPC[A].Location.SpeedX;
                             auto &pl = Player[int(NPC[A].Special5)].Location;
-                            NPC[A].Special3 = NPC[A].Special3 + 1;
+                            NPC[A].Special3 += 1;
                             NPC[A].Location.SpeedY = -12;
                             NPC[A].BeltSpeed = 0;
-                            NPC[A].Location.Y = NPC[A].Location.Y - 0.1;
+                            NPC[A].Location.Y -= 0.1;
                             // This formula got been compacted: If something will glitch, feel free to restore back this crap
                             //NPC[A].Location.SpeedX = (static_cast<int>(std::floor(static_cast<double>(((Player[NPC[A].Special5].Location.X + Player[NPC[A].Special5].Location.Width / 2.0 - 16) + 1) / 32))) * 32 + 1 - NPC[A].Location.X) / 50;
                             double pCenter = pl.X + pl.Width / 2.0;
@@ -4196,22 +4196,22 @@ void UpdateNPCs()
                         else if(NPC[A].Special3 < 13)
                         {
                             NPC[A].Location.SpeedY = -2;
-                            NPC[A].Special3 = NPC[A].Special3 + 1;
+                            NPC[A].Special3 += 1;
                         }
                         else if(NPC[A].Special3 < 16)
                         {
                             NPC[A].Location.SpeedY = 2;
-                            NPC[A].Special3 = NPC[A].Special3 + 1;
+                            NPC[A].Special3 += 1;
                         }
                         else if(NPC[A].Special3 < 19)
                         {
                             NPC[A].Location.SpeedY = -2;
-                            NPC[A].Special3 = NPC[A].Special3 + 1;
+                            NPC[A].Special3 += 1;
                         }
                         else if(NPC[A].Special3 < 21)
                         {
                             NPC[A].Location.SpeedY = 2;
-                            NPC[A].Special3 = NPC[A].Special3 + 1;
+                            NPC[A].Special3 += 1;
                         }
                         else if(fiEqual(NPC[A].Special3, 21))
                         {
@@ -4307,12 +4307,12 @@ void UpdateNPCs()
                         else if(NPC[A].Special3 < 35)
                         {
                             NPC[A].Frame = 11;
-                            NPC[A].Special3 = NPC[A].Special3 + 1;
+                            NPC[A].Special3 += 1;
                         }
                         else if(NPC[A].Special3 < 40)
                         {
                             NPC[A].Frame = 12;
-                            NPC[A].Special3 = NPC[A].Special3 + 1;
+                            NPC[A].Special3 += 1;
                             NPC[A].Special5 = 0;
                         }
                         else
@@ -4329,7 +4329,7 @@ void UpdateNPCs()
                     }
                     else if(fiEqual(NPC[A].Special4, 4)) // shoot a fireball
                     {
-                        NPC[A].Special3 = NPC[A].Special3 + 1;
+                        NPC[A].Special3 += 1;
                         if(NPC[A].Special3 < 15)
                         {
                             if(NPC[A].Direction < 0)
@@ -4387,7 +4387,7 @@ void UpdateNPCs()
                 else if(NPC[A].Type == 29 && NPC[A].HoldingPlayer > 0)
                 {
                     if(Player[NPC[A].HoldingPlayer].Effect == 0)
-                        NPC[A].Special3 = NPC[A].Special3 + 1;
+                        NPC[A].Special3 += 1;
                     if(NPC[A].Special3 >= 20)
                     {
                         PlaySound(SFX_HammerToss);
@@ -4715,8 +4715,8 @@ void UpdateNPCs()
                                 NPC[A].Special = (iRand() % 3) + 1;
                             if(fiEqual(NPC[A].Special, 1))
                             {
-                                NPC[A].FrameCount = NPC[A].FrameCount + 1;
-                                NPC[A].Special2 = NPC[A].Special2 + 1;
+                                NPC[A].FrameCount += 1;
+                                NPC[A].Special2 += 1;
                                 NPC[A].Location.SpeedX = 0;
                                 if(NPC[A].Special2 >= 90)
                                 {
@@ -4728,8 +4728,8 @@ void UpdateNPCs()
                             }
                             else if(NPC[A].Special == 3)
                             {
-                                NPC[A].FrameCount = NPC[A].FrameCount + 1;
-                                NPC[A].Special2 = NPC[A].Special2 + 30;
+                                NPC[A].FrameCount += 1;
+                                NPC[A].Special2 += 30;
                                 NPC[A].Location.SpeedX = 0;
                                 if(NPC[A].Special2 >= 30)
                                 {
@@ -4742,7 +4742,7 @@ void UpdateNPCs()
                             else if(NPC[A].Special == 2)
                             {
                                 NPC[A].Location.SpeedX = 0.5 * NPC[A].Direction;
-                                NPC[A].Special2 = NPC[A].Special2 + 1;
+                                NPC[A].Special2 += 1;
                                 if(NPC[A].Special2 == 120)
                                 {
                                     NPC[A].Special2 = 0;
@@ -4751,7 +4751,7 @@ void UpdateNPCs()
                             }
                             else
                             {
-                                NPC[A].Special2 = NPC[A].Special2 + 1;
+                                NPC[A].Special2 += 1;
                                 if(NPC[A].Special2 == 30)
                                 {
                                     NPC[A].Special2 = 0;
@@ -4798,18 +4798,18 @@ void UpdateNPCs()
                     }
                 }
                 NPC[A].Frame = EditorNPCFrame(NPC[A].Type, NPC[A].Direction, A);
-                NPC[A].Effect2 = NPC[A].Effect2 + 1;
-                NPC[A].Location.Y = NPC[A].Location.Y - 1; // .01
-                NPC[A].Location.Height = NPC[A].Location.Height + 1;
+                NPC[A].Effect2 += 1;
+                NPC[A].Location.Y -= 1; // .01
+                NPC[A].Location.Height += 1;
                 if(NPCHeightGFX[NPC[A].Type] > 0)
                 {
                     if(NPC[A].Effect2 >= NPCHeightGFX[NPC[A].Type])
                     {
                         NPC[A].Effect = 0;
                         NPC[A].Effect2 = 0;
-                        NPC[A].Location.Y = NPC[A].Location.Y + NPC[A].Location.Height;
+                        NPC[A].Location.Y += NPC[A].Location.Height;
                         NPC[A].Location.Height = NPCHeight[NPC[A].Type];
-                        NPC[A].Location.Y = NPC[A].Location.Y - NPC[A].Location.Height;
+                        NPC[A].Location.Y += -NPC[A].Location.Height;
                     }
                 }
                 else
@@ -4841,8 +4841,8 @@ void UpdateNPCs()
             }
             else if(NPC[A].Effect == 2) // Bonus item is falling from the players container effect
             {
-                NPC[A].Location.Y = NPC[A].Location.Y + 2.2;
-                NPC[A].Effect2 = NPC[A].Effect2 + 1;
+                NPC[A].Location.Y += 2.2;
+                NPC[A].Effect2 += 1;
                 if(NPC[A].Effect2 == 5)
                     NPC[A].Effect2 = 1;
             }
@@ -4866,8 +4866,8 @@ void UpdateNPCs()
                     }
                 }
 
-                NPC[A].Effect2 = NPC[A].Effect2 + 1;
-                NPC[A].Location.Y = NPC[A].Location.Y + 1;
+                NPC[A].Effect2 += 1;
+                NPC[A].Location.Y += 1;
 
                 if(fEqual(NPC[A].Effect2, 32.0))
                 {
@@ -4907,7 +4907,7 @@ void UpdateNPCs()
                 {
                     NPC[A].Location.Y -= 1;
                     if(NPC[A].Type == 106)
-                        NPC[A].Location.Y = NPC[A].Location.Y - 1;
+                        NPC[A].Location.Y -= 1;
                     if(NPC[A].Location.Y + NPC[A].Location.Height <= NPC[A].Effect2)
                     {
                         NPC[A].Effect = 0;
@@ -4932,7 +4932,7 @@ void UpdateNPCs()
                     if(NPC[A].Type == 9 || NPC[A].Type == 90 || NPC[A].Type == 153 || NPC[A].Type == 184 || NPC[A].Type == 185 || NPC[A].Type == 186 || NPC[A].Type == 187 || NPC[A].Type == 163 || NPC[A].Type == 164)
                         NPC[A].Location.X -= double(Physics.NPCMushroomSpeed);
                     else if(NPCCanWalkOn[NPC[A].Type] == true)
-                        NPC[A].Location.X = NPC[A].Location.X - 1;
+                        NPC[A].Location.X -= 1;
                     else
                         NPC[A].Location.X -= double(Physics.NPCWalkingSpeed);
                     if(NPC[A].Location.X + NPC[A].Location.Width <= NPC[A].Effect2)
@@ -4947,7 +4947,7 @@ void UpdateNPCs()
                     if(NPC[A].Type == 9 || NPC[A].Type == 90 || NPC[A].Type == 153 || NPC[A].Type == 184 || NPC[A].Type == 185 || NPC[A].Type == 186 || NPC[A].Type == 187 || NPC[A].Type == 163 || NPC[A].Type == 164)
                         NPC[A].Location.X += double(Physics.NPCMushroomSpeed);
                     else if(NPCCanWalkOn[NPC[A].Type] == true)
-                        NPC[A].Location.X = NPC[A].Location.X + 1;
+                        NPC[A].Location.X += 1;
                     else
                         NPC[A].Location.X += double(Physics.NPCWalkingSpeed);
                     if(NPC[A].Location.X >= NPC[A].Effect2)
@@ -4967,7 +4967,7 @@ void UpdateNPCs()
             else if(NPC[A].Effect == 5) // Grabbed by Yoshi
             {
                 NPC[A].TimeLeft = 100;
-                NPC[A].Effect3 = NPC[A].Effect3 - 1;
+                NPC[A].Effect3 -= 1;
                 if(NPC[A].Effect3 <= 0)
                 {
                     NPC[A].Effect = 0;
@@ -4987,7 +4987,7 @@ void UpdateNPCs()
             }
             else if(NPC[A].Effect == 8) // Holding Pattern
             {
-                NPC[A].Effect2 = NPC[A].Effect2 - 1;
+                NPC[A].Effect2 -= 1;
                 if(NPC[A].Effect2 <= 0)
                 {
                     NPC[A].Effect = 0;
@@ -5056,7 +5056,7 @@ void UpdateNPCs()
 
     }
 
-    numBlock = numBlock - numTempBlock; // clean up the temp npc blocks
+    numBlock += -numTempBlock; // clean up the temp npc blocks
     for(A = numNPCs; A >= 1; A--) // KILL THE NPCS <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><
     {
         if(NPC[A].Killed > 0)
@@ -5065,9 +5065,9 @@ void UpdateNPCs()
             {
                 NPC[A].Location.SpeedX = dRand() * 2 - 1;
                 if(NPC[A].Location.SpeedX < 0)
-                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX - 0.5;
+                    NPC[A].Location.SpeedX -= 0.5;
                 else
-                    NPC[A].Location.SpeedX = NPC[A].Location.SpeedX + 0.5;
+                    NPC[A].Location.SpeedX += 0.5;
             }
             KillNPC(A, NPC[A].Killed);
         }
@@ -5076,7 +5076,7 @@ void UpdateNPCs()
     //    {
     //        if(nPlay.Mode == 1)
     //        {
-    //            nPlay.NPCWaitCount = nPlay.NPCWaitCount + 10;
+    //            nPlay.NPCWaitCount += 10;
     //            if(nPlay.NPCWaitCount >= 5)
     //            {
     //                tempStr = "L" + LB;
@@ -5086,9 +5086,9 @@ void UpdateNPCs()
     //                    {
     //                        if(NPC[A].HoldingPlayer <= 1)
     //                        {
-    //                            tempStr = tempStr + "K" + std::to_string(A) + "|" + NPC[A].Type + "|" + NPC[A].Location.X + "|" + NPC[A].Location.Y + "|" + std::to_string(NPC[A].Location.Width) + "|" + std::to_string(NPC[A].Location.Height) + "|" + NPC[A].Location.SpeedX + "|" + NPC[A].Location.SpeedY + "|" + NPC[A].Section + "|" + NPC[A].TimeLeft + "|" + NPC[A].Direction + "|" + std::to_string(static_cast<int>(floor(static_cast<double>(NPC[A].Projectile)))) + "|" + NPC[A].Special + "|" + NPC[A].Special2 + "|" + NPC[A].Special3 + "|" + NPC[A].Special4 + "|" + NPC[A].Special5 + "|" + NPC[A].Effect + LB;
+    //                            tempStr += "K" + std::to_string(A) + "|" + NPC[A].Type + "|" + NPC[A].Location.X + "|" + NPC[A].Location.Y + "|" + std::to_string(NPC[A].Location.Width) + "|" + std::to_string(NPC[A].Location.Height) + "|" + NPC[A].Location.SpeedX + "|" + NPC[A].Location.SpeedY + "|" + NPC[A].Section + "|" + NPC[A].TimeLeft + "|" + NPC[A].Direction + "|" + std::to_string(static_cast<int>(floor(static_cast<double>(NPC[A].Projectile)))) + "|" + NPC[A].Special + "|" + NPC[A].Special2 + "|" + NPC[A].Special3 + "|" + NPC[A].Special4 + "|" + NPC[A].Special5 + "|" + NPC[A].Effect + LB;
     //                            if(NPC[A].Effect != 0)
-    //                                tempStr = tempStr + "2c" + std::to_string(A) + "|" + NPC[A].Effect2 + "|" + NPC[A].Effect3 + LB;
+    //                                tempStr += "2c" + std::to_string(A) + "|" + NPC[A].Effect2 + "|" + NPC[A].Effect3 + LB;
     //                        }
     //                    }
     //                }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -91,8 +91,8 @@ static void setupPlayerAtCheckpoints(NPC_t &npc, Checkpoint_t &cp)
 
     if(numPlayers > 1)
     {
-        Player[1].Location.X = Player[1].Location.X - 16;
-        Player[2].Location.X = Player[2].Location.X + 16;
+        Player[1].Location.X -= 16;
+        Player[2].Location.X += 16;
     }
 }
 
@@ -233,7 +233,7 @@ void SetupPlayers()
                 Player[A].Hearts = 2;
             if(Player[A].HeldBonus > 0)
             {
-                Player[A].Hearts = Player[A].Hearts + 1;
+                Player[A].Hearts += 1;
                 Player[A].HeldBonus = 0;
             }
             if(Player[A].State == 1 && Player[A].Hearts > 1)
@@ -383,13 +383,13 @@ void SetupPlayers()
             /*if(nPlay.Online)
             {
                 Player[A].Location = Player[1].Location;
-                Player[A].Location.X = Player[A].Location.X + A * 32 - 32;
+                Player[A].Location.X += A * 32 - 32;
             }
             else*/
             if(GameOutro)
             {
                 Player[A].Location = Player[1].Location;
-                Player[A].Location.X = Player[A].Location.X + A * 52 - 52;
+                Player[A].Location.X += A * 52 - 52;
             }
             else
             {
@@ -502,9 +502,9 @@ void PlayerHurt(int A)
                     NewEffect(101, tempLocation);
                 else
                     NewEffect(102, tempLocation);
-                Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                Player[A].Location.Y += Player[A].Location.Height;
                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
-                Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                Player[A].Location.Y += -Player[A].Location.Height;
                 Player[A].Immune = 150;
                 Player[A].Immune2 = true;
             }
@@ -573,13 +573,13 @@ void PlayerHurt(int A)
                         Player[A].State = 2;
                         Player[A].Immune = 150;
                         Player[A].Immune2 = true;
-                        Player[A].Hearts = Player[A].Hearts - 1;
+                        Player[A].Hearts -= 1;
                         PlaySound(SFX_PlayerHit);
                         return;
                     }
                     else
                     {
-                        Player[A].Hearts = Player[A].Hearts - 1;
+                        Player[A].Hearts -= 1;
                         if(Player[A].Hearts == 0)
                             Player[A].State = 1;
                         else if(Player[A].State == 3 && Player[A].Hearts == 2)
@@ -602,7 +602,7 @@ void PlayerHurt(int A)
                 }
                 else if(Player[A].Character == 5)
                 {
-                    Player[A].Hearts = Player[A].Hearts - 1;
+                    Player[A].Hearts -= 1;
                     if(Player[A].Hearts > 0)
                     {
                         if(Player[A].Hearts == 1)
@@ -643,7 +643,7 @@ void PlayerHurt(int A)
                         NPC[numNPCs].Direction = Player[A].Direction;
                         if(NPC[numNPCs].Direction == 1)
                             NPC[numNPCs].Frame = 4;
-                        NPC[numNPCs].Frame = NPC[numNPCs].Frame + SpecialFrame[2];
+                        NPC[numNPCs].Frame += SpecialFrame[2];
                         NPC[numNPCs].Active = true;
                         NPC[numNPCs].TimeLeft = 100;
                         NPC[numNPCs].Type = 56;
@@ -657,7 +657,7 @@ void PlayerHurt(int A)
                         NPC[numNPCs].CantHurtPlayer = A;
                         Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
                         Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
-                        Player[A].Location.X = Player[A].Location.X + 64 - Physics.PlayerWidth[Player[A].Character][Player[A].State] / 2;
+                        Player[A].Location.X += 64 - Physics.PlayerWidth[Player[A].Character][Player[A].State] / 2;
                         Player[A].ForceHitSpot3 = true;
                         Player[A].Location.Y = NPC[numNPCs].Location.Y - Player[A].Location.Height;
 
@@ -741,7 +741,7 @@ void PlayerDead(int A)
         NPC[numNPCs].Direction = Player[A].Direction;
         if(Maths::iRound(NPC[numNPCs].Direction) == 1)
             NPC[numNPCs].Frame = 4;
-        NPC[numNPCs].Frame = NPC[numNPCs].Frame + SpecialFrame[2];
+        NPC[numNPCs].Frame += SpecialFrame[2];
         NPC[numNPCs].Active = true;
         NPC[numNPCs].TimeLeft = 100;
         NPC[numNPCs].Type = 56;
@@ -754,7 +754,7 @@ void PlayerDead(int A)
         NPC[numNPCs].CantHurt = 10;
         NPC[numNPCs].CantHurtPlayer = A;
         Player[A].Mount = 0;
-        Player[A].Location.Y = Player[A].Location.Y - 32;
+        Player[A].Location.Y -= 32;
         Player[A].Location.Height = 32;
         SizeCheck(A);
     }
@@ -836,7 +836,7 @@ void KillPlayer(int A)
         if(A == BattleWinner || BattleWinner == 0)
         {
             if(BattleLives[A] > 0)
-                BattleLives[A] = BattleLives[A] - 1;
+                BattleLives[A] -= 1;
             PlaySound(SFX_Raccoon);
             Player[A].Frame = 1;
             Player[A].Location.SpeedX = 0;
@@ -970,25 +970,25 @@ void UnDuck(int A)
         Player[A].Duck = false;
         if(Player[A].Mount == 3)
         {
-            Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+            Player[A].Location.Y += Player[A].Location.Height;
             if(Player[A].State == 1)
                 Player[A].Location.Height = 54;
             else
                 Player[A].Location.Height = 60;
-            Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+            Player[A].Location.Y += -Player[A].Location.Height;
         }
         else
         {
             if(Player[A].State == 1 && Player[A].Mount == 1)
             {
                 Player[A].Location.Height = Physics.PlayerHeight[1][2];
-                Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[1][2] + Physics.PlayerDuckHeight[1][2];
+                Player[A].Location.Y += -Physics.PlayerHeight[1][2] + Physics.PlayerDuckHeight[1][2];
             }
             else
             {
-                Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                Player[A].Location.Y += Player[A].Location.Height;
                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
-                Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                Player[A].Location.Y += -Player[A].Location.Height;
             }
         }
         SizeCheck(A);
@@ -1122,7 +1122,7 @@ void PlayerFrame(int A)
     {
         if(Player[A].Immune > 0)
         {
-            Player[A].Immune = Player[A].Immune - 1;
+            Player[A].Immune -= 1;
             if(Player[A].Immune % 3 == 0)
             {
                 if(Player[A].Immune2 == false)
@@ -1145,7 +1145,7 @@ void PlayerFrame(int A)
 // for the grab animation when picking something up from the top
     if(Player[A].GrabTime > 0)
     {
-        Player[A].FrameCount = Player[A].FrameCount + 1;
+        Player[A].FrameCount += 1;
         if(Player[A].FrameCount <= 6)
             Player[A].Frame = 23;
         else if(Player[A].FrameCount <= 12)
@@ -1276,7 +1276,7 @@ void PlayerFrame(int A)
             if(NPC[Player[A].StandingOnNPC].Location.SpeedX > 0)
                 Player[A].Direction = -Player[A].Direction;
         }
-        Player[A].SpinFrame = Player[A].SpinFrame + 1;
+        Player[A].SpinFrame += 1;
         if(Player[A].SpinFrame < 0)
             Player[A].SpinFrame = 14;
         if(Player[A].SpinFrame < 3)
@@ -1403,19 +1403,19 @@ void PlayerFrame(int A)
                         {
                             if(Player[A].Location.SpeedX != 0 && !(Player[A].Slippy && !Player[A].Controls.Left && !Player[A].Controls.Right))
                             {
-                                Player[A].FrameCount = Player[A].FrameCount + 1;
+                                Player[A].FrameCount += 1;
 
                                 if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed - 1.5 || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed + 1.5)
-                                    Player[A].FrameCount = Player[A].FrameCount + 1;
+                                    Player[A].FrameCount += 1;
 
                                 if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed)
-                                    Player[A].FrameCount = Player[A].FrameCount + 1;
+                                    Player[A].FrameCount += 1;
 
                                 if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed + 1 || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed - 1)
-                                    Player[A].FrameCount = Player[A].FrameCount + 1;
+                                    Player[A].FrameCount += 1;
 
                                 if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed + 2 || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed - 2)
-                                    Player[A].FrameCount = Player[A].FrameCount + 1;
+                                    Player[A].FrameCount += 1;
 
                                 if(Player[A].FrameCount >= 10)
                                 {
@@ -1455,10 +1455,10 @@ void PlayerFrame(int A)
 
                     if(Player[A].Location.SpeedX != 0)
                     {
-                        Player[A].FrameCount = Player[A].FrameCount + 2;
+                        Player[A].FrameCount += 2;
 
                         if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed)
-                            Player[A].FrameCount = Player[A].FrameCount + 3;
+                            Player[A].FrameCount += 3;
 
                         if(Player[A].FrameCount >= 10)
                         {
@@ -1541,7 +1541,7 @@ void PlayerFrame(int A)
                                 Player[A].FrameCount = 6;
                         }
 
-                        Player[A].FrameCount = Player[A].FrameCount + 1;
+                        Player[A].FrameCount += 1;
                         if(Player[A].FrameCount < 6)
                             Player[A].Frame = 40;
                         else if(Player[A].FrameCount < 12)
@@ -1556,7 +1556,7 @@ void PlayerFrame(int A)
                     }
                     else
                     {
-                        Player[A].FrameCount = Player[A].FrameCount + 1;
+                        Player[A].FrameCount += 1;
                         if(Player[A].FrameCount < 10)
                             Player[A].Frame = 40;
                         else if(Player[A].FrameCount < 20)
@@ -1627,13 +1627,13 @@ void PlayerFrame(int A)
                         {
                             if(Player[A].Location.SpeedX != 0 && !(Player[A].Slippy && Player[A].Controls.Left == false && Player[A].Controls.Right == false))
                             {
-                                Player[A].FrameCount = Player[A].FrameCount + 1;
+                                Player[A].FrameCount += 1;
 
                                 if(Player[A].Location.SpeedX >= Physics.PlayerWalkSpeed || Player[A].Location.SpeedX <= -Physics.PlayerWalkSpeed)
-                                    Player[A].FrameCount = Player[A].FrameCount + 1;
+                                    Player[A].FrameCount += 1;
 
                                 if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed + 1.5 || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed - 1.5)
-                                    Player[A].FrameCount = Player[A].FrameCount + 1;
+                                    Player[A].FrameCount += 1;
 
                                 if(Player[A].FrameCount >= 5 && Player[A].FrameCount < 10)
                                 {
@@ -1658,7 +1658,7 @@ void PlayerFrame(int A)
                                 }
                                 else if(Player[A].FrameCount >= 20)
                                 {
-                                    Player[A].FrameCount = Player[A].FrameCount - 20;
+                                    Player[A].FrameCount -= 20;
                                     if(Player[A].CanFly && Player[A].Character != 3)
                                         Player[A].Frame = 17;
                                     else
@@ -1685,7 +1685,7 @@ void PlayerFrame(int A)
                             }
                             else
                             {
-                                Player[A].FrameCount = Player[A].FrameCount + 1;
+                                Player[A].FrameCount += 1;
                                 if(!(Player[A].Frame == 19 || Player[A].Frame == 20 || Player[A].Frame == 21))
                                     Player[A].Frame = 19;
                                 if(Player[A].FrameCount >= 5)
@@ -1708,7 +1708,7 @@ void PlayerFrame(int A)
                             {
                                 if((Player[A].State == 4 || Player[A].State == 5) && Player[A].Controls.Jump && !(Player[A].Character == 3 || Player[A].Character == 4))
                                 {
-                                    Player[A].FrameCount = Player[A].FrameCount + 1;
+                                    Player[A].FrameCount += 1;
                                     if(!(Player[A].Frame == 3 || Player[A].Frame == 5 || Player[A].Frame == 11))
                                         Player[A].Frame = 11;
                                     if(Player[A].FrameCount >= 5)
@@ -1748,9 +1748,9 @@ void PlayerFrame(int A)
                     }
                     if(Player[A].Location.SpeedX != 0)
                     {
-                        Player[A].FrameCount = Player[A].FrameCount + 1;
+                        Player[A].FrameCount += 1;
                         if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed)
-                            Player[A].FrameCount = Player[A].FrameCount + 1;
+                            Player[A].FrameCount += 1;
                         if(Player[A].FrameCount >= 5 && Player[A].FrameCount < 10)
                             Player[A].Frame = 8;
                         else if(Player[A].FrameCount >= 10 && Player[A].FrameCount < 15)
@@ -1841,25 +1841,25 @@ void PlayerFrame(int A)
                     else if(Player[A].YoshiBFrameCount > 24)
                     {
                         Player[A].YoshiBFrame = 1;
-                        Player[A].YoshiTX = Player[A].YoshiTX - 1;
-                        Player[A].YoshiTY = Player[A].YoshiTY + 2;
-                        Player[A].YoshiBY = Player[A].YoshiBY + 1;
+                        Player[A].YoshiTX -= 1;
+                        Player[A].YoshiTY += 2;
+                        Player[A].YoshiBY += 1;
                         Player[A].MountOffsetY += 1;
                     }
                     else if(Player[A].YoshiBFrameCount > 16)
                     {
                         Player[A].YoshiBFrame = 2;
-                        Player[A].YoshiTX = Player[A].YoshiTX - 2;
-                        Player[A].YoshiTY = Player[A].YoshiTY + 4;
-                        Player[A].YoshiBY = Player[A].YoshiBY + 2;
+                        Player[A].YoshiTX -= 2;
+                        Player[A].YoshiTY += 4;
+                        Player[A].YoshiBY += 2;
                         Player[A].MountOffsetY += 2;
                     }
                     else if(Player[A].YoshiBFrameCount > 8)
                     {
                         Player[A].YoshiBFrame = 1;
-                        Player[A].YoshiTX = Player[A].YoshiTX - 1;
-                        Player[A].YoshiTY = Player[A].YoshiTY + 2;
-                        Player[A].YoshiBY = Player[A].YoshiBY + 1;
+                        Player[A].YoshiTX -= 1;
+                        Player[A].YoshiTY += 2;
+                        Player[A].YoshiBY += 1;
                         Player[A].MountOffsetY += 1;
                     }
                     else
@@ -1896,7 +1896,7 @@ void PlayerFrame(int A)
                     Player[A].YoshiTX += 12;
                     /*
                     Player[A].MountOffsetY = 0;
-                    Player[A].MountOffsetY = Player[A].MountOffsetY + 8;
+                    Player[A].MountOffsetY += 8;
                     */
                     Player[A].MountOffsetY = 8;
                 }
@@ -1964,7 +1964,7 @@ void PlayerFrame(int A)
                     Player[A].YoshiWingsFrame = 1;
                 else if(Player[A].Location.SpeedY < 0)
                 {
-                    Player[A].YoshiWingsFrameCount = Player[A].YoshiWingsFrameCount + 1;
+                    Player[A].YoshiWingsFrameCount += 1;
                     if(Player[A].YoshiWingsFrameCount < 6)
                         Player[A].YoshiWingsFrame = 1;
                     else if(Player[A].YoshiWingsFrameCount < 12)
@@ -1977,7 +1977,7 @@ void PlayerFrame(int A)
                 }
                 else
                 {
-                    Player[A].YoshiWingsFrameCount = Player[A].YoshiWingsFrameCount + 1;
+                    Player[A].YoshiWingsFrameCount += 1;
                     if(Player[A].YoshiWingsFrameCount < 12)
                         Player[A].YoshiWingsFrame = 1;
                     else if(Player[A].YoshiWingsFrameCount < 24)
@@ -1991,7 +1991,7 @@ void PlayerFrame(int A)
                 if(Player[A].GroundPound)
                     Player[A].YoshiWingsFrame = 0;
                 if(Player[A].Direction == 1)
-                    Player[A].YoshiWingsFrame = Player[A].YoshiWingsFrame + 2;
+                    Player[A].YoshiWingsFrame += 2;
             }
         }
     }
@@ -2002,7 +2002,7 @@ void PlayerFrame(int A)
             Player[A].YoshiWingsFrame = 1;
         else if(Player[A].Location.SpeedY < 0)
         {
-            Player[A].YoshiWingsFrameCount = Player[A].YoshiWingsFrameCount + 1;
+            Player[A].YoshiWingsFrameCount += 1;
             if(Player[A].YoshiWingsFrameCount < 6)
                 Player[A].YoshiWingsFrame = 1;
             else if(Player[A].YoshiWingsFrameCount < 12)
@@ -2015,7 +2015,7 @@ void PlayerFrame(int A)
         }
         else
         {
-            Player[A].YoshiWingsFrameCount = Player[A].YoshiWingsFrameCount + 1;
+            Player[A].YoshiWingsFrameCount += 1;
             if(Player[A].YoshiWingsFrameCount < 12)
                 Player[A].YoshiWingsFrame = 1;
             else if(Player[A].YoshiWingsFrameCount < 24)
@@ -2031,7 +2031,7 @@ void PlayerFrame(int A)
             Player[A].YoshiWingsFrame = 0;
 
         if(Player[A].Direction == 1)
-            Player[A].YoshiWingsFrame = Player[A].YoshiWingsFrame + 2;
+            Player[A].YoshiWingsFrame += 2;
     }
 }
 
@@ -2161,7 +2161,7 @@ void TailSwipe(int plr, bool boo, bool Stab, int StabDir)
     }
 
     if(Player[plr].Character == 4) // move tail down for toad
-        tailLoc.Y = tailLoc.Y + 4;
+        tailLoc.Y += 4;
 
     if(boo) // the bool flag means hit a block
     {
@@ -2214,7 +2214,7 @@ void TailSwipe(int plr, bool boo, bool Stab, int StabDir)
                                 {
                                     if(BlockHurts[Block[A].Type])
                                         PlaySound(SFX_Spring);
-                                    Player[plr].Location.Y = Player[plr].Location.Y - 0.1;
+                                    Player[plr].Location.Y -= 0.1;
                                     Player[plr].Location.SpeedY = Physics.PlayerJumpVelocity;
                                     Player[plr].StandingOnNPC = 0;
                                     if(Player[plr].Controls.Jump || Player[plr].Controls.AltJump)
@@ -2249,12 +2249,12 @@ void TailSwipe(int plr, bool boo, bool Stab, int StabDir)
                 stabLoc = NPC[A].Location;
                 if(NPCHeightGFX[NPC[A].Type] > NPC[A].Location.Height && NPC[A].Type != 8 && NPC[A].Type != 15 && NPC[A].Type != 205 && NPC[A].Type != 9 && NPC[A].Type != 51 && NPC[A].Type != 52 && NPC[A].Type != 74 && NPC[A].Type != 93 && NPC[A].Type != 245)
                 {
-                    stabLoc.Y = stabLoc.Y + stabLoc.Height;
+                    stabLoc.Y += stabLoc.Height;
                     stabLoc.Height = NPCHeightGFX[NPC[A].Type];
-                    stabLoc.Y = stabLoc.Y - stabLoc.Height;
+                    stabLoc.Y += -stabLoc.Height;
                 }
                 if(NPC[A].Type == 91 && Stab)
-                    stabLoc.Y = stabLoc.Y - stabLoc.Height;
+                    stabLoc.Y += -stabLoc.Height;
                 if(CheckCollision(tailLoc, stabLoc) && NPC[A].Killed == 0 && NPC[A].TailCD == 0 && !(StabDir != 0 && NPC[A].Type == 91))
                 {
                     oldNPC = NPC[A];
@@ -2356,12 +2356,12 @@ void YoshiHeight(int A)
 {
     if(Player[A].Mount == 3)
     {
-        Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+        Player[A].Location.Y += Player[A].Location.Height;
         if(Player[A].State == 1)
             Player[A].Location.Height = 54;
         else
             Player[A].Location.Height = 60;
-        Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+        Player[A].Location.Y += -Player[A].Location.Height;
     }
 }
 
@@ -2429,12 +2429,12 @@ void YoshiEat(int A)
                     NPC[B].Type = 139 + (iRand() % 9);
                     if(NPC[B].Type == 147)
                         NPC[B].Type = 92;
-                    NPC[B].Location.X = NPC[B].Location.X + NPC[B].Location.Width / 2.0;
-                    NPC[B].Location.Y = NPC[B].Location.Y + NPC[B].Location.Height / 2.0;
+                    NPC[B].Location.X += NPC[B].Location.Width / 2.0;
+                    NPC[B].Location.Y += NPC[B].Location.Height / 2.0;
                     NPC[B].Location.Width = NPCWidth[NPC[B].Type];
                     NPC[B].Location.Height = NPCHeight[NPC[B].Type];
-                    NPC[B].Location.X = NPC[B].Location.X - NPC[B].Location.Width / 2.0;
-                    NPC[B].Location.Y = NPC[B].Location.Y - NPC[B].Location.Height / 2.0;
+                    NPC[B].Location.X += -NPC[B].Location.Width / 2.0;
+                    NPC[B].Location.Y += -NPC[B].Location.Height / 2.0;
                 }
                 break;
             }
@@ -2461,7 +2461,7 @@ void YoshiSpit(int A)
         if(Player[A].Controls.Down)
         {
             Player[Player[A].YoshiPlayer].Location.X = Player[A].Location.X + Player[A].YoshiTX + Player[Player[A].YoshiPlayer].Location.Width * Player[A].Direction;
-            Player[Player[A].YoshiPlayer].Location.X = Player[Player[A].YoshiPlayer].Location.X + 5;
+            Player[Player[A].YoshiPlayer].Location.X += 5;
             Player[Player[A].YoshiPlayer].Location.Y = Player[A].Location.Y + Player[A].Location.Height - Player[Player[A].YoshiPlayer].Location.Height;
             Player[Player[A].YoshiPlayer].Location.SpeedX = 0 + Player[A].Location.SpeedX * 0.3;
             Player[Player[A].YoshiPlayer].Location.SpeedY = 1 + Player[A].Location.SpeedY * 0.3;
@@ -2469,7 +2469,7 @@ void YoshiSpit(int A)
         else
         {
             Player[Player[A].YoshiPlayer].Location.X = Player[A].Location.X + Player[A].YoshiTX + Player[Player[A].YoshiPlayer].Location.Width * Player[A].Direction;
-            Player[Player[A].YoshiPlayer].Location.X = Player[Player[A].YoshiPlayer].Location.X + 5;
+            Player[Player[A].YoshiPlayer].Location.X += 5;
             Player[Player[A].YoshiPlayer].Location.Y = Player[A].Location.Y + 1;
             Player[Player[A].YoshiPlayer].Location.SpeedX = 7 * Player[A].Direction + Player[A].Location.SpeedX * 0.3;
             Player[Player[A].YoshiPlayer].Location.SpeedY = -3 + Player[A].Location.SpeedY * 0.3;
@@ -2543,8 +2543,8 @@ void YoshiSpit(int A)
             NPC[Player[A].YoshiNPC].Location.X = Player[A].Location.X + Player[A].YoshiTX + 32 * Player[A].Direction;
             NPC[Player[A].YoshiNPC].Location.Y = Player[A].Location.Y + Player[A].YoshiTY;
             if(Player[A].Duck)
-                NPC[Player[A].YoshiNPC].Location.Y = NPC[Player[A].YoshiNPC].Location.Y - 8;
-            NPC[Player[A].YoshiNPC].Location.Y = NPC[Player[A].YoshiNPC].Location.Y - 2;
+                NPC[Player[A].YoshiNPC].Location.Y -= 8;
+            NPC[Player[A].YoshiNPC].Location.Y -= 2;
             NPC[Player[A].YoshiNPC].Location.SpeedX = 0;
             NPC[Player[A].YoshiNPC].Location.SpeedY = 0;
 
@@ -2609,7 +2609,7 @@ void YoshiPound(int A, int mount, bool BreakBlocks)
             if(NPC[B].Hidden == false && NPC[B].Active && NPC[B].Effect == 0)
             {
                 tempLocation2 = NPC[B].Location;
-                tempLocation2.Y = tempLocation2.Y + tempLocation2.Height - 4;
+                tempLocation2.Y += tempLocation2.Height - 4;
                 tempLocation2.Height = 8;
                 if(CheckCollision(tempLocation, tempLocation2))
                 {
@@ -2746,12 +2746,12 @@ void SizeCheck(int A)
         }
         if(Player[A].Location.Width != 22.0)
         {
-            Player[A].Location.X = Player[A].Location.X + Player[A].Location.Width / 2.0 - 11;
+            Player[A].Location.X += Player[A].Location.Width / 2.0 - 11;
             Player[A].Location.Width = 22;
         }
         if(Player[A].Location.Height != 26.0)
         {
-            Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height - 26;
+            Player[A].Location.Y += Player[A].Location.Height - 26;
             Player[A].Location.Height = 26;
         }
     }
@@ -2761,18 +2761,18 @@ void SizeCheck(int A)
         {
             if(Player[A].Location.Height != Physics.PlayerHeight[Player[A].Character][Player[A].State])
             {
-                Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                Player[A].Location.Y += Player[A].Location.Height;
                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
-                Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                Player[A].Location.Y += -Player[A].Location.Height;
             }
         }
         else
         {
             if(Player[A].Location.Height != Physics.PlayerDuckHeight[Player[A].Character][Player[A].State])
             {
-                Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                Player[A].Location.Y += Player[A].Location.Height;
                 Player[A].Location.Height = Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
-                Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                Player[A].Location.Y += -Player[A].Location.Height;
             }
         }
     }
@@ -2782,27 +2782,27 @@ void SizeCheck(int A)
         {
             if(Player[A].Location.Height != Physics.PlayerDuckHeight[Player[A].Character][2])
             {
-                Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                Player[A].Location.Y += Player[A].Location.Height;
                 Player[A].Location.Height = Physics.PlayerDuckHeight[Player[A].Character][2];
-                Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                Player[A].Location.Y += -Player[A].Location.Height;
             }
         }
         else if(Player[A].Character == 2 && Player[A].State > 1)
         {
             if(Player[A].Location.Height != Physics.PlayerHeight[1][2])
             {
-                Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                Player[A].Location.Y += Player[A].Location.Height;
                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
-                Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                Player[A].Location.Y += -Player[A].Location.Height;
             }
         }
         else
         {
             if(Player[A].Location.Height != Physics.PlayerHeight[1][2])
             {
-                Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                Player[A].Location.Y += Player[A].Location.Height;
                 Player[A].Location.Height = Physics.PlayerHeight[1][2];
-                Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                Player[A].Location.Y += -Player[A].Location.Height;
             }
         }
     }
@@ -2810,9 +2810,9 @@ void SizeCheck(int A)
     {
         if(Player[A].Location.Height != 128)
         {
-            Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+            Player[A].Location.Y += Player[A].Location.Height;
             Player[A].Location.Height = 128;
-            Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+            Player[A].Location.Y += -Player[A].Location.Height;
         }
     }
     else if(Player[A].Mount == 3)
@@ -2823,18 +2823,18 @@ void SizeCheck(int A)
             {
                 if(Player[A].Location.Height != Physics.PlayerHeight[1][2])
                 {
-                    Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                    Player[A].Location.Y += Player[A].Location.Height;
                     Player[A].Location.Height = Physics.PlayerHeight[1][2];
-                    Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                    Player[A].Location.Y += -Player[A].Location.Height;
                 }
             }
             else
             {
                 if(Player[A].Location.Height != Physics.PlayerHeight[2][2])
                 {
-                    Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                    Player[A].Location.Y += Player[A].Location.Height;
                     Player[A].Location.Height = Physics.PlayerHeight[2][2];
-                    Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                    Player[A].Location.Y += -Player[A].Location.Height;
                 }
             }
         }
@@ -2842,9 +2842,9 @@ void SizeCheck(int A)
         {
             if(Player[A].Location.Height != 31)
             {
-                Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                Player[A].Location.Y += Player[A].Location.Height;
                 Player[A].Location.Height = 31;
-                Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                Player[A].Location.Y += -Player[A].Location.Height;
             }
         }
     }
@@ -2853,18 +2853,18 @@ void SizeCheck(int A)
     {
         if(Player[A].Location.Width != 127.9)
         {
-            Player[A].Location.X = Player[A].Location.X + Player[A].Location.Width / 2.0;
+            Player[A].Location.X += Player[A].Location.Width / 2.0;
             Player[A].Location.Width = 127.9;
-            Player[A].Location.X = Player[A].Location.X - Player[A].Location.Width / 2.0;
+            Player[A].Location.X += -Player[A].Location.Width / 2.0;
         }
     }
     else
     {
         if(Player[A].Location.Width != Physics.PlayerWidth[Player[A].Character][Player[A].State])
         {
-            Player[A].Location.X = Player[A].Location.X + Player[A].Location.Width / 2.0;
+            Player[A].Location.X += Player[A].Location.Width / 2.0;
             Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
-            Player[A].Location.X = Player[A].Location.X - Player[A].Location.Width / 2.0;
+            Player[A].Location.X += -Player[A].Location.Width / 2.0;
         }
     }
 }
@@ -2936,9 +2936,9 @@ void YoshiEatCode(int A)
                     {
                         tempLocation = Background[B].Location;
                         tempLocation.Width = 16;
-                        tempLocation.X = tempLocation.X + 8;
+                        tempLocation.X += 8;
                         tempLocation.Height = 26;
-                        tempLocation.Y = tempLocation.Y + 2;
+                        tempLocation.Y += 2;
                         if(CheckCollision(Player[A].Location, tempLocation))
                         {
                             PlaySound(SFX_Key);
@@ -2952,7 +2952,7 @@ void YoshiEatCode(int A)
             else if(NPC[Player[A].YoshiNPC].Type == 45)
                 NPC[Player[A].YoshiNPC].Special = 1;
             if(Player[A].FireBallCD > 0)
-                Player[A].FireBallCD = Player[A].FireBallCD - 1;
+                Player[A].FireBallCD -= 1;
             if(Player[A].Controls.Run)
             {
                 if(Player[A].RunRelease)
@@ -2984,16 +2984,16 @@ void YoshiEatCode(int A)
                 if(Player[A].MountType <= 4)
                 {
                     if(Player[A].YoshiTongueLength < 64 * 0.7)
-                        Player[A].YoshiTongueLength = Player[A].YoshiTongueLength + 6;
+                        Player[A].YoshiTongueLength += 6;
                     else
-                        Player[A].YoshiTongueLength = Player[A].YoshiTongueLength + 3;
+                        Player[A].YoshiTongueLength += 3;
                 }
                 else
                 {
                     if(Player[A].YoshiTongueLength < 80 * 0.7)
-                        Player[A].YoshiTongueLength = Player[A].YoshiTongueLength + 7.5;
+                        Player[A].YoshiTongueLength += 7.5;
                     else
-                        Player[A].YoshiTongueLength = Player[A].YoshiTongueLength + 3.75;
+                        Player[A].YoshiTongueLength += 3.75;
                 }
 
                 if(Player[A].YoshiTongueLength >= 64 && Player[A].MountType <= 4)
@@ -3006,16 +3006,16 @@ void YoshiEatCode(int A)
                 if(Player[A].MountType <= 4)
                 {
                     if(Player[A].YoshiTongueLength < 64 * 0.7)
-                        Player[A].YoshiTongueLength = Player[A].YoshiTongueLength - 6;
+                        Player[A].YoshiTongueLength -= 6;
                     else
-                        Player[A].YoshiTongueLength = Player[A].YoshiTongueLength - 3;
+                        Player[A].YoshiTongueLength -= 3;
                 }
                 else
                 {
                     if(Player[A].YoshiTongueLength < 80 * 0.7)
-                        Player[A].YoshiTongueLength = Player[A].YoshiTongueLength - 7.5;
+                        Player[A].YoshiTongueLength -= 7.5;
                     else
-                        Player[A].YoshiTongueLength = Player[A].YoshiTongueLength - 3.75;
+                        Player[A].YoshiTongueLength -= 3.75;
                 }
                 if(Player[A].YoshiTongueLength <= -8)
                 {
@@ -3029,18 +3029,18 @@ void YoshiEatCode(int A)
             Player[A].YoshiTongueX = Player[A].Location.X + Player[A].Location.Width / 2.0;
             if(Player[A].Controls.Up || (Player[A].StandingOnNPC == 0 && Player[A].Slope == 0 && Player[A].Location.SpeedY != 0 && Player[A].Controls.Down == false))
             {
-                Player[A].YoshiTongueX = Player[A].YoshiTongueX + Player[A].Direction * (22);
+                Player[A].YoshiTongueX += Player[A].Direction * (22);
                 Player[A].YoshiTongue.Y = Player[A].Location.Y + 8 + (Player[A].Location.Height - 54);
                 Player[A].YoshiTongue.X = Player[A].YoshiTongueX + Player[A].YoshiTongueLength * Player[A].Direction;
             }
             else
             {
-                Player[A].YoshiTongueX = Player[A].YoshiTongueX + Player[A].Direction * (34);
+                Player[A].YoshiTongueX += Player[A].Direction * (34);
                 Player[A].YoshiTongue.Y = Player[A].Location.Y + 30 + (Player[A].Location.Height - 54);
                 Player[A].YoshiTongue.X = Player[A].YoshiTongueX + Player[A].YoshiTongueLength * Player[A].Direction;
             }
             if(Player[A].Direction == -1)
-                Player[A].YoshiTongue.X = Player[A].YoshiTongue.X - 16;
+                Player[A].YoshiTongue.X -= 16;
             if(Player[A].YoshiNPC == 0 && Player[A].YoshiPlayer == 0)
             {
                 YoshiEat(A);
@@ -3076,10 +3076,10 @@ void YoshiEatCode(int A)
             else if(NPC[Player[A].YoshiNPC].Type == 72)
                 NPC[Player[A].YoshiNPC].Type = 73;
             else if(NPC[Player[A].YoshiNPC].Type >= 109 && NPC[Player[A].YoshiNPC].Type <= 112)
-                NPC[Player[A].YoshiNPC].Type = NPC[Player[A].YoshiNPC].Type + 4;
+                NPC[Player[A].YoshiNPC].Type += 4;
             else if(NPC[Player[A].YoshiNPC].Type >= 121 && NPC[Player[A].YoshiNPC].Type <= 124)
             {
-                NPC[Player[A].YoshiNPC].Type = NPC[Player[A].YoshiNPC].Type - 8;
+                NPC[Player[A].YoshiNPC].Type -= 8;
                 NPC[Player[A].YoshiNPC].Special = 0;
             }
             else if(NPC[Player[A].YoshiNPC].Type == 173 || NPC[Player[A].YoshiNPC].Type == 176)
@@ -3120,12 +3120,12 @@ void YoshiEatCode(int A)
                 NPC[Player[A].YoshiNPC].Type = 139 + B;
                 if(NPC[Player[A].YoshiNPC].Type == 147)
                     NPC[Player[A].YoshiNPC].Type = 92;
-                NPC[Player[A].YoshiNPC].Location.X = NPC[Player[A].YoshiNPC].Location.X + NPC[Player[A].YoshiNPC].Location.Width / 2.0;
-                NPC[Player[A].YoshiNPC].Location.Y = NPC[Player[A].YoshiNPC].Location.Y + NPC[Player[A].YoshiNPC].Location.Height / 2.0;
+                NPC[Player[A].YoshiNPC].Location.X += NPC[Player[A].YoshiNPC].Location.Width / 2.0;
+                NPC[Player[A].YoshiNPC].Location.Y += NPC[Player[A].YoshiNPC].Location.Height / 2.0;
                 NPC[Player[A].YoshiNPC].Location.Width = NPCWidth[NPC[Player[A].YoshiNPC].Type];
                 NPC[Player[A].YoshiNPC].Location.Height = NPCHeight[NPC[Player[A].YoshiNPC].Type];
-                NPC[Player[A].YoshiNPC].Location.X = NPC[Player[A].YoshiNPC].Location.X - NPC[Player[A].YoshiNPC].Location.Width / 2.0;
-                NPC[Player[A].YoshiNPC].Location.Y = NPC[Player[A].YoshiNPC].Location.Y - NPC[Player[A].YoshiNPC].Location.Height / 2.0;
+                NPC[Player[A].YoshiNPC].Location.X += -NPC[Player[A].YoshiNPC].Location.Width / 2.0;
+                NPC[Player[A].YoshiNPC].Location.Y += -NPC[Player[A].YoshiNPC].Location.Height / 2.0;
                 NPC[Player[A].YoshiNPC].Effect = 6;
                 NPC[Player[A].YoshiNPC].Effect2 = A;
                 NPC[Player[A].YoshiNPC].Active = false;
@@ -3133,12 +3133,12 @@ void YoshiEatCode(int A)
             else if(Player[A].MountType == 8 && NPCIsABonus[NPC[Player[A].YoshiNPC].Type] == false)
             {
                 NPC[Player[A].YoshiNPC].Type = 237;
-                NPC[Player[A].YoshiNPC].Location.X = NPC[Player[A].YoshiNPC].Location.X + NPC[Player[A].YoshiNPC].Location.Width / 2.0;
-                NPC[Player[A].YoshiNPC].Location.Y = NPC[Player[A].YoshiNPC].Location.Y + NPC[Player[A].YoshiNPC].Location.Height / 2.0;
+                NPC[Player[A].YoshiNPC].Location.X += NPC[Player[A].YoshiNPC].Location.Width / 2.0;
+                NPC[Player[A].YoshiNPC].Location.Y += NPC[Player[A].YoshiNPC].Location.Height / 2.0;
                 NPC[Player[A].YoshiNPC].Location.Width = NPCWidth[NPC[Player[A].YoshiNPC].Type];
                 NPC[Player[A].YoshiNPC].Location.Height = NPCHeight[NPC[Player[A].YoshiNPC].Type];
-                NPC[Player[A].YoshiNPC].Location.X = NPC[Player[A].YoshiNPC].Location.X - NPC[Player[A].YoshiNPC].Location.Width / 2.0;
-                NPC[Player[A].YoshiNPC].Location.Y = NPC[Player[A].YoshiNPC].Location.Y - NPC[Player[A].YoshiNPC].Location.Height / 2.0;
+                NPC[Player[A].YoshiNPC].Location.X += -NPC[Player[A].YoshiNPC].Location.Width / 2.0;
+                NPC[Player[A].YoshiNPC].Location.Y += -NPC[Player[A].YoshiNPC].Location.Height / 2.0;
                 NPC[Player[A].YoshiNPC].Effect = 6;
                 NPC[Player[A].YoshiNPC].Effect2 = A;
                 NPC[Player[A].YoshiNPC].Active = false;
@@ -3156,14 +3156,14 @@ void YoshiEatCode(int A)
                     NPC[Player[A].YoshiNPC].Killed = 9;
                     Player[A].YoshiNPC = 0;
                     Player[A].FireBallCD = 30;
-                    Coins = Coins + 1;
+                    Coins += 1;
                     if(Coins >= 100)
                     {
                         if(Lives < 99)
                         {
-                            Lives = Lives + 1;
+                            Lives += 1;
                             PlaySound(SFX_1up);
-                            Coins = Coins - 100;
+                            Coins -= 100;
                         }
                         else
                             Coins = 99;
@@ -3218,7 +3218,7 @@ void StealBonus()
                 {
                     if(Player[A].Controls.Jump || Player[A].Controls.Run)
                     {
-                        Lives = Lives - 1;
+                        Lives -= 1;
                         if(B == 1)
                             C = -40;
                         if(B == 2)
@@ -3266,43 +3266,43 @@ void ClownCar()
             {
                 if(Player[A].Controls.Left)
                 {
-                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.1;
+                    Player[A].Location.SpeedX -= 0.1;
                     if(Player[A].Location.SpeedX > 0)
-                        Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.15;
+                        Player[A].Location.SpeedX -= 0.15;
                 }
                 else if(Player[A].Controls.Right)
                 {
-                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.1;
+                    Player[A].Location.SpeedX += 0.1;
                     if(Player[A].Location.SpeedX < 0)
-                        Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.15;
+                        Player[A].Location.SpeedX += 0.15;
                 }
                 else
                 {
                     if(Player[A].Location.SpeedX > 0.2)
-                        Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.05;
+                        Player[A].Location.SpeedX -= 0.05;
                     else if(Player[A].Location.SpeedX < -0.2)
-                        Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.05;
+                        Player[A].Location.SpeedX += 0.05;
                     else
                         Player[A].Location.SpeedX = 0;
                 }
                 if(Player[A].Controls.Up)
                 {
-                    Player[A].Location.SpeedY = Player[A].Location.SpeedY - 0.1;
+                    Player[A].Location.SpeedY -= 0.1;
                     if(Player[A].Location.SpeedY > 0)
-                        Player[A].Location.SpeedY = Player[A].Location.SpeedY - 0.2;
+                        Player[A].Location.SpeedY -= 0.2;
                 }
                 else if(Player[A].Controls.Down)
                 {
-                    Player[A].Location.SpeedY = Player[A].Location.SpeedY + 0.2;
+                    Player[A].Location.SpeedY += 0.2;
                     if(Player[A].Location.SpeedY < 0)
-                        Player[A].Location.SpeedY = Player[A].Location.SpeedY + 0.2;
+                        Player[A].Location.SpeedY += 0.2;
                 }
                 else
                 {
                     if(Player[A].Location.SpeedY > 0.1)
-                        Player[A].Location.SpeedY = Player[A].Location.SpeedY - 0.1;
+                        Player[A].Location.SpeedY -= 0.1;
                     else if(Player[A].Location.SpeedY < -0.1)
-                        Player[A].Location.SpeedY = Player[A].Location.SpeedY + 0.1;
+                        Player[A].Location.SpeedY += 0.1;
                     else
                         Player[A].Location.SpeedY = 0;
                 }
@@ -3328,19 +3328,19 @@ void ClownCar()
                 NPC[numNPCs].Location.SpeedX = 0;
                 NPC[numNPCs].Location.SpeedY = 0;
             }
-            NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y + NPC[numNPCs].Location.SpeedY;
-            NPC[numNPCs].Location.X = NPC[numNPCs].Location.X + NPC[numNPCs].Location.SpeedX;
+            NPC[numNPCs].Location.Y += NPC[numNPCs].Location.SpeedY;
+            NPC[numNPCs].Location.X += NPC[numNPCs].Location.SpeedX;
             NPC[numNPCs].Section = Player[A].Section;
             for(B = 1; B <= numPlayers; B++)
             {
                 if(Player[B].StandingOnTempNPC == 56)
                 {
                     Player[B].StandingOnNPC = numNPCs;
-                    Player[B].Location.X = Player[B].Location.X + double(Player[A].mountBump);
+                    Player[B].Location.X += double(Player[A].mountBump);
                     if(Player[B].Effect != 0)
                     {
                         Player[B].Location.Y = Player[A].Location.Y - Player[B].Location.Height;
-                        Player[B].Location.X = Player[B].Location.X + Player[A].Location.SpeedX;
+                        Player[B].Location.X += Player[A].Location.SpeedX;
                     }
                 }
             }
@@ -3350,7 +3350,7 @@ void ClownCar()
                 if(NPC[B].standingOnPlayer == A && NPC[B].Type != 50)
                 {
                     if(Player[A].Effect == 0)
-                        NPC[B].Location.X = NPC[B].Location.X + Player[A].Location.SpeedX + double(Player[A].mountBump);
+                        NPC[B].Location.X += Player[A].Location.SpeedX + double(Player[A].mountBump);
                     NPC[B].TimeLeft = 100;
                     NPC[B].Location.SpeedY = Player[A].Location.SpeedY;
                     NPC[B].Location.SpeedX = 0;
@@ -3399,9 +3399,9 @@ void ClownCar()
                     }
                     tempBool = false;
                     tempLocation = NPC[B].Location;
-                    tempLocation.Y = tempLocation.Y + tempLocation.Height + 0.1;
-                    tempLocation.X = tempLocation.X + 0.5;
-                    tempLocation.Width = tempLocation.Width - 1;
+                    tempLocation.Y += tempLocation.Height + 0.1;
+                    tempLocation.X += 0.5;
+                    tempLocation.Width -= 1;
                     tempLocation.Height = 1;
                     for(int numNPCsMax10 = numNPCs, C = 1; C <= numNPCsMax10; C++)
                     {
@@ -3431,13 +3431,13 @@ void WaterCheck(int A)
 
     if(Player[A].Wet > 0)
     {
-        Player[A].Wet = Player[A].Wet - 1;
+        Player[A].Wet -= 1;
         Player[A].Multiplier = 0;
     }
 
     if(Player[A].Quicksand > 0)
     {
-        Player[A].Quicksand = Player[A].Quicksand - 1;
+        Player[A].Quicksand -= 1;
         if(Player[A].Quicksand == 0)
             Player[A].WetFrame = false;
     }
@@ -3556,7 +3556,7 @@ void Tanooki(int A)
         if(Player[A].Location.SpeedX >= -0.5 && Player[A].Location.SpeedX <= 0.5)
             Player[A].Location.SpeedX = 0;
         if(Player[A].Location.SpeedY < 8)
-            Player[A].Location.SpeedY = Player[A].Location.SpeedY + 0.25;
+            Player[A].Location.SpeedY += 0.25;
     }
 
     if(Player[A].StonedCD == 0)
@@ -3571,11 +3571,11 @@ void Tanooki(int A)
             Player[A].Effect = 500;
     }
     else
-        Player[A].StonedCD = Player[A].StonedCD - 1;
+        Player[A].StonedCD -= 1;
 
     if(Player[A].Stoned)
     {
-        Player[A].StonedTime = Player[A].StonedTime + 1;
+        Player[A].StonedTime += 1;
         if(Player[A].StonedTime >= 240)
         {
             Player[A].Effect = 500;
@@ -3583,7 +3583,7 @@ void Tanooki(int A)
         }
         else if(Player[A].StonedTime >= 180)
         {
-            Player[A].Immune = Player[A].Immune + 1;
+            Player[A].Immune += 1;
             if(Player[A].Immune % 3 == 0)
             {
                 Player[A].Immune2 = !Player[A].Immune2;
@@ -3688,11 +3688,11 @@ void PowerUps(int A)
                                 NPC[numNPCs].Location.SpeedY = -8 + Player[A].Location.SpeedY * 0.3;
                             else
                                 NPC[numNPCs].Location.SpeedY = -8 + NPC[Player[A].StandingOnNPC].Location.SpeedY * 0.3;
-                            NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y - 24;
-                            NPC[numNPCs].Location.X = NPC[numNPCs].Location.X - 6 * Player[A].Direction;
+                            NPC[numNPCs].Location.Y -= 24;
+                            NPC[numNPCs].Location.X += -6 * Player[A].Direction;
                             if(Player[A].Character == 3)
                             {
-                                NPC[numNPCs].Location.SpeedY = NPC[numNPCs].Location.SpeedY + 1;
+                                NPC[numNPCs].Location.SpeedY += 1;
                                 NPC[numNPCs].Location.SpeedX = NPC[numNPCs].Location.SpeedX * 1.5;
                             }
                             else if(Player[A].Character == 4)
@@ -3709,12 +3709,12 @@ void PowerUps(int A)
                             else
                                 NPC[numNPCs].Location.SpeedY = -5 + NPC[Player[A].StandingOnNPC].Location.SpeedY * 0.3;
                             if(Player[A].Character == 3)
-                                NPC[numNPCs].Location.SpeedY = NPC[numNPCs].Location.SpeedY + 1;
+                                NPC[numNPCs].Location.SpeedY += 1;
                             else if(Player[A].Character == 4)
                             {
                                 NPC[numNPCs].Location.SpeedY = -5;
                                 NPC[numNPCs].Location.SpeedX = 10 * Player[A].Direction + Player[A].Location.SpeedX;
-                                NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y - 12;
+                                NPC[numNPCs].Location.Y -= 12;
                             }
                         }
                         if(Player[A].Character == 4)
@@ -3852,7 +3852,7 @@ void PowerUps(int A)
         }
         if(Player[A].TailCount > 0)
         {
-            Player[A].TailCount = Player[A].TailCount + 1;
+            Player[A].TailCount += 1;
             if(Player[A].TailCount == 25)
                 Player[A].TailCount = 0;
             if(Player[A].TailCount % 7 == 0 || (Player[A].SpinJump && Player[A].TailCount) % 2 == 0)
@@ -3874,7 +3874,7 @@ void PowerUps(int A)
         if(Player[A].Bombs > 0 && Player[A].Controls.AltRun && Player[A].RunRelease)
         {
             Player[A].FireBallCD = 10;
-            Player[A].Bombs = Player[A].Bombs - 1;
+            Player[A].Bombs -= 1;
             numNPCs++;
             NPC[numNPCs] = NPC_t();
             NPC[numNPCs].Active = true;
@@ -3917,9 +3917,9 @@ void PowerUps(int A)
                     if(Player[A].Controls.Down && Player[A].Duck == false && Player[A].Mount == 0)
                     {
                         Player[A].Duck = true;
-                        Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                        Player[A].Location.Y += Player[A].Location.Height;
                         Player[A].Location.Height = Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
-                        Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                        Player[A].Location.Y += -Player[A].Location.Height;
                     }
                     else if(Player[A].Controls.Down == false && Player[A].Duck)
                     {
@@ -3950,15 +3950,15 @@ void PowerUps(int A)
 
 
 // cooldown timer
-    Player[A].FireBallCD2 = Player[A].FireBallCD2 - 1;
+    Player[A].FireBallCD2 -= 1;
     if(Player[A].FireBallCD2 < 0)
         Player[A].FireBallCD2 = 0;
 
     if(!(Player[A].Character == 3 && NPC[Player[A].HoldingNPC].Type == 13))
     {
-        Player[A].FireBallCD = Player[A].FireBallCD - 1;
+        Player[A].FireBallCD -= 1;
         if(FlameThrower)
-            Player[A].FireBallCD = Player[A].FireBallCD - 3;
+            Player[A].FireBallCD -= 3;
         if(Player[A].FireBallCD < 0)
             Player[A].FireBallCD = 0;
     }
@@ -4214,9 +4214,9 @@ static SDL_INLINE bool checkWarp(Warp_t &warp, int B, Player_t &plr, int A, bool
                     else if(Background[C].Type == 141)
                     {
                         Location_t bLoc = Background[C].Location;
-                        bLoc.X = bLoc.X + bLoc.Width / 2.0;
+                        bLoc.X += bLoc.Width / 2.0;
                         bLoc.Width = 104;
-                        bLoc.X = bLoc.X - bLoc.Width / 2.0;
+                        bLoc.X += -bLoc.Width / 2.0;
                         NewEffect(103, bLoc);
                     }
                 }
@@ -4325,9 +4325,9 @@ void PlayerCollide(int A)
                     Player[A].Location.SpeedY = Physics.PlayerJumpVelocity;
                     Player[A].Jump = Physics.PlayerHeadJumpHeight;
                     if(Player[A].Character == 2)
-                        Player[A].Jump = Player[A].Jump + 3;
+                        Player[A].Jump += 3;
                     if(Player[A].SpinJump)
-                        Player[A].Jump = Player[A].Jump - 6;
+                        Player[A].Jump -= 6;
                     Player[B].Jump = 0;
                     if(Player[B].Location.SpeedY <= 0)
                         Player[B].Location.SpeedY = 0.1;
@@ -4343,9 +4343,9 @@ void PlayerCollide(int A)
                     Player[B].Location.SpeedY = Physics.PlayerJumpVelocity;
                     Player[B].Jump = Physics.PlayerHeadJumpHeight;
                     if(Player[B].Character == 2)
-                        Player[A].Jump = Player[A].Jump + 3;
+                        Player[A].Jump += 3;
                     if(Player[A].SpinJump)
-                        Player[A].Jump = Player[A].Jump - 6;
+                        Player[A].Jump -= 6;
                     Player[A].Jump = 0;
                     if(Player[A].Location.SpeedY <= 0)
                         Player[A].Location.SpeedY = 0.1;
@@ -4437,7 +4437,7 @@ void PlayerGrabCode(int A, bool DontResetGrabTime)
                     NPCFrames(Player[A].StandingOnNPC);
                     if(NPC[Player[A].StandingOnNPC].Type == 91)
                     {
-                        Player[A].Location.SpeedX = Player[A].Location.SpeedX + NPC[Player[A].StandingOnNPC].Location.SpeedX;
+                        Player[A].Location.SpeedX += NPC[Player[A].StandingOnNPC].Location.SpeedX;
                         NPC[Player[A].StandingOnNPC].Direction = Player[A].Direction;
                         NPC[Player[A].StandingOnNPC].Generator = false;
                         NPC[Player[A].StandingOnNPC].Frame = 0;
@@ -4468,12 +4468,12 @@ void PlayerGrabCode(int A, bool DontResetGrabTime)
                             NPC[Player[A].StandingOnNPC].Type = 139 + B;
                             if(NPC[Player[A].StandingOnNPC].Type == 147)
                                 NPC[Player[A].StandingOnNPC].Type = 92;
-                            NPC[Player[A].StandingOnNPC].Location.X = NPC[Player[A].StandingOnNPC].Location.X + NPC[Player[A].StandingOnNPC].Location.Width / 2.0;
-                            NPC[Player[A].StandingOnNPC].Location.Y = NPC[Player[A].StandingOnNPC].Location.Y + NPC[Player[A].StandingOnNPC].Location.Height / 2.0;
+                            NPC[Player[A].StandingOnNPC].Location.X += NPC[Player[A].StandingOnNPC].Location.Width / 2.0;
+                            NPC[Player[A].StandingOnNPC].Location.Y += NPC[Player[A].StandingOnNPC].Location.Height / 2.0;
                             NPC[Player[A].StandingOnNPC].Location.Width = NPCWidth[NPC[Player[A].StandingOnNPC].Type];
                             NPC[Player[A].StandingOnNPC].Location.Height = NPCHeight[NPC[Player[A].StandingOnNPC].Type];
-                            NPC[Player[A].StandingOnNPC].Location.X = NPC[Player[A].StandingOnNPC].Location.X - NPC[Player[A].StandingOnNPC].Location.Width / 2.0;
-                            NPC[Player[A].StandingOnNPC].Location.Y = NPC[Player[A].StandingOnNPC].Location.Y - NPC[Player[A].StandingOnNPC].Location.Height / 2.0;
+                            NPC[Player[A].StandingOnNPC].Location.X += -NPC[Player[A].StandingOnNPC].Location.Width / 2.0;
+                            NPC[Player[A].StandingOnNPC].Location.Y += -NPC[Player[A].StandingOnNPC].Location.Height / 2.0;
                         }
                         NPCFrames(Player[A].StandingOnNPC);
                         Player[A].StandingOnNPC = 0;
@@ -4491,7 +4491,7 @@ void PlayerGrabCode(int A, bool DontResetGrabTime)
                         Player[A].GrabSpeed = Player[A].Location.SpeedX;
                     }
                     Player[A].Location.SpeedX = 0;
-                    Player[A].GrabTime = Player[A].GrabTime + 1;
+                    Player[A].GrabTime += 1;
                     Player[A].Slide = false;
                 }
             }
@@ -4521,7 +4521,7 @@ void PlayerGrabCode(int A, bool DontResetGrabTime)
             }
             if(NPC[Player[A].HoldingNPC].Type == 279)
             {
-                NPC[Player[A].HoldingNPC].Special2 = NPC[Player[A].HoldingNPC].Special2 + 1;
+                NPC[Player[A].HoldingNPC].Special2 += 1;
                 if(Player[A].SpinJump)
                 {
                     if(NPC[Player[A].HoldingNPC].Special3 == 0)
@@ -4773,7 +4773,7 @@ void PlayerGrabCode(int A, bool DontResetGrabTime)
                     if(NPC[Player[A].HoldingNPC].Type == 272)
                         NPC[Player[A].HoldingNPC].Projectile = true;
                     if(Player[A].StandingOnNPC != 0)
-                        NPC[Player[A].HoldingNPC].Location.Y = NPC[Player[A].HoldingNPC].Location.Y + NPC[Player[A].StandingOnNPC].Location.SpeedY;
+                        NPC[Player[A].HoldingNPC].Location.Y += NPC[Player[A].StandingOnNPC].Location.SpeedY;
                 }
                 if(NPC[Player[A].HoldingNPC].Type == 13 || NPC[Player[A].HoldingNPC].Type == 265 || NPC[Player[A].HoldingNPC].Type == 291)
                 {
@@ -4859,9 +4859,9 @@ void PlayerGrabCode(int A, bool DontResetGrabTime)
             }
             if(NPC[Player[A].HoldingNPC].Type == 134 && NPC[Player[A].HoldingNPC].Location.SpeedX != 0)
             {
-                NPC[Player[A].HoldingNPC].Location.SpeedX = NPC[Player[A].HoldingNPC].Location.SpeedX + Player[A].Location.SpeedX * 0.5;
+                NPC[Player[A].HoldingNPC].Location.SpeedX += Player[A].Location.SpeedX * 0.5;
                 if(Player[A].StandingOnNPC != 0)
-                    NPC[Player[A].HoldingNPC].Location.SpeedX = NPC[Player[A].HoldingNPC].Location.SpeedX + NPC[Player[A].StandingOnNPC].Location.SpeedX;
+                    NPC[Player[A].HoldingNPC].Location.SpeedX += NPC[Player[A].StandingOnNPC].Location.SpeedX;
             }
             if(NPC[Player[A].HoldingNPC].Type == 13 && NPC[Player[A].HoldingNPC].Special == 4) // give toad fireballs a little spunk
             {
@@ -4871,7 +4871,7 @@ void PlayerGrabCode(int A, bool DontResetGrabTime)
             if(NPC[Player[A].HoldingNPC].Type == 291)
             {
                 if(Player[A].Location.SpeedX != 0 && NPC[Player[A].HoldingNPC].Location.SpeedX != 0)
-                    NPC[Player[A].HoldingNPC].Location.SpeedX = NPC[Player[A].HoldingNPC].Location.SpeedX + Player[A].Location.SpeedX * 0.5;
+                    NPC[Player[A].HoldingNPC].Location.SpeedX += Player[A].Location.SpeedX * 0.5;
             }
 
         if(NPC[Player[A].HoldingNPC].Type == 292)
@@ -5014,7 +5014,7 @@ void LinkFrame(int A)
         Player[A].Frame = 1;
         Player[A].MountFrame = SpecialFrame[2];
         if(Player[A].Direction == 1)
-            Player[A].MountFrame = Player[A].MountFrame + 4;
+            Player[A].MountFrame += 4;
     }
     else if(Player[A].Duck) // Ducking
         Player[A].Frame = 5;
@@ -5025,7 +5025,7 @@ void LinkFrame(int A)
             if(Player[A].Frame != 1 && Player[A].Frame != 2 && Player[A].Frame != 3 && Player[A].Frame != 4)
                 Player[A].FrameCount = 6;
 
-            Player[A].FrameCount = Player[A].FrameCount + 1;
+            Player[A].FrameCount += 1;
 
             if(Player[A].FrameCount < 6)
                 Player[A].Frame = 3;
@@ -5065,24 +5065,24 @@ void LinkFrame(int A)
         Player[A].Frame = 1;
     else // Running
     {
-        Player[A].FrameCount = Player[A].FrameCount + 1;
+        Player[A].FrameCount += 1;
 
         if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed - 1.5 || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed + 1.5)
-            Player[A].FrameCount = Player[A].FrameCount + 1;
+            Player[A].FrameCount += 1;
 
         if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed)
-            Player[A].FrameCount = Player[A].FrameCount + 1;
+            Player[A].FrameCount += 1;
 
         if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed + 1 || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed - 1)
-            Player[A].FrameCount = Player[A].FrameCount + 1;
+            Player[A].FrameCount += 1;
 
         if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed + 2 || Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed - 2)
-            Player[A].FrameCount = Player[A].FrameCount + 1;
+            Player[A].FrameCount += 1;
 
         if(Player[A].FrameCount >= 8)
         {
             Player[A].FrameCount = 0;
-            Player[A].Frame = Player[A].Frame - 1;
+            Player[A].Frame -= 1;
         }
 
         if(Player[A].Frame <= 0)
@@ -5147,8 +5147,8 @@ void PlayerEffects(int A)
                 Player[A].State = 2;
                 if(Player[A].Mount == 0)
                 {
-                    Player[A].Location.X = Player[A].Location.X - Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
+                    Player[A].Location.X += -Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
+                    Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
                     Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
                     Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
                 }
@@ -5158,7 +5158,7 @@ void PlayerEffects(int A)
                 }
                 else if(Player[A].Character == 2 && Player[A].Mount != 2)
                 {
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
+                    Player[A].Location.Y += -Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
                     Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
                 }
             }
@@ -5167,8 +5167,8 @@ void PlayerEffects(int A)
                 Player[A].State = 1;
                 if(Player[A].Mount == 0)
                 {
-                    Player[A].Location.X = Player[A].Location.X - Physics.PlayerWidth[Player[A].Character][1] * 0.5 + Physics.PlayerWidth[Player[A].Character][2] * 0.5;
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][1] + Physics.PlayerHeight[Player[A].Character][2];
+                    Player[A].Location.X += -Physics.PlayerWidth[Player[A].Character][1] * 0.5 + Physics.PlayerWidth[Player[A].Character][2] * 0.5;
+                    Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][1] + Physics.PlayerHeight[Player[A].Character][2];
                     Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
                     Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][1];
                 }
@@ -5178,14 +5178,14 @@ void PlayerEffects(int A)
                 }
                 else if(Player[A].Character == 2 && Player[A].Mount != 2)
                 {
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[1][2] + Physics.PlayerHeight[2][2];
+                    Player[A].Location.Y += -Physics.PlayerHeight[1][2] + Physics.PlayerHeight[2][2];
                     Player[A].Location.Height = Physics.PlayerHeight[1][2];
                 }
             }
         }
         if(Player[A].Effect2 >= 50 && Player[A].State == 2)
         {
-            Player[A].Immune = Player[A].Immune + 50;
+            Player[A].Immune += 50;
             Player[A].Immune2 = true;
             Player[A].Effect = 0;
             Player[A].Effect2 = 0;
@@ -5199,7 +5199,7 @@ void PlayerEffects(int A)
             Player[A].StandUp = true; // Fixes a block collision bug
             Player[A].Duck = false;
             Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
-            Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][Player[A].State] + Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
+            Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][Player[A].State] + Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
         }
         Player[A].Frame = 1;
         Player[A].Effect2 += 1;
@@ -5214,8 +5214,8 @@ void PlayerEffects(int A)
                 }
                 else if(!(Player[A].Mount == 2))
                 {
-                    Player[A].Location.X = Player[A].Location.X - Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
+                    Player[A].Location.X += -Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
+                    Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
                     Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
                     Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
                 }
@@ -5229,8 +5229,8 @@ void PlayerEffects(int A)
                 }
                 else if(!(Player[A].Mount == 2))
                 {
-                    Player[A].Location.X = Player[A].Location.X - Physics.PlayerWidth[Player[A].Character][1] * 0.5 + Physics.PlayerWidth[Player[A].Character][2] * 0.5;
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][1] + Physics.PlayerHeight[Player[A].Character][2];
+                    Player[A].Location.X += -Physics.PlayerWidth[Player[A].Character][1] * 0.5 + Physics.PlayerWidth[Player[A].Character][2] * 0.5;
+                    Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][1] + Physics.PlayerHeight[Player[A].Character][2];
                     Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
                     Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][1];
                 }
@@ -5243,8 +5243,8 @@ void PlayerEffects(int A)
                 Player[A].State = 1;
                 if(!(Player[A].Mount == 2))
                 {
-                    Player[A].Location.X = Player[A].Location.X - Physics.PlayerWidth[Player[A].Character][1] * 0.5 + Physics.PlayerWidth[Player[A].Character][2] * 0.5;
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][1] + Physics.PlayerHeight[Player[A].Character][2];
+                    Player[A].Location.X += -Physics.PlayerWidth[Player[A].Character][1] * 0.5 + Physics.PlayerWidth[Player[A].Character][2] * 0.5;
+                    Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][1] + Physics.PlayerHeight[Player[A].Character][2];
                     Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
                     Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
                 }
@@ -5263,7 +5263,7 @@ void PlayerEffects(int A)
             Player[A].StandUp = true; // Fixes a block collision bug
             Player[A].Duck = false;
             Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
-            Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][Player[A].State] + Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
+            Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][Player[A].State] + Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
         }
         Player[A].Frame = 1;
         Player[A].Effect2 += 1;
@@ -5292,7 +5292,7 @@ void PlayerEffects(int A)
             Player[A].StandUp = true; // Fixes a block collision bug
             Player[A].Duck = false;
             Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
-            Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][Player[A].State] + Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
+            Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][Player[A].State] + Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
         }
 
         Player[A].Frame = 1;
@@ -5334,7 +5334,7 @@ void PlayerEffects(int A)
         {
             if(warp_dir_enter == 3)
             {
-                Player[A].Location.Y = Player[A].Location.Y + 1;
+                Player[A].Location.Y += 1;
                 Player[A].Location.X = warp_enter.X + warp_enter.Width / 2.0 - Player[A].Location.Width / 2.0;
                 if(Player[A].Location.Y > warp_enter.Y + warp_enter.Height + 8)
                     Player[A].Effect2 = 1;
@@ -5348,7 +5348,7 @@ void PlayerEffects(int A)
             }
             else if(warp_dir_enter == 1)
             {
-                Player[A].Location.Y = Player[A].Location.Y - 1;
+                Player[A].Location.Y -= 1;
                 Player[A].Location.X = warp_enter.X + warp_enter.Width / 2.0 - Player[A].Location.Width / 2.0;
                 if(Player[A].Location.Y + Player[A].Location.Height + 8 < warp_enter.Y)
                     Player[A].Effect2 = 1;
@@ -5369,7 +5369,7 @@ void PlayerEffects(int A)
                 }
                 Player[A].Direction = -1;
                 Player[A].Location.Y = warp_enter.Y + warp_enter.Height - Player[A].Location.Height - 2;
-                Player[A].Location.X = Player[A].Location.X - 0.5;
+                Player[A].Location.X -= 0.5;
                 if(Player[A].Location.X + Player[A].Location.Width + 8 < warp_enter.X)
                     Player[A].Effect2 = 1;
                 if(Player[A].HoldingNPC > 0)
@@ -5393,7 +5393,7 @@ void PlayerEffects(int A)
                 }
                 Player[A].Direction = 1;
                 Player[A].Location.Y = warp_enter.Y + warp_enter.Height - Player[A].Location.Height - 2;
-                Player[A].Location.X = Player[A].Location.X + 0.5;
+                Player[A].Location.X += 0.5;
                 if(Player[A].Location.X > warp_enter.X + warp_enter.Width + 8)
                     Player[A].Effect2 = 1;
                 if(Player[A].HoldingNPC > 0)
@@ -5923,7 +5923,7 @@ void PlayerEffects(int A)
         }
         else if(Player[A].Effect2 <= 30)
         {
-            Player[A].Effect2 = Player[A].Effect2 - 1;
+            Player[A].Effect2 -= 1;
             if(Player[A].Effect2 == 0.0)
             {
                 Player[A].Effect = 0;
@@ -5962,7 +5962,7 @@ void PlayerEffects(int A)
         }
         else if(Player[A].Effect2 <= 130)
         {
-            Player[A].Effect2 = Player[A].Effect2 - 1;
+            Player[A].Effect2 -= 1;
             if(fEqual(Player[A].Effect2, 100))
             {
                 Player[A].Effect = 0;
@@ -5971,7 +5971,7 @@ void PlayerEffects(int A)
         }
         else if(Player[A].Effect2 <= 300)
         {
-            Player[A].Effect2 = Player[A].Effect2 - 1;
+            Player[A].Effect2 -= 1;
             if(fEqual(Player[A].Effect2, 200))
             {
                 Player[A].Effect2 = 100;
@@ -5980,7 +5980,7 @@ void PlayerEffects(int A)
         }
         else if(Player[A].Effect2 <= 1000) // Start Wait
         {
-            Player[A].Effect2 = Player[A].Effect2 - 1;
+            Player[A].Effect2 -= 1;
             if(fEqual(Player[A].Effect2, 900))
             {
                 Player[A].Effect = 3;
@@ -6071,8 +6071,8 @@ void PlayerEffects(int A)
 
                 if(Player[A].Mount == 0)
                 {
-                    Player[A].Location.X = Player[A].Location.X - Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
+                    Player[A].Location.X += -Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
+                    Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
                     Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
                     Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
                 }
@@ -6082,7 +6082,7 @@ void PlayerEffects(int A)
                 }
                 else if(Player[A].Character == 2 && Player[A].Mount != 2)
                 {
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
+                    Player[A].Location.Y += -Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
                     Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
                 }
             }
@@ -6096,7 +6096,7 @@ void PlayerEffects(int A)
         {
             if(Player[A].State == 2)
                 Player[A].State = 3;
-            Player[A].Immune = Player[A].Immune + 50;
+            Player[A].Immune += 50;
             Player[A].Immune2 = true;
             Player[A].Effect = 0;
             Player[A].Effect2 = 0;
@@ -6120,8 +6120,8 @@ void PlayerEffects(int A)
                 Player[A].State = 2;
                 if(Player[A].Mount == 0)
                 {
-                    Player[A].Location.X = Player[A].Location.X - Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
+                    Player[A].Location.X += -Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
+                    Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
                     Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
                     Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
                 }
@@ -6131,7 +6131,7 @@ void PlayerEffects(int A)
                 }
                 else if(Player[A].Character == 2 && Player[A].Mount != 2)
                 {
-                    Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
+                    Player[A].Location.Y += -Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
                     Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
                 }
             }
@@ -6145,7 +6145,7 @@ void PlayerEffects(int A)
         {
             if(Player[A].State == 2)
                 Player[A].State = 7;
-            Player[A].Immune = Player[A].Immune + 50;
+            Player[A].Immune += 50;
             Player[A].Immune2 = true;
             Player[A].Effect = 0;
             Player[A].Effect2 = 0;
@@ -6160,8 +6160,8 @@ void PlayerEffects(int A)
         {
             if(Player[A].State == 1 && Player[A].Mount == 0)
             {
-                Player[A].Location.X = Player[A].Location.X - Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
-                Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
+                Player[A].Location.X += -Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
+                Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
                 Player[A].State = 4;
                 Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
@@ -6172,7 +6172,7 @@ void PlayerEffects(int A)
             }
             else if(Player[A].Character == 2 && Player[A].State == 1 && Player[A].Mount == 1)
             {
-                Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
+                Player[A].Location.Y += -Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][4];
             }
             Player[A].State = 4;
@@ -6187,7 +6187,7 @@ void PlayerEffects(int A)
 
         if(fEqual(Player[A].Effect2, 14))
         {
-            Player[A].Immune = Player[A].Immune + 50;
+            Player[A].Immune += 50;
             Player[A].Immune2 = true;
             Player[A].Effect = 0;
             Player[A].Effect2 = 0;
@@ -6202,8 +6202,8 @@ void PlayerEffects(int A)
         {
             if(Player[A].State == 1 && Player[A].Mount == 0)
             {
-                Player[A].Location.X = Player[A].Location.X - Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
-                Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
+                Player[A].Location.X += -Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
+                Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
                 Player[A].State = 5;
                 Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
@@ -6214,7 +6214,7 @@ void PlayerEffects(int A)
             }
             else if(Player[A].Character == 2 && Player[A].State == 1 && Player[A].Mount == 1)
             {
-                Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
+                Player[A].Location.Y += -Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][4];
             }
             Player[A].State = 5;
@@ -6227,7 +6227,7 @@ void PlayerEffects(int A)
         Player[A].Effect2 += 1;
         if(fEqual(Player[A].Effect2, 14))
         {
-            Player[A].Immune = Player[A].Immune + 50;
+            Player[A].Immune += 50;
             Player[A].Immune2 = true;
             Player[A].Effect = 0;
             Player[A].Effect2 = 0;
@@ -6243,8 +6243,8 @@ void PlayerEffects(int A)
         {
             if(Player[A].State == 1 && Player[A].Mount == 0)
             {
-                Player[A].Location.X = Player[A].Location.X - Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
-                Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
+                Player[A].Location.X += -Physics.PlayerWidth[Player[A].Character][2] * 0.5 + Physics.PlayerWidth[Player[A].Character][1] * 0.5;
+                Player[A].Location.Y += -Physics.PlayerHeight[Player[A].Character][2] + Physics.PlayerHeight[Player[A].Character][1];
                 Player[A].State = 5;
                 Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
@@ -6255,7 +6255,7 @@ void PlayerEffects(int A)
             }
             else if(Player[A].Character == 2 && Player[A].State == 1 && Player[A].Mount == 1)
             {
-                Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
+                Player[A].Location.Y += -Physics.PlayerHeight[2][2] + Physics.PlayerHeight[1][2];
                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][6];
             }
 
@@ -6271,7 +6271,7 @@ void PlayerEffects(int A)
 
         if(Player[A].Effect2 == 14.0)
         {
-            Player[A].Immune = Player[A].Immune + 50;
+            Player[A].Immune += 50;
             Player[A].Immune2 = true;
             Player[A].Effect = 0;
             Player[A].Effect2 = 0;
@@ -6423,7 +6423,7 @@ void PlayerEffects(int A)
                 Player[A].Immune2 = true;
         }
 
-        Player[A].Location.Y = Player[A].Location.Y + 2.2;
+        Player[A].Location.Y += 2.2;
 
         if(Player[A].Location.Y >= Player[A].Effect2)
         {

--- a/src/player/player_update.cpp
+++ b/src/player/player_update.cpp
@@ -104,7 +104,7 @@ void UpdatePlayer()
 //    if(nPlay.Online == true)
 //    {
 //        A = nPlay.MySlot + 1;
-//        nPlay.PlayerWaitCount = nPlay.PlayerWaitCount + 1;
+//        nPlay.PlayerWaitCount += 1;
 //        if(Player[A].Dead == true || Player[A].TimeToLive > 0)
 //        {
 //            if(nPlay.PlayerWaitCount == 10)
@@ -172,7 +172,7 @@ void UpdatePlayer()
             Player[A].Controls.AltJump = false;
         }
         if(Player[A].Dismount > 0) // count down to being able to hop in a shoe or yoshi
-            Player[A].Dismount = Player[A].Dismount - 1;
+            Player[A].Dismount -= 1;
         if(Player[A].Mount != 0 || Player[A].Stoned || Player[A].Fairy) // if .holdingnpc is -1 then the player can't grab anything. this stops the player from grabbing things while on a yoshi/shoe
             Player[A].HoldingNPC = -1;
         else if(Player[A].HoldingNPC == -1)
@@ -193,7 +193,7 @@ void UpdatePlayer()
         // Handle the death effecs
         if(Player[A].TimeToLive > 0)
         {
-            Player[A].TimeToLive = Player[A].TimeToLive + 1;
+            Player[A].TimeToLive += 1;
             if(Player[A].TimeToLive >= 200 || ScreenType != 5)
             {
                 B = CheckLiving();
@@ -234,8 +234,8 @@ void UpdatePlayer()
                         X = 0;
                         Y = 0;
                     }
-                    Player[A].Location.X = Player[A].Location.X + X * 10;
-                    Player[A].Location.Y = Player[A].Location.Y + Y * 10;
+                    Player[A].Location.X += X * 10;
+                    Player[A].Location.Y += Y * 10;
                     if(ScreenType == 5 && Player[1].Section != Player[2].Section)
                     {
                         C1 = 0;
@@ -288,7 +288,7 @@ void UpdatePlayer()
         {
             oldLoc = Player[A].Location;
             if(Player[A].SlideCounter > 0) // for making the slide Effect
-                Player[A].SlideCounter = Player[A].SlideCounter - 1;
+                Player[A].SlideCounter -= 1;
 
             // for the purple yoshi ground pound
             if(Player[A].Effect == 0)
@@ -330,7 +330,7 @@ void UpdatePlayer()
                     Player[A].CanFly = false;
                     Player[A].FlyCount = 0;
                     Player[A].CanFly2 = false;
-                    Player[A].Location.SpeedY = Player[A].Location.SpeedY + 1;
+                    Player[A].Location.SpeedY += 1;
                     Player[A].CanPound = false;
                     Player[A].Jump = 0;
                 }
@@ -434,18 +434,18 @@ void UpdatePlayer()
                         Angle = 1 / (Block[Player[A].Slope].Location.Width / static_cast<double>(Block[Player[A].Slope].Location.Height));
                         slideSpeed = 0.1 * Angle * BlockSlope[Block[Player[A].Slope].Type];
                         if(slideSpeed > 0 && Player[A].Location.SpeedX < 0)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + slideSpeed * 2;
+                            Player[A].Location.SpeedX += slideSpeed * 2;
                         else if(slideSpeed < 0 && Player[A].Location.SpeedX > 0)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + slideSpeed * 2;
+                            Player[A].Location.SpeedX += slideSpeed * 2;
                         else
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + slideSpeed;
+                            Player[A].Location.SpeedX += slideSpeed;
                     }
                     else if(Player[A].Location.SpeedY == 0.0 || Player[A].StandingOnNPC != 0)
                     {
                         if(Player[A].Location.SpeedX > 0.2)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.1;
+                            Player[A].Location.SpeedX -= 0.1;
                         else if(Player[A].Location.SpeedX < -0.2)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.1;
+                            Player[A].Location.SpeedX += 0.1;
                         else
                         {
                             Player[A].Location.SpeedX = 0;
@@ -471,9 +471,9 @@ void UpdatePlayer()
                         tempBool = true;
                         tempLocation = Player[A].Location;
                         tempLocation.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
-                        tempLocation.Y = tempLocation.Y - Physics.PlayerHeight[Player[A].Character][Player[A].State];
+                        tempLocation.Y += -Physics.PlayerHeight[Player[A].Character][Player[A].State];
                         tempLocation.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
-                        tempLocation.X = tempLocation.X + 64 - tempLocation.Width / 2.0;
+                        tempLocation.X += 64 - tempLocation.Width / 2.0;
                         // fBlock = FirstBlock[(tempLocation.X / 32) - 1];
                         // lBlock = LastBlock[((tempLocation.X + tempLocation.Width) / 32.0) + 1];
                         blockTileGet(tempLocation, fBlock, lBlock);
@@ -510,15 +510,15 @@ void UpdatePlayer()
                             PlaySound(SFX_Boot);
                             Player[A].Jump = Physics.PlayerJumpHeight;
                             if(Player[A].Character == 2)
-                                Player[A].Jump = Player[A].Jump + 3;
+                                Player[A].Jump += 3;
                             if(Player[A].SpinJump)
-                                Player[A].Jump = Player[A].Jump - 6;
+                                Player[A].Jump -= 6;
                             Player[A].Mount = 0;
                             numNPCs += 1;
                             NPC[numNPCs].Direction = Player[A].Direction;
                             if(Maths::iRound(NPC[numNPCs].Direction) == 1)
                                 NPC[numNPCs].Frame = 4;
-                            NPC[numNPCs].Frame = NPC[numNPCs].Frame + SpecialFrame[2];
+                            NPC[numNPCs].Frame += SpecialFrame[2];
                             NPC[numNPCs].Active = true;
                             NPC[numNPCs].TimeLeft = 100;
                             NPC[numNPCs].Type = 56;
@@ -533,7 +533,7 @@ void UpdatePlayer()
                             Player[A].Location.SpeedY = double(Physics.PlayerJumpVelocity) - tempSpeed;
                             Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
                             Player[A].Location.Width = Physics.PlayerWidth[Player[A].Character][Player[A].State];
-                            Player[A].Location.X = Player[A].Location.X + 64 - Physics.PlayerWidth[Player[A].Character][Player[A].State] / 2;
+                            Player[A].Location.X += 64 - Physics.PlayerWidth[Player[A].Character][Player[A].State] / 2;
                             Player[A].StandUp = true;
                             Player[A].StandUp2 = true;
                             Player[A].ForceHitSpot3 = true;
@@ -603,21 +603,21 @@ void UpdatePlayer()
                     if(Player[A].Controls.Right)
                     {
                         if(Player[A].Location.SpeedX < 3)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.15;
+                            Player[A].Location.SpeedX += 0.15;
                         if(Player[A].Location.SpeedX < 0)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.1;
+                            Player[A].Location.SpeedX += 0.1;
                     }
                     else if(Player[A].Controls.Left)
                     {
                         if(Player[A].Location.SpeedX > -3)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.15;
+                            Player[A].Location.SpeedX -= 0.15;
                         if(Player[A].Location.SpeedX > 0)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.1;
+                            Player[A].Location.SpeedX -= 0.1;
                     }
                     else if(Player[A].Location.SpeedX > 0.1)
-                        Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.1;
+                        Player[A].Location.SpeedX -= 0.1;
                     else if(Player[A].Location.SpeedX < -0.1)
-                        Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.1;
+                        Player[A].Location.SpeedX += 0.1;
                     else
                         Player[A].Location.SpeedX = 0;
                 }
@@ -685,9 +685,9 @@ void UpdatePlayer()
                                 {
                                     if(!Player[A].Duck)
                                     {
-                                        Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                                        Player[A].Location.Y += Player[A].Location.Height;
                                         Player[A].Location.Height = 31;
-                                        Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                                        Player[A].Location.Y += -Player[A].Location.Height;
                                         Player[A].Duck = true;
                                         // If nPlay.Online = True And A = nPlay.MySlot + 1 Then Netplay.sendData Netplay.PutPlayerLoc(nPlay.MySlot) & "1q" & A & LB
 //                                        if(nPlay.Online == true && A == nPlay.MySlot + 1)
@@ -703,9 +703,9 @@ void UpdatePlayer()
                                             if(Player[A].Character == 5)
                                                 Player[A].SwordPoke = 0;
                                             Player[A].Duck = true;
-                                            Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                                            Player[A].Location.Y += Player[A].Location.Height;
                                             Player[A].Location.Height = Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
-                                            Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                                            Player[A].Location.Y += -Player[A].Location.Height;
 //                                            if(nPlay.Online == true && A == nPlay.MySlot + 1)
 //                                                Netplay::sendData "1q" + std::to_string(A) + LB;
                                         }
@@ -716,7 +716,7 @@ void UpdatePlayer()
                                         {
                                             Player[A].Duck = true;
                                             Player[A].Location.Height = Physics.PlayerDuckHeight[1][2];
-                                            Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerDuckHeight[1][2] + Physics.PlayerHeight[1][2];
+                                            Player[A].Location.Y += -Physics.PlayerDuckHeight[1][2] + Physics.PlayerHeight[1][2];
 //                                            if(nPlay.Online == true && A == nPlay.MySlot + 1)
 //                                                Netplay::sendData "1q" + std::to_string(A) + LB;
                                         }
@@ -746,35 +746,35 @@ void UpdatePlayer()
                             if(Player[A].Location.SpeedX > -Physics.PlayerWalkSpeed * speedVar * C)
                             {
                                 if(Player[A].Character == 2) // LUIGI
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.1 * 0.175;
+                                    Player[A].Location.SpeedX += 0.1 * 0.175;
                                 if(Player[A].Character == 3) // PEACH
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.05 * 0.175;
+                                    Player[A].Location.SpeedX += 0.05 * 0.175;
                                 if(Player[A].Character == 4) // toad
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.05 * 0.175;
-                                Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.1 * speedVar;
+                                    Player[A].Location.SpeedX += -0.05 * 0.175;
+                                Player[A].Location.SpeedX += -0.1 * speedVar;
                             }
                             else // Running
                             {
                                 if(Player[A].Character == 2) // LUIGI
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.05 * 0.175;
+                                    Player[A].Location.SpeedX += 0.05 * 0.175;
                                 if(Player[A].Character == 3) // PEACH
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.025 * 0.175;
+                                    Player[A].Location.SpeedX += 0.025 * 0.175;
                                 if(Player[A].Character == 4) // toad
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.025 * 0.175;
+                                    Player[A].Location.SpeedX += -0.025 * 0.175;
                                 if(Player[A].Character == 5) // Link
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.025 * speedVar;
+                                    Player[A].Location.SpeedX += -0.025 * speedVar;
                                 else // Mario
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.05 * speedVar;
+                                    Player[A].Location.SpeedX += -0.05 * speedVar;
                             }
                             if(Player[A].Location.SpeedX > 0)
                             {
-                                Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.18;
+                                Player[A].Location.SpeedX -= 0.18;
                                 if(Player[A].Character == 2) // LUIGI
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.18 * 0.29;
+                                    Player[A].Location.SpeedX += 0.18 * 0.29;
                                 if(Player[A].Character == 3) // PEACH
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.09 * 0.29;
+                                    Player[A].Location.SpeedX += 0.09 * 0.29;
                                 if(Player[A].Character == 4) // toad
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.09 * 0.29;
+                                    Player[A].Location.SpeedX += -0.09 * 0.29;
                                 if(SuperSpeed)
                                     Player[A].Location.SpeedX = Player[A].Location.SpeedX * 0.95;
                             }
@@ -790,50 +790,50 @@ void UpdatePlayer()
                             if(Player[A].Location.SpeedX < Physics.PlayerWalkSpeed * speedVar * C)
                             {
                                 if(Player[A].Character == 2) // LUIGI
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.1 * 0.175;
+                                    Player[A].Location.SpeedX += -0.1 * 0.175;
                                 if(Player[A].Character == 3) // PEACH
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.05 * 0.175;
+                                    Player[A].Location.SpeedX += -0.05 * 0.175;
                                 if(Player[A].Character == 4) // toad
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.05 * 0.175;
-                                Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.1 * speedVar;
+                                    Player[A].Location.SpeedX += 0.05 * 0.175;
+                                Player[A].Location.SpeedX += 0.1 * speedVar;
                             }
                             else
                             {
                                 if(Player[A].Character == 2) // LUIGI
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.05 * 0.175;
+                                    Player[A].Location.SpeedX += -0.05 * 0.175;
                                 if(Player[A].Character == 3) // PEACH
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.025 * 0.175;
+                                    Player[A].Location.SpeedX += -0.025 * 0.175;
                                 if(Player[A].Character == 4) // toad
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.025 * 0.175;
+                                    Player[A].Location.SpeedX += 0.025 * 0.175;
                                 if(Player[A].Character == 5) // Link
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.025 * speedVar;
+                                    Player[A].Location.SpeedX += 0.025 * speedVar;
                                 else // Mario
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.05 * speedVar;
+                                    Player[A].Location.SpeedX += 0.05 * speedVar;
                             }
                             if(Player[A].Location.SpeedX < 0)
                             {
-                                Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.18;
+                                Player[A].Location.SpeedX += 0.18;
                                 if(Player[A].Character == 2) // LUIGI
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.18 * 0.29;
+                                    Player[A].Location.SpeedX += -0.18 * 0.29;
                                 if(Player[A].Character == 3) // PEACH
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.09 * 0.29;
+                                    Player[A].Location.SpeedX += -0.09 * 0.29;
                                 if(Player[A].Character == 4) // toad
-                                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.09 * 0.29;
+                                    Player[A].Location.SpeedX += 0.09 * 0.29;
                                 if(SuperSpeed)
                                     Player[A].Location.SpeedX = Player[A].Location.SpeedX * 0.95;
                             }
                         }
                         if(SuperSpeed && Player[A].Controls.Run)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.1;
+                            Player[A].Location.SpeedX += 0.1;
                     }
                     else
                     {
                         if(Player[A].Location.SpeedY == 0.0 || Player[A].StandingOnNPC != 0 || Player[A].Slope > 0 || Player[A].WetFrame) // Only lose speed when not in the air
                         {
                             if(Player[A].Location.SpeedX > 0)
-                                Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.07 * speedVar;
+                                Player[A].Location.SpeedX += -0.07 * speedVar;
                             if(Player[A].Location.SpeedX < 0)
-                                Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.07 * speedVar;
+                                Player[A].Location.SpeedX += 0.07 * speedVar;
                             if(Player[A].Character == 2) // LUIGI
                                 Player[A].Location.SpeedX = Player[A].Location.SpeedX * 1.003;
                             if(Player[A].Character == 3) // PEACH
@@ -882,9 +882,9 @@ void UpdatePlayer()
                     else
                     {
                         if(Player[A].Location.SpeedX > Physics.PlayerWalkSpeed + 0.1 * speedVar)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX - 0.1;
+                            Player[A].Location.SpeedX -= 0.1;
                         else if(Player[A].Location.SpeedX < -Physics.PlayerWalkSpeed - 0.1 * speedVar)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + 0.1;
+                            Player[A].Location.SpeedX += 0.1;
                         else if(std::abs(Player[A].Location.SpeedX) > Physics.PlayerWalkSpeed * speedVar)
                         {
                             if(Player[A].Location.SpeedX > 0)
@@ -1009,7 +1009,7 @@ void UpdatePlayer()
                         Effect[numEffects].Frame = 1;
                     }
                     if(Player[A].FairyTime > 0)
-                        Player[A].FairyTime = Player[A].FairyTime - 1;
+                        Player[A].FairyTime -= 1;
                     if(Player[A].FairyTime != -1 && Player[A].FairyTime < 20 && Player[A].Character == 5)
                     {
                         for(int numNPCsMax4 = numNPCs, Bi = 1; Bi <= numNPCsMax4; Bi++)
@@ -1017,10 +1017,10 @@ void UpdatePlayer()
                             if(NPC[Bi].Active && !NPC[Bi].Hidden && NPCIsAVine[NPC[Bi].Type])
                             {
                                 tempLocation = NPC[Bi].Location;
-                                tempLocation.Width = tempLocation.Width + 32;
-                                tempLocation.Height = tempLocation.Height + 32;
-                                tempLocation.X = tempLocation.X - 16;
-                                tempLocation.Y = tempLocation.Y - 16;
+                                tempLocation.Width += 32;
+                                tempLocation.Height += 32;
+                                tempLocation.X -= 16;
+                                tempLocation.Y -= 16;
                                 if(CheckCollision(tempLocation, Player[A].Location))
                                 {
                                     Player[A].FairyTime = 20;
@@ -1034,10 +1034,10 @@ void UpdatePlayer()
                             if(BackgroundFence[Background[B].Type] && !Background[B].Hidden)
                             {
                                 tempLocation = Background[B].Location;
-                                tempLocation.Width = tempLocation.Width + 32;
-                                tempLocation.Height = tempLocation.Height + 32;
-                                tempLocation.X = tempLocation.X - 16;
-                                tempLocation.Y = tempLocation.Y - 16;
+                                tempLocation.Width += 32;
+                                tempLocation.Height += 32;
+                                tempLocation.X -= 16;
+                                tempLocation.Y -= 16;
                                 if(CheckCollision(tempLocation, Player[A].Location))
                                 {
                                     Player[A].FairyTime = 20;
@@ -1062,14 +1062,14 @@ void UpdatePlayer()
                 else
                     Player[A].FairyTime = 0;
                 if(Player[A].FairyCD != 0 && (Player[A].Location.SpeedY == 0.0 || Player[A].Slope != 0 || Player[A].StandingOnNPC != 0 || Player[A].WetFrame))
-                    Player[A].FairyCD = Player[A].FairyCD - 1;
+                    Player[A].FairyCD -= 1;
 
 
                 if(Player[A].StandingOnNPC != 0 && !NPC[Player[A].StandingOnNPC].Pinched && !FreezeNPCs)
                 {
                     if(Player[A].StandingOnNPC < 0)
                         NPC[Player[A].StandingOnNPC].Location = Block[NPC[Player[A].StandingOnNPC].Special].Location;
-                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + NPC[Player[A].StandingOnNPC].Location.SpeedX + NPC[Player[A].StandingOnNPC].BeltSpeed;
+                    Player[A].Location.SpeedX += NPC[Player[A].StandingOnNPC].Location.SpeedX + NPC[Player[A].StandingOnNPC].BeltSpeed;
                 }
 
                 if(GameOutro) // force the player to walk a specific speed during the credits
@@ -1109,11 +1109,11 @@ void UpdatePlayer()
                 }
 
 
-                Player[A].Location.X = Player[A].Location.X + Player[A].Location.SpeedX; // This is where the actual movement happens
+                Player[A].Location.X += Player[A].Location.SpeedX; // This is where the actual movement happens
 
                 // Players Y movement.
                 if(Block[Player[A].Slope].Location.SpeedY != 0.0 && Player[A].Slope != 0)
-                    Player[A].Location.Y = Player[A].Location.Y + Block[Player[A].Slope].Location.SpeedY;
+                    Player[A].Location.Y += Block[Player[A].Slope].Location.SpeedY;
 
                 if(Player[A].Fairy) // the player is a fairy
                 {
@@ -1123,22 +1123,22 @@ void UpdatePlayer()
                     {
                         if(Player[A].Controls.Jump || Player[A].Controls.AltJump || Player[A].Controls.Up)
                         {
-                            Player[A].Location.SpeedY = Player[A].Location.SpeedY - 0.15;
+                            Player[A].Location.SpeedY -= 0.15;
                             if(Player[A].Location.SpeedY > 0)
-                                Player[A].Location.SpeedY = Player[A].Location.SpeedY - 0.1;
+                                Player[A].Location.SpeedY -= 0.1;
                         }
                         else if(Player[A].Location.SpeedY < -0.1 || Player[A].Controls.Down)
                         {
                             if(Player[A].Location.SpeedY < 3)
-                                Player[A].Location.SpeedY = Player[A].Location.SpeedY + double(Physics.PlayerGravity * 0.05f);
+                                Player[A].Location.SpeedY += double(Physics.PlayerGravity * 0.05f);
                             if(Player[A].Location.SpeedY < 0)
-                                Player[A].Location.SpeedY = Player[A].Location.SpeedY + double(Physics.PlayerGravity * 0.05f);
-                            Player[A].Location.SpeedY = Player[A].Location.SpeedY + double(Physics.PlayerGravity * 0.1f);
+                                Player[A].Location.SpeedY += double(Physics.PlayerGravity * 0.05f);
+                            Player[A].Location.SpeedY += double(Physics.PlayerGravity * 0.1f);
                             if(Player[A].Controls.Down)
-                                Player[A].Location.SpeedY = Player[A].Location.SpeedY + 0.05;
+                                Player[A].Location.SpeedY += 0.05;
                         }
                         else if(Player[A].Location.SpeedY > 0.1)
-                            Player[A].Location.SpeedY = Player[A].Location.SpeedY - 0.15;
+                            Player[A].Location.SpeedY -= 0.15;
                         else
                             Player[A].Location.SpeedY = 0;
                     }
@@ -1146,19 +1146,19 @@ void UpdatePlayer()
                     {
                         if(Player[A].Controls.Jump || Player[A].Controls.AltJump || Player[A].Controls.Up)
                         {
-                            Player[A].Location.SpeedY = Player[A].Location.SpeedY - 0.15;
+                            Player[A].Location.SpeedY -= 0.15;
                             if(Player[A].Location.SpeedY > 0)
-                                Player[A].Location.SpeedY = Player[A].Location.SpeedY - 0.1;
+                                Player[A].Location.SpeedY -= 0.1;
                         }
                         else
                         {
                             if(Player[A].Location.SpeedY < 3)
-                                Player[A].Location.SpeedY = Player[A].Location.SpeedY + Physics.PlayerGravity * 0.05;
+                                Player[A].Location.SpeedY += Physics.PlayerGravity * 0.05;
                             if(Player[A].Location.SpeedY < 0)
-                                Player[A].Location.SpeedY = Player[A].Location.SpeedY + Physics.PlayerGravity * 0.05;
-                            Player[A].Location.SpeedY = Player[A].Location.SpeedY + Physics.PlayerGravity * 0.1;
+                                Player[A].Location.SpeedY += Physics.PlayerGravity * 0.05;
+                            Player[A].Location.SpeedY += Physics.PlayerGravity * 0.1;
                             if(Player[A].Controls.Down)
-                                Player[A].Location.SpeedY = Player[A].Location.SpeedY + 0.05;
+                                Player[A].Location.SpeedY += 0.05;
                         }
                     }
 
@@ -1166,7 +1166,7 @@ void UpdatePlayer()
                         Player[A].Location.SpeedY = 4;
                     else if(Player[A].Location.SpeedY < -3)
                         Player[A].Location.SpeedY = -3;
-                    Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.SpeedY;
+                    Player[A].Location.Y += Player[A].Location.SpeedY;
                 }
                 else if(Player[A].Wet > 0 && Player[A].Quicksand == 0) // the player is swimming
                 {
@@ -1180,9 +1180,9 @@ void UpdatePlayer()
                             Player[A].Location.SpeedY = Physics.PlayerJumpVelocity - tempSpeed;
                             Player[A].Jump = Physics.PlayerJumpHeight;
                             if(Player[A].Character == 2)
-                                Player[A].Jump = Player[A].Jump + 3;
+                                Player[A].Jump += 3;
                             if(Player[A].SpinJump)
-                                Player[A].Jump = Player[A].Jump - 6;
+                                Player[A].Jump -= 6;
                             Player[A].Mount = 0;
                             Player[A].StandingOnNPC = 0;
                             numNPCs++;
@@ -1208,9 +1208,9 @@ void UpdatePlayer()
                             NPC[numNPCs].Location.SpeedX = (Player[A].Location.SpeedX - NPC[Player[A].StandingOnNPC].Location.SpeedX) * 0.8;
                             NPC[numNPCs].CantHurt = 10;
                             NPC[numNPCs].CantHurtPlayer = A;
-                            Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                            Player[A].Location.Y += Player[A].Location.Height;
                             Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
-                            Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                            Player[A].Location.Y += -Player[A].Location.Height;
                         }
                     }
                     else if(Player[A].Mount == 3)
@@ -1267,7 +1267,7 @@ void UpdatePlayer()
                         }
                     }
 
-                    Player[A].Location.SpeedY = Player[A].Location.SpeedY + Physics.PlayerGravity * 0.1;
+                    Player[A].Location.SpeedY += Physics.PlayerGravity * 0.1;
                     if(Player[A].Location.SpeedY >= 3) // Terminal Velocity in water
                         Player[A].Location.SpeedY = 3;
                     if(Player[A].Mount == 1)
@@ -1303,7 +1303,7 @@ void UpdatePlayer()
                     }
 
                     if(Player[A].SwimCount > 0)
-                        Player[A].SwimCount = Player[A].SwimCount - 1;
+                        Player[A].SwimCount -= 1;
                     if(Player[A].SwimCount == 0)
                     {
                         if(Player[A].Mount != 1 || Player[A].Location.SpeedY == Physics.PlayerGravity * 0.1 || Player[A].Slope != 0 || Player[A].StandingOnNPC != 0)
@@ -1322,12 +1322,12 @@ void UpdatePlayer()
                                     Player[A].StandingOnNPC = 0;
                                 }
                                 Player[A].SwimCount = 15;
-                                // If .Location.SpeedY = 0 Then .Location.Y = .Location.Y - 1
+                                // If .Location.SpeedY = 0 Then .Location.Y += -1
                                 if(Player[A].Controls.Down)
                                 {
                                     if(Player[A].Location.SpeedY >= Physics.PlayerJumpVelocity * 0.2)
                                     {
-                                        Player[A].Location.SpeedY = Player[A].Location.SpeedY + Physics.PlayerJumpVelocity * 0.2;
+                                        Player[A].Location.SpeedY += Physics.PlayerJumpVelocity * 0.2;
                                         if(Player[A].Location.SpeedY < Physics.PlayerJumpVelocity * 0.2)
                                             Player[A].Location.SpeedY = Physics.PlayerJumpVelocity * 0.2;
                                     }
@@ -1335,9 +1335,9 @@ void UpdatePlayer()
                                 else
                                 {
                                     if(Player[A].Controls.Up)
-                                        Player[A].Location.SpeedY = Player[A].Location.SpeedY + Physics.PlayerJumpVelocity * 0.5;
+                                        Player[A].Location.SpeedY += Physics.PlayerJumpVelocity * 0.5;
                                     else
-                                        Player[A].Location.SpeedY = Player[A].Location.SpeedY + Physics.PlayerJumpVelocity * 0.4;
+                                        Player[A].Location.SpeedY += Physics.PlayerJumpVelocity * 0.4;
                                     if(Player[A].Mount == 1)
                                         Player[A].Location.SpeedY = Physics.PlayerJumpVelocity;
                                 }
@@ -1367,7 +1367,7 @@ void UpdatePlayer()
                             Player[A].Location.SpeedY = -3;
                     }
 
-                    Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.SpeedY;
+                    Player[A].Location.Y += Player[A].Location.SpeedY;
 
                 }
                 else // the player is not swimming
@@ -1413,9 +1413,9 @@ void UpdatePlayer()
                                 Player[A].Location.SpeedY = Physics.PlayerJumpVelocity - tempSpeed;
                                 Player[A].Jump = Physics.PlayerJumpHeight;
                                 if(Player[A].Character == 2)
-                                    Player[A].Jump = Player[A].Jump + 3;
+                                    Player[A].Jump += 3;
                                 if(Player[A].SpinJump)
-                                    Player[A].Jump = Player[A].Jump - 6;
+                                    Player[A].Jump -= 6;
                                 Player[A].Mount = 0;
                                 Player[A].StandingOnNPC = 0;
                                 numNPCs++;
@@ -1441,9 +1441,9 @@ void UpdatePlayer()
                                 NPC[numNPCs].Location.SpeedX = (Player[A].Location.SpeedX - NPC[Player[A].StandingOnNPC].Location.SpeedX) * 0.8;
                                 NPC[numNPCs].CantHurt = 10;
                                 NPC[numNPCs].CantHurtPlayer = A;
-                                Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                                Player[A].Location.Y += Player[A].Location.Height;
                                 Player[A].Location.Height = Physics.PlayerHeight[Player[A].Character][Player[A].State];
-                                Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                                Player[A].Location.Y += -Player[A].Location.Height;
                             }
                         }
                         else if(Player[A].Mount == 3)
@@ -1459,9 +1459,9 @@ void UpdatePlayer()
                                 Player[A].Location.SpeedY = Physics.PlayerJumpVelocity - tempSpeed;
                                 Player[A].Jump = Physics.PlayerJumpHeight;
                                 if(Player[A].Character == 2)
-                                    Player[A].Jump = Player[A].Jump + 3;
+                                    Player[A].Jump += 3;
                                 if(Player[A].SpinJump)
-                                    Player[A].Jump = Player[A].Jump - 6;
+                                    Player[A].Jump -= 6;
                                 Player[A].Mount = 0;
                                 UpdateYoshiMusic();
                                 numNPCs++;
@@ -1539,15 +1539,15 @@ void UpdatePlayer()
                                         Player[A].DoubleJump = true;
 
                                     if(Player[A].Character == 2)
-                                        Player[A].Jump = Player[A].Jump + 3;
+                                        Player[A].Jump += 3;
 
                                     if(Player[A].SpinJump)
-                                        Player[A].Jump = Player[A].Jump - 6;
+                                        Player[A].Jump -= 6;
 
                                     if(Player[A].StandingOnNPC > 0 && !FreezeNPCs)
                                     {
                                         if(NPC[Player[A].StandingOnNPC].Type != 91)
-                                            Player[A].Location.SpeedX = Player[A].Location.SpeedX - NPC[Player[A].StandingOnNPC].Location.SpeedX;
+                                            Player[A].Location.SpeedX += -NPC[Player[A].StandingOnNPC].Location.SpeedX;
                                     }
 
                                     Player[A].StandingOnNPC = 0; // the player can't stand on an NPC after jumping
@@ -1557,9 +1557,9 @@ void UpdatePlayer()
                                         Player[A].StandingOnNPC = 0;
                                         Player[A].Jump = 30;
                                         if(Player[A].Character == 2)
-                                            Player[A].Jump = Player[A].Jump + 3;
+                                            Player[A].Jump += 3;
                                         if(Player[A].SpinJump)
-                                            Player[A].Jump = Player[A].Jump - 6;
+                                            Player[A].Jump -= 6;
                                         Player[A].CanFly = false;
                                         Player[A].RunCount = 0;
                                         Player[A].CanFly2 = true;
@@ -1590,16 +1590,16 @@ void UpdatePlayer()
                                     if(Player[A].Jump > 20)
                                     {
                                         if(Player[A].Jump > 40)
-                                            Player[A].Location.SpeedY = Player[A].Location.SpeedY - (40 - 20) * 0.2;
+                                            Player[A].Location.SpeedY += -(40 - 20) * 0.2;
                                         else
-                                            Player[A].Location.SpeedY = Player[A].Location.SpeedY - (Player[A].Jump - 20) * 0.2;
+                                            Player[A].Location.SpeedY += -(Player[A].Jump - 20) * 0.2;
                                     }
                                 }
                                 else if(Player[A].CanFly2)
                                 {
                                     if(Player[A].Location.SpeedY > Physics.PlayerJumpVelocity * 0.5)
                                     {
-                                        Player[A].Location.SpeedY = Player[A].Location.SpeedY - 1;
+                                        Player[A].Location.SpeedY -= 1;
                                         Player[A].CanPound = true;
                                         if(Player[A].YoshiBlue || (Player[A].Mount == 1 && Player[A].MountType == 3))
                                             PlaySound(SFX_YoshiTongue);
@@ -1633,7 +1633,7 @@ void UpdatePlayer()
                                     NewEffect(80, tempLocation);
                                     Effect[numEffects].Location.SpeedX = (dRand() * 3) - 1.5;
                                     Effect[numEffects].Location.SpeedY = (dRand() *0.5) + (1.5 - std::abs(Effect[numEffects].Location.SpeedX)) * 0.5;
-                                    Effect[numEffects].Location.SpeedX = Effect[numEffects].Location.SpeedX - Player[A].Location.SpeedX * 0.2;
+                                    Effect[numEffects].Location.SpeedX += -Player[A].Location.SpeedX * 0.2;
                                 }
                             }
                         }
@@ -1680,7 +1680,7 @@ void UpdatePlayer()
                             {
                                 if(NPC[Player[A].StandingOnNPC].Type == 195)
                                     NPC[Player[A].StandingOnNPC].Special4 = 1;
-                                NPC[Player[A].StandingOnNPC].Location.SpeedY = NPC[Player[A].StandingOnNPC].Location.SpeedY - Physics.NPCGravity * 1.5;
+                                NPC[Player[A].StandingOnNPC].Location.SpeedY += -Physics.NPCGravity * 1.5;
                             }
                         }
 
@@ -1701,16 +1701,16 @@ void UpdatePlayer()
                                     Player[A].Location.SpeedY = Physics.PlayerJumpVelocity - tempSpeed;
                                     Player[A].Jump = Physics.PlayerJumpHeight;
                                     if(Player[A].Character == 2)
-                                        Player[A].Jump = Player[A].Jump + 3;
+                                        Player[A].Jump += 3;
 
                                     if(Player[A].StandingOnNPC > 0 && !FreezeNPCs)
                                     {
                                         if(NPC[Player[A].StandingOnNPC].Type != 91)
-                                            Player[A].Location.SpeedX = Player[A].Location.SpeedX - NPC[Player[A].StandingOnNPC].Location.SpeedX;
+                                            Player[A].Location.SpeedX += -NPC[Player[A].StandingOnNPC].Location.SpeedX;
                                     }
 
                                     PlaySound(SFX_Tail); // Jump sound
-                                    Player[A].Jump = Player[A].Jump - 6;
+                                    Player[A].Jump -= 6;
                                     if(Player[A].Direction == 1)
                                         Player[A].SpinFrame = 0;
                                     else
@@ -1735,9 +1735,9 @@ void UpdatePlayer()
                                         Player[A].StandingOnNPC = 0;
                                         Player[A].Jump = 30;
                                         if(Player[A].Character == 2)
-                                            Player[A].Jump = Player[A].Jump + 3;
+                                            Player[A].Jump += 3;
                                         if(Player[A].SpinJump)
-                                            Player[A].Jump = Player[A].Jump - 6;
+                                            Player[A].Jump -= 6;
                                         Player[A].CanFly = false;
                                         Player[A].RunCount = 0;
                                         Player[A].CanFly2 = true;
@@ -1749,13 +1749,13 @@ void UpdatePlayer()
                             {
                                 Player[A].Location.SpeedY = Physics.PlayerJumpVelocity - tempSpeed;
                                 if(Player[A].Jump > 20)
-                                    Player[A].Location.SpeedY = Player[A].Location.SpeedY - (Player[A].Jump - 20) * 0.2;
+                                    Player[A].Location.SpeedY += -(Player[A].Jump - 20) * 0.2;
                             }
                             else if(Player[A].CanFly2)
                             {
                                 if(Player[A].Location.SpeedY > Physics.PlayerJumpVelocity * 0.5)
                                 {
-                                    Player[A].Location.SpeedY = Player[A].Location.SpeedY - 1;
+                                    Player[A].Location.SpeedY -= 1;
                                     Player[A].CanPound = true;
                                     if(Player[A].YoshiBlue)
                                         PlaySound(SFX_YoshiTongue);
@@ -1782,7 +1782,7 @@ void UpdatePlayer()
                         if(!Player[A].Controls.AltJump && !Player[A].Controls.Jump)
                             Player[A].Jump = 0;
                         if(Player[A].Jump > 0)
-                            Player[A].Jump = Player[A].Jump - 1;
+                            Player[A].Jump -= 1;
 
                         if(Player[A].Jump > 0)
                             Player[A].Vine = 0;
@@ -1794,16 +1794,16 @@ void UpdatePlayer()
                             if(Player[A].Location.SpeedY < -0.7)
                             {
                                 Player[A].Location.SpeedY = -0.7;
-                                Player[A].Jump = Player[A].Jump - 1;
+                                Player[A].Jump -= 1;
                             }
                             else if(Player[A].Location.SpeedY < 0)
                             {
-                                Player[A].Location.SpeedY = Player[A].Location.SpeedY + 0.1;
+                                Player[A].Location.SpeedY += 0.1;
                                 Player[A].Jump = 0;
                             }
                             if(Player[A].Location.SpeedY >= 0.1)
                                 Player[A].Location.SpeedY = 0.1;
-                            Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.SpeedY;
+                            Player[A].Location.Y += Player[A].Location.SpeedY;
                         }
 
 
@@ -1813,9 +1813,9 @@ void UpdatePlayer()
                             if(Player[A].NoGravity == 0)
                             {
                                 if(Player[A].Character == 2)
-                                    Player[A].Location.SpeedY = Player[A].Location.SpeedY + Physics.PlayerGravity * 0.9;
+                                    Player[A].Location.SpeedY += Physics.PlayerGravity * 0.9;
                                 else
-                                    Player[A].Location.SpeedY = Player[A].Location.SpeedY + Physics.PlayerGravity;
+                                    Player[A].Location.SpeedY += Physics.PlayerGravity;
                                 if(Player[A].HoldingNPC > 0)
                                 {
                                     if(NPC[Player[A].HoldingNPC].Type == 278 || NPC[Player[A].HoldingNPC].Type == 279)
@@ -1823,9 +1823,9 @@ void UpdatePlayer()
                                         if(Player[A].Controls.Jump || Player[A].Controls.AltJump)
                                         {
                                             if(Player[A].Character == 2)
-                                                Player[A].Location.SpeedY = Player[A].Location.SpeedY - Physics.PlayerGravity * 0.9 * 0.8;
+                                                Player[A].Location.SpeedY += -Physics.PlayerGravity * 0.9 * 0.8;
                                             else
-                                                Player[A].Location.SpeedY = Player[A].Location.SpeedY - Physics.PlayerGravity * 0.8;
+                                                Player[A].Location.SpeedY += -Physics.PlayerGravity * 0.8;
                                             if(Player[A].Location.SpeedY > Physics.PlayerGravity * 3)
                                                 Player[A].Location.SpeedY = Physics.PlayerGravity * 3;
                                         }
@@ -1837,7 +1837,7 @@ void UpdatePlayer()
                                     Player[A].Location.SpeedY = Physics.PlayerTerminalVelocity;
                             }
                             else
-                                Player[A].NoGravity = Player[A].NoGravity - 1;
+                                Player[A].NoGravity -= 1;
                         }
 
                         // princess float
@@ -1881,8 +1881,8 @@ void UpdatePlayer()
                         {
                             if((Player[A].Controls.Jump || Player[A].Controls.AltJump) && Player[A].Vine == 0)
                             {
-                                Player[A].FloatTime = Player[A].FloatTime - 1;
-                                Player[A].FloatSpeed = Player[A].FloatSpeed + Player[A].FloatDir * 0.1;
+                                Player[A].FloatTime -= 1;
+                                Player[A].FloatSpeed += Player[A].FloatDir * 0.1;
                                 if(Player[A].FloatSpeed > 0.8)
                                     Player[A].FloatDir = -1;
                                 if(Player[A].FloatSpeed < -0.8)
@@ -1935,7 +1935,7 @@ void UpdatePlayer()
                             }
                         }
                     }
-                    Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.SpeedY;
+                    Player[A].Location.Y += Player[A].Location.SpeedY;
                 }
 
                 // princess peach and toad stuff
@@ -2016,10 +2016,10 @@ void UpdatePlayer()
                                 Player[A].FairyCD = 0;
                             }
                         }
-                        // Coins = Coins - 1
+                        // Coins += -1
                         // If Coins < 0 Then
-                        // Lives = Lives - 1
-                        // Coins = Coins + 99
+                        // Lives += -1
+                        // Coins += 99
                         // If Lives < 0 Then
                         // Lives = 0
                         // Coins = 0
@@ -2037,9 +2037,9 @@ void UpdatePlayer()
                             {
                                 tempLocation = Background[B].Location;
                                 tempLocation.Width = 16;
-                                tempLocation.X = tempLocation.X + 8;
+                                tempLocation.X += 8;
                                 tempLocation.Height = 26;
-                                tempLocation.Y = tempLocation.Y + 2;
+                                tempLocation.Y += 2;
                                 if(CheckCollision(Player[A].Location, tempLocation))
                                 {
                                     PlaySound(SFX_Key);
@@ -2052,7 +2052,7 @@ void UpdatePlayer()
                     }
                     if(Player[A].SwordPoke < 0)
                     {
-                        Player[A].SwordPoke = Player[A].SwordPoke - 1;
+                        Player[A].SwordPoke -= 1;
                         if(Player[A].SwordPoke == -7)
                             Player[A].SwordPoke = 1;
                         if(Player[A].SwordPoke == -40)
@@ -2096,13 +2096,13 @@ void UpdatePlayer()
                                 {
                                     NPC[numNPCs].Location.Y = Player[A].Location.Y + 5;
                                     if(Player[A].State == 6)
-                                        NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y + 7;
+                                        NPC[numNPCs].Location.Y += 7;
                                 }
                                 else
                                 {
                                     NPC[numNPCs].Location.Y = Player[A].Location.Y + 18;
                                     if(Player[A].State == 6)
-                                        NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y + 4;
+                                        NPC[numNPCs].Location.Y += 4;
                                 }
 
 
@@ -2120,13 +2120,13 @@ void UpdatePlayer()
                                 if(Player[A].State == 6)
                                     NPC[numNPCs].Location.SpeedX = 9 * Player[A].Direction + (Player[A].Location.SpeedX / 3);
                                 if(Player[A].StandingOnNPC != 0)
-                                    NPC[numNPCs].Location.Y = NPC[numNPCs].Location.Y - Player[A].Location.SpeedY;
+                                    NPC[numNPCs].Location.Y += -Player[A].Location.SpeedY;
                                 CheckSectionNPC(numNPCs);
                             }
                         }
                         else
                             TailSwipe(A, false, true);
-                        Player[A].SwordPoke = Player[A].SwordPoke + 1;
+                        Player[A].SwordPoke += 1;
                         if(Player[A].Duck)
                         {
                             if(Player[A].SwordPoke >= 10)
@@ -2150,9 +2150,9 @@ void UpdatePlayer()
                         {
                             Player[A].SwordPoke = 0;
                             Player[A].Duck = true;
-                            Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                            Player[A].Location.Y += Player[A].Location.Height;
                             Player[A].Location.Height = Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
-                            Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                            Player[A].Location.Y += -Player[A].Location.Height;
                         }
                         else if(Player[A].Duck && Player[A].Location.SpeedY > Physics.PlayerGravity && Player[A].StandingOnNPC == 0 && Player[A].Slope == 0) // Link stands when falling
                         {
@@ -2175,8 +2175,8 @@ void UpdatePlayer()
 //                    Player[A].FloatRelease = true;
 
                 // Player interactions
-                Player[A].Location.SpeedX = Player[A].Location.SpeedX + Player[A].Bumped2;
-                Player[A].Location.X = Player[A].Location.X + Player[A].Bumped2;
+                Player[A].Location.SpeedX += Player[A].Bumped2;
+                Player[A].Location.X += Player[A].Bumped2;
                 Player[A].Bumped2 = 0;
                 if(Player[A].Mount == 0)
                     Player[A].YoshiYellow = false;
@@ -2316,21 +2316,21 @@ void UpdatePlayer()
                 tempSlope2 = 0;
                 tempSlope3 = 0;
                 if(Player[A].Pinched1 > 0)
-                    Player[A].Pinched1 = Player[A].Pinched1 - 1;
+                    Player[A].Pinched1 -= 1;
                 if(Player[A].Pinched2 > 0)
-                    Player[A].Pinched2 = Player[A].Pinched2 - 1;
+                    Player[A].Pinched2 -= 1;
                 if(Player[A].Pinched3 > 0)
-                    Player[A].Pinched3 = Player[A].Pinched3 - 1;
+                    Player[A].Pinched3 -= 1;
                 if(Player[A].Pinched4 > 0)
-                    Player[A].Pinched4 = Player[A].Pinched4 - 1;
+                    Player[A].Pinched4 -= 1;
                 if(Player[A].NPCPinched > 0)
-                    Player[A].NPCPinched = Player[A].NPCPinched - 1;
+                    Player[A].NPCPinched -= 1;
 
                 if(Player[A].Character == 5 && Player[A].Duck && (Player[A].Location.SpeedY == Physics.PlayerGravity || Player[A].StandingOnNPC != 0 || Player[A].Slope != 0))
                 {
-                    Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                    Player[A].Location.Y += Player[A].Location.Height;
                     Player[A].Location.Height = 30;
-                    Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                    Player[A].Location.Y += -Player[A].Location.Height;
                 }
 
 
@@ -2764,8 +2764,8 @@ void UpdatePlayer()
                                                         C = Block[B].Location.X + Block[B].Location.Width * 0.5;
                                                         D = Block[tempHit3].Location.X + Block[tempHit3].Location.Width * 0.5;
 
-                                                        C = C - (Player[A].Location.X + Player[A].Location.Width * 0.5);
-                                                        D = D - (Player[A].Location.X + Player[A].Location.Width * 0.5);
+                                                        C += -(Player[A].Location.X + Player[A].Location.Width * 0.5);
+                                                        D += -(Player[A].Location.X + Player[A].Location.Width * 0.5);
                                                         if(C < 0)
                                                             C = -C;
                                                         if(D < 0)
@@ -2898,8 +2898,8 @@ void UpdatePlayer()
                                                 {
                                                     Player[A].CanJump = false;
                                                     Player[A].Jump = 0;
-                                                    Player[A].Location.X = Player[A].Location.X - 4 * Player[A].Direction;
-                                                    Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.SpeedY;
+                                                    Player[A].Location.X += -4 * Player[A].Direction;
+                                                    Player[A].Location.Y += -Player[A].Location.SpeedY;
                                                     Player[A].Location.SpeedX = 0;
                                                     Player[A].Location.SpeedY = 0;
                                                 }
@@ -2917,9 +2917,9 @@ void UpdatePlayer()
 
                 if(Player[A].Character == 5 && Player[A].Duck)
                 {
-                    Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.Height;
+                    Player[A].Location.Y += Player[A].Location.Height;
                     Player[A].Location.Height = Physics.PlayerDuckHeight[Player[A].Character][Player[A].State];
-                    Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.Height;
+                    Player[A].Location.Y += -Player[A].Location.Height;
                 }
 
 
@@ -2941,7 +2941,7 @@ void UpdatePlayer()
                     {
                         if(NPC[Player[A].StandingOnNPC].Special2 != 0)
                         {
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX - NPC[Player[A].StandingOnNPC].Location.SpeedX;
+                            Player[A].Location.SpeedX += -NPC[Player[A].StandingOnNPC].Location.SpeedX;
                             movingBlock = false;
                             Player[A].StandingOnNPC = 0;
                         }
@@ -2974,7 +2974,7 @@ void UpdatePlayer()
                                 }
                                 Player[A].Location.SpeedX = 0;
                                 Player[A].Slide = false;
-                                Player[A].GrabTime = Player[A].GrabTime + 1;
+                                Player[A].GrabTime += 1;
                             }
                         }
                     }
@@ -3030,9 +3030,9 @@ void UpdatePlayer()
                                     PlaySound(SFX_Jump);
                                     Player[A].Jump = Physics.PlayerBlockJumpHeight;
                                     if(Player[A].Character == 2)
-                                        Player[A].Jump = Player[A].Jump + 3;
+                                        Player[A].Jump += 3;
                                     if(Player[A].SpinJump)
-                                        Player[A].Jump = Player[A].Jump - 6;
+                                        Player[A].Jump -= 6;
                                 }
                             }
 
@@ -3040,14 +3040,14 @@ void UpdatePlayer()
                             {
                                 Player[A].Location.SpeedY = Physics.PlayerJumpVelocity;
                                 Block[tempHit3].Kill = true;
-                                iBlocks = iBlocks + 1;
+                                iBlocks += 1;
                                 iBlock[iBlocks] = tempHit3;
                                 HitSpot = 0;
                                 tempHit3 = 0;
                                 Player[A].Jump = 7;
 
                                 if(Player[A].Character == 2)
-                                    Player[A].Jump = Player[A].Jump + 3;
+                                    Player[A].Jump += 3;
 
                                 if(Player[A].Controls.Down)
                                 {
@@ -3106,7 +3106,7 @@ void UpdatePlayer()
                         {
                             Player[A].Location.SpeedY = 1;
                             if(!NPC[Player[A].StandingOnNPC].Pinched && !FreezeNPCs)
-                                Player[A].Location.SpeedX = Player[A].Location.SpeedX - NPC[Player[A].StandingOnNPC].Location.SpeedX - NPC[Player[A].StandingOnNPC].BeltSpeed;
+                                Player[A].Location.SpeedX += -NPC[Player[A].StandingOnNPC].Location.SpeedX - NPC[Player[A].StandingOnNPC].BeltSpeed;
                             Player[A].StandingOnNPC = 0;
                         }
                         else if(movingBlock)
@@ -3133,21 +3133,21 @@ void UpdatePlayer()
                                 PlaySound(SFX_Jump);
                                 Player[A].Jump = Physics.PlayerBlockJumpHeight;
                                 if(Player[A].Character == 2)
-                                    Player[A].Jump = Player[A].Jump + 3;
+                                    Player[A].Jump += 3;
                                 if(Player[A].SpinJump)
-                                    Player[A].Jump = Player[A].Jump - 6;
+                                    Player[A].Jump -= 6;
                             }
                         }
                         if(Player[A].SpinJump && (Block[tempHit3].Type == 90 || Block[tempHit3].Type == 526) && Player[A].State > 1 && Block[tempHit3].Special == 0)
                         {
                             Player[A].Location.SpeedY = Physics.PlayerJumpVelocity;
                             Block[tempHit3].Kill = true;
-                            iBlocks = iBlocks + 1;
+                            iBlocks += 1;
                             iBlock[iBlocks] = tempHit3;
                             tempHit3 = 0;
                             Player[A].Jump = 7;
                             if(Player[A].Character == 2)
-                                Player[A].Jump = Player[A].Jump + 3;
+                                Player[A].Jump += 3;
                             if(Player[A].Controls.Down)
                             {
                                 Player[A].Jump = 0;
@@ -3170,13 +3170,13 @@ void UpdatePlayer()
                     {
                         Player[A].Location.SpeedX = 0.2 * Player[A].Direction;
                         if(blockPushX > 0)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + blockPushX;
+                            Player[A].Location.SpeedX += blockPushX;
                     }
                     else if(Player[A].Location.SpeedX + NPC[Player[A].StandingOnNPC].Location.SpeedX < 0 && Player[A].Controls.Left)
                     {
                         Player[A].Location.SpeedX = 0.2 * Player[A].Direction;
                         if(blockPushX < 0)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + blockPushX;
+                            Player[A].Location.SpeedX += blockPushX;
                     }
                     else
                     {
@@ -3192,8 +3192,8 @@ void UpdatePlayer()
                 {
                     C = Block[tempBlockHit[1]].Location.X + Block[tempBlockHit[1]].Location.Width * 0.5;
                     D = Block[tempBlockHit[2]].Location.X + Block[tempBlockHit[2]].Location.Width * 0.5;
-                    C = C - (Player[A].Location.X + Player[A].Location.Width * 0.5);
-                    D = D - (Player[A].Location.X + Player[A].Location.Width * 0.5);
+                    C += -(Player[A].Location.X + Player[A].Location.Width * 0.5);
+                    D += -(Player[A].Location.X + Player[A].Location.Width * 0.5);
                     if(C < 0)
                         C = -C;
                     if(D < 0)
@@ -3238,7 +3238,7 @@ void UpdatePlayer()
                     if(Player[A].Fairy)
                         Player[A].Location.SpeedY = 2;
                     if(Player[A].Vine > 0)
-                        Player[A].Location.Y = Player[A].Location.Y + 0.1;
+                        Player[A].Location.Y += 0.1;
                     if(Player[A].Mount == 2)
                         Player[A].Location.SpeedY = 2;
                     if(Player[A].CanFly2)
@@ -3294,9 +3294,9 @@ void UpdatePlayer()
                         if(CheckCollision(Player[A].Location, Background[B].Location))
                         {
                             tempLocation = Background[B].Location;
-                            tempLocation.Height = tempLocation.Height - 16;
-                            tempLocation.Width = tempLocation.Width - 20;
-                            tempLocation.X = tempLocation.X + 10;
+                            tempLocation.Height -= 16;
+                            tempLocation.Width -= 20;
+                            tempLocation.X += 10;
                             if(CheckCollision(Player[A].Location, tempLocation))
                             {
                                 if(Player[A].Character == 5)
@@ -3364,7 +3364,7 @@ void UpdatePlayer()
                     if(!tempHit2)
                     {
                         if(!NPC[Player[A].StandingOnNPC].Pinched && !FreezeNPCs)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX - NPC[Player[A].StandingOnNPC].Location.SpeedX - NPC[Player[A].StandingOnNPC].BeltSpeed;
+                            Player[A].Location.SpeedX += -NPC[Player[A].StandingOnNPC].Location.SpeedX - NPC[Player[A].StandingOnNPC].BeltSpeed;
                     }
                 }
                 tempHit = false; // Used for JUMP detection
@@ -3636,8 +3636,8 @@ void UpdatePlayer()
                                                 else
                                                     Effect[numEffects].Frame = 5 + (iRand() % 3);
                                             }
-                                            NPC[B].Location.X = NPC[B].Location.X + NPC[B].Location.Width / 2.0 - EffectWidth[10] / 2.0;
-                                            NPC[B].Location.Y = NPC[B].Location.Y + NPC[B].Location.Height / 2.0 - EffectHeight[10] / 2.0;
+                                            NPC[B].Location.X += NPC[B].Location.Width / 2.0 - EffectWidth[10] / 2.0;
+                                            NPC[B].Location.Y += NPC[B].Location.Height / 2.0 - EffectHeight[10] / 2.0;
                                             NewEffect(10, NPC[B].Location);
                                         }
                                     }
@@ -3730,11 +3730,11 @@ void UpdatePlayer()
                                             Player[A].Location.X = Warp[Player[A].Warp].Entrance.X + Warp[Player[A].Warp].Entrance.Width / 2.0 - Player[A].Location.Width / 2.0;
                                             Player[A].Location.Y = Warp[Player[A].Warp].Entrance.Y + Warp[Player[A].Warp].Entrance.Height - Player[A].Location.Height;
                                             tempLocation = Warp[numWarps + 1].Entrance;
-                                            tempLocation.Y = tempLocation.Y - 32;
+                                            tempLocation.Y -= 32;
                                             tempLocation.Height = 64;
                                             NewEffect(54, tempLocation);
                                             tempLocation = Warp[numWarps + 1].Exit;
-                                            tempLocation.Y = tempLocation.Y - 32;
+                                            tempLocation.Y -= 32;
                                             tempLocation.Height = 64;
                                             NewEffect(54, tempLocation);
                                         }
@@ -3768,8 +3768,8 @@ void UpdatePlayer()
                                                 // if standing on 2 or more NPCs find out the best one to stand on
                                                 C = NPC[tempBlockHit[1]].Location.X + NPC[tempBlockHit[1]].Location.Width * 0.5;
                                                 D = NPC[tempBlockHit[2]].Location.X + NPC[tempBlockHit[2]].Location.Width * 0.5;
-                                                C = C - (Player[A].Location.X + Player[A].Location.Width * 0.5);
-                                                D = D - (Player[A].Location.X + Player[A].Location.Width * 0.5);
+                                                C += -(Player[A].Location.X + Player[A].Location.Width * 0.5);
+                                                D += -(Player[A].Location.X + Player[A].Location.Width * 0.5);
                                                 if(C < 0)
                                                     C = -C;
                                                 if(D < 0)
@@ -3795,7 +3795,7 @@ void UpdatePlayer()
                                                     if(Player[A].State == 1)
                                                     {
                                                         Player[A].Location.Height = Physics.PlayerHeight[1][2];
-                                                        Player[A].Location.Y = Player[A].Location.Y - Physics.PlayerHeight[1][2] + Physics.PlayerHeight[Player[A].Character][1];
+                                                        Player[A].Location.Y += -Physics.PlayerHeight[1][2] + Physics.PlayerHeight[Player[A].Character][1];
                                                     }
                                                     Player[A].Mount = 1;
                                                     if(NPC[B].Type == 35)
@@ -4096,7 +4096,7 @@ void UpdatePlayer()
                                                     PlaySound(SFX_BlockHit);
                                                     Player[A].Jump = 0;
                                                     if(Player[A].Mount == 2)
-                                                        Player[A].Location.SpeedY = Player[A].Location.SpeedY + 2;
+                                                        Player[A].Location.SpeedY += 2;
                                                     if(NPC[B].Type == 58 || NPC[B].Type == 21 || NPC[B].Type == 67 || NPC[B].Type == 68 || NPC[B].Type == 69 || NPC[B].Type == 70 || (NPC[B].Type >= 78 && NPC[B].Type <= 83))
                                                     {
                                                         if(NPC[B].Location.SpeedY >= Physics.NPCGravity * 20)
@@ -4134,7 +4134,7 @@ void UpdatePlayer()
                                                         if(!tempBool && NPC[B].Type != 168)
                                                             Player[A].Location.SpeedX = 0.2 * Player[A].Direction;
                                                         if(NPC[Player[A].StandingOnNPC].Type == 57)
-                                                            Player[A].Location.X = Player[A].Location.X - 1;
+                                                            Player[A].Location.X -= 1;
                                                         if(tempBlockHit[1] > 0)
                                                         {
                                                             if(NPC[B].Location.X >= NPC[tempBlockHit[1]].Location.X - 2 && NPC[B].Location.X <= NPC[tempBlockHit[1]].Location.X + 2)
@@ -4182,12 +4182,12 @@ void UpdatePlayer()
                                                         for(int C = 1; C <= numNPCs; C++)
                                                         {
                                                             if(NPC[C].standingOnPlayer == A)
-                                                                NPC[C].Location.X = NPC[C].Location.X + D;
+                                                                NPC[C].Location.X += D;
                                                         }
                                                         for(int C = 1; C <= numPlayers; C++)
                                                         {
                                                             if(Player[C].StandingOnTempNPC == 56)
-                                                                Player[C].Location.X = Player[C].Location.X + D;
+                                                                Player[C].Location.X += D;
                                                         }
                                                     }
                                                 }
@@ -4224,9 +4224,9 @@ void UpdatePlayer()
                     {
                         Player[A].Jump = Physics.PlayerSpringJumpHeight;
                         if(Player[A].Character == 2)
-                            Player[A].Jump = Player[A].Jump + 3;
+                            Player[A].Jump += 3;
                         if(Player[A].SpinJump)
-                            Player[A].Jump = Player[A].Jump - 6;
+                            Player[A].Jump -= 6;
                         Player[A].Location.SpeedY = Physics.PlayerJumpVelocity - 4;
                         if(Player[A].Wet > 0)
                             Player[A].Location.SpeedY = Player[A].Location.SpeedY * 0.3;
@@ -4235,9 +4235,9 @@ void UpdatePlayer()
                     {
                         Player[A].Jump = Physics.PlayerNPCJumpHeight;
                         if(Player[A].Character == 2)
-                            Player[A].Jump = Player[A].Jump + 3;
+                            Player[A].Jump += 3;
                         if(Player[A].SpinJump)
-                            Player[A].Jump = Player[A].Jump - 6;
+                            Player[A].Jump -= 6;
                         Player[A].Location.SpeedY = Physics.PlayerJumpVelocity;
                         if(Player[A].Wet > 0)
                             Player[A].Location.SpeedY = Player[A].Location.SpeedY * 0.3;
@@ -4273,8 +4273,8 @@ void UpdatePlayer()
                     {
                         C = NPC[tempBlockHit[1]].Location.X + NPC[tempBlockHit[1]].Location.Width * 0.5;
                         D = NPC[tempBlockHit[2]].Location.X + NPC[tempBlockHit[2]].Location.Width * 0.5;
-                        C = C - (Player[A].Location.X + Player[A].Location.Width * 0.5);
-                        D = D - (Player[A].Location.X + Player[A].Location.Width * 0.5);
+                        C += -(Player[A].Location.X + Player[A].Location.Width * 0.5);
+                        D += -(Player[A].Location.X + Player[A].Location.Width * 0.5);
                         if(C < 0)
                             C = -C;
                         if(D < 0)
@@ -4316,11 +4316,11 @@ void UpdatePlayer()
                     if(NPC[B].Type == 263)
                     {
                         Player[A].Location.SpeedY = Physics.PlayerJumpVelocity;
-                        NPC[B].Multiplier = NPC[B].Multiplier + Player[A].Multiplier;
+                        NPC[B].Multiplier += Player[A].Multiplier;
                         NPCHit(B, 3, B);
                         Player[A].Jump = 7;
                         if(Player[A].Character == 2)
-                            Player[A].Jump = Player[A].Jump + 3;
+                            Player[A].Jump += 3;
                         if(Player[A].Controls.Down)
                         {
                             Player[A].Jump = 0;
@@ -4333,9 +4333,9 @@ void UpdatePlayer()
                 if(Player[A].HoldingNPC == B) // cant hold an npc that you are standing on
                     B = 0;
                 if(B == 0 && Player[A].StandingOnTempNPC > 0 && Player[A].Mount == 0)
-                    Player[A].Location.SpeedX = Player[A].Location.SpeedX + (NPC[Player[A].StandingOnNPC].Location.SpeedX + NPC[Player[A].StandingOnNPC].BeltSpeed);
+                    Player[A].Location.SpeedX += (NPC[Player[A].StandingOnNPC].Location.SpeedX + NPC[Player[A].StandingOnNPC].BeltSpeed);
                 else if(B > 0 && Player[A].StandingOnNPC == 0 && NPC[B].playerTemp && Player[A].Location.SpeedY >= 0)
-                    Player[A].Location.SpeedX = Player[A].Location.SpeedX - (NPC[B].Location.SpeedX + NPC[B].BeltSpeed);
+                    Player[A].Location.SpeedX += -(NPC[B].Location.SpeedX + NPC[B].BeltSpeed);
 
                 if(movingBlock) // this is for when the player is standing on a moving block
                 {
@@ -4356,20 +4356,20 @@ void UpdatePlayer()
                     {
                         if(Player[A].GroundPound)
                         {
-                            numBlock = numBlock + 1;
+                            numBlock += 1;
                             Block[numBlock].Location.Y = NPC[B].Location.Y;
                             YoshiPound(A, Player[A].Mount, true);
                             Block[numBlock].Location.Y = 0;
-                            numBlock = numBlock - 1;
+                            numBlock -= 1;
                             Player[A].GroundPound = false;
                         }
                         else if(Player[A].YoshiYellow)
                         {
-                            numBlock = numBlock + 1;
+                            numBlock += 1;
                             Block[numBlock].Location.Y = NPC[B].Location.Y;
                             YoshiPound(A, Player[A].Mount);
                             Block[numBlock].Location.Y = 0;
-                            numBlock = numBlock - 1;
+                            numBlock -= 1;
                         }
                     }
                     if(NPC[B].playerTemp == 0)
@@ -4434,11 +4434,11 @@ void UpdatePlayer()
                             Player[A].StandingOnTempNPC = 0;
                             if(Player[A].Location.SpeedY > 4.1)
                             {
-                                Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.SpeedY;
+                                Player[A].Location.Y += -Player[A].Location.SpeedY;
                                 Player[A].Location.SpeedY = NPC[Player[A].StandingOnNPC].Location.SpeedY;
                                 if(Player[A].Location.SpeedY > Physics.PlayerTerminalVelocity)
                                     Player[A].Location.SpeedY = Physics.PlayerTerminalVelocity;
-                                Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.SpeedY;
+                                Player[A].Location.Y += Player[A].Location.SpeedY;
                             }
                         }
                     }
@@ -4446,9 +4446,9 @@ void UpdatePlayer()
                 else if(Player[A].Mount == 1 && Player[A].Jump > 0)
                 {
                     if(B == 0 && Player[A].StandingOnTempNPC > 0)
-                        Player[A].Location.SpeedX = Player[A].Location.SpeedX + (NPC[Player[A].StandingOnNPC].Location.SpeedX + NPC[Player[A].StandingOnNPC].BeltSpeed);
+                        Player[A].Location.SpeedX += (NPC[Player[A].StandingOnNPC].Location.SpeedX + NPC[Player[A].StandingOnNPC].BeltSpeed);
                     else if(B > 0 && Player[A].StandingOnNPC == 0 && NPC[B].playerTemp)
-                        Player[A].Location.SpeedX = Player[A].Location.SpeedX - (NPC[B].Location.SpeedX + NPC[B].BeltSpeed);
+                        Player[A].Location.SpeedX += -(NPC[B].Location.SpeedX + NPC[B].BeltSpeed);
                     Player[A].StandingOnNPC = 0;
                     Player[A].StandingOnTempNPC = 0;
                 }
@@ -4458,14 +4458,14 @@ void UpdatePlayer()
                     {
 
                         if(Player[A].StandingOnNPC < 0)
-                            Player[A].Location.SpeedX = Player[A].Location.SpeedX + NPC[Player[A].StandingOnNPC].Location.SpeedX;
-                        Player[A].Location.Y = Player[A].Location.Y - Player[A].Location.SpeedY;
+                            Player[A].Location.SpeedX += NPC[Player[A].StandingOnNPC].Location.SpeedX;
+                        Player[A].Location.Y += -Player[A].Location.SpeedY;
                         Player[A].Location.SpeedY = NPC[Player[A].StandingOnNPC].Location.SpeedY;
                         if(FreezeNPCs)
                             Player[A].Location.SpeedY = 0;
                         if(Player[A].Location.SpeedY > Physics.PlayerTerminalVelocity)
                             Player[A].Location.SpeedY = Physics.PlayerTerminalVelocity;
-                        Player[A].Location.Y = Player[A].Location.Y + Player[A].Location.SpeedY;
+                        Player[A].Location.Y += Player[A].Location.SpeedY;
                     }
                     Player[A].StandingOnNPC = 0;
                     Player[A].StandingOnTempNPC = 0;
@@ -4568,7 +4568,7 @@ void UpdatePlayer()
                     Player[A].StandUp = true;
                 Player[A].ForceHitSpot3 = false;
                 if(Player[A].ForceHold > 0)
-                    Player[A].ForceHold = Player[A].ForceHold - 1;
+                    Player[A].ForceHold -= 1;
             }
             else // Player special effects
                 PlayerEffects(A);

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -38,7 +38,7 @@ void qSortBlocksY(int min, int max)
     {
         while(Block[hi].Location.Y >= medBlock.Location.Y)
         {
-            hi = hi - 1;
+            hi -= 1;
             if(hi <= lo)
                 break;
         }
@@ -48,10 +48,10 @@ void qSortBlocksY(int min, int max)
             break;
         }
         Block[lo] = Block[hi];
-        lo = lo + 1;
+        lo += 1;
         while(Block[lo].Location.Y < medBlock.Location.Y)
         {
-            lo = lo + 1;
+            lo += 1;
             if(lo >= hi)
                 break;
         }
@@ -85,7 +85,7 @@ void qSortBlocksX(int min, int max)
     {
         while(Block[hi].Location.X >= medBlock.Location.X)
         {
-            hi = hi - 1;
+            hi -= 1;
             if(hi <= lo)
                 break;
         }
@@ -95,10 +95,10 @@ void qSortBlocksX(int min, int max)
             break;
         }
         Block[lo] = Block[hi];
-        lo = lo + 1;
+        lo += 1;
         while(Block[lo].Location.X < medBlock.Location.X)
         {
-            lo = lo + 1;
+            lo += 1;
             if(lo >= hi)
                 break;
         }
@@ -134,7 +134,7 @@ void qSortBackgrounds(int min, int max)
         while(BackGroundPri(hi) >= medBackgroundPri)
         {
 
-            hi = hi - 1;
+            hi -= 1;
             if(hi <= lo)
                 break;
         }
@@ -144,10 +144,10 @@ void qSortBackgrounds(int min, int max)
             break;
         }
         Background[lo] = Background[hi];
-        lo = lo + 1;
+        lo += 1;
         while(BackGroundPri(lo) < medBackgroundPri)
         {
-            lo = lo + 1;
+            lo += 1;
             if(lo >= hi)
                 break;
         }
@@ -392,7 +392,7 @@ void FindSBlocks()
     {
         if(BlockIsSizable[Block[A].Type])
         {
-            sBlockNum = sBlockNum + 1;
+            sBlockNum += 1;
             sBlockArray[sBlockNum] = A;
         }
     }
@@ -417,7 +417,7 @@ void qSortSBlocks(int min, int max)
     {
         while(Block[sBlockArray[hi]].Location.Y >= Block[medBlock].Location.Y)
         {
-            hi = hi - 1;
+            hi -= 1;
             if(hi <= lo)
                 break;
         }
@@ -427,10 +427,10 @@ void qSortSBlocks(int min, int max)
             break;
         }
         sBlockArray[lo] = sBlockArray[hi];
-        lo = lo + 1;
+        lo += 1;
         while(Block[sBlockArray[lo]].Location.Y < Block[medBlock].Location.Y)
         {
-            lo = lo + 1;
+            lo += 1;
             if(lo >= hi)
                 break;
         }
@@ -463,7 +463,7 @@ void qSortNPCsY(int min, int max)
     {
         while(NPC[hi].Location.Y < medNPC.Location.Y)
         {
-            hi = hi - 1;
+            hi -= 1;
             if(hi <= lo)
                 break;
         }
@@ -473,10 +473,10 @@ void qSortNPCsY(int min, int max)
             break;
         }
         NPC[lo] = NPC[hi];
-        lo = lo + 1;
+        lo += 1;
         while(NPC[lo].Location.Y >= medNPC.Location.Y)
         {
-            lo = lo + 1;
+            lo += 1;
             if(lo >= hi)
                 break;
         }
@@ -538,7 +538,7 @@ void qSortTempBlocksX(int min, int max)
     {
         while(Block[hi].Location.X >= medBlock.Location.X)
         {
-            hi = hi - 1;
+            hi -= 1;
             if(hi <= lo)
                 break;
         }
@@ -548,10 +548,10 @@ void qSortTempBlocksX(int min, int max)
             break;
         }
         Block[lo] = Block[hi];
-        lo = lo + 1;
+        lo += 1;
         while(Block[lo].Location.X < medBlock.Location.X)
         {
-            lo = lo + 1;
+            lo += 1;
             if(lo >= hi)
                 break;
         }


### PR DESCRIPTION
There is an effort to get rid all ugly adding / subtracting formulas using "X = X + n;" style came off Visual Basic limits that don't have any support for += or -= operators.

I used next regular expressions to fix up all these formulas, however, to avoid possible damage, I made different things:

Replace adding/subtracting of digits (`x = x + 42;`):
`( +)([a-zA-Z0-9._\[\]]+) = \2 (\+|-) ([0-9\.]+);` -> `\1\2 \3= \4;`

Replace adds with formulas (`x = x + n / 2 - 42;`):
`( +)([a-zA-Z0-9\._\[\]]+) = \2 \+ ` -> `\1\2 += `

Replace subs with formulas (`x = x - n / 2 + 24;`):
`( +)([a-zA-Z0-9\._\[\]]+) = \2 - ` -> `\1\2 += -`

The last case is the most sensitive, if try to do it the silly way, the formula will get distorted because of the minus sign loss.