### PR TITLE
Use CMake's FindBacktrace instead of #include <execinfo.h>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,9 @@ include(version.cmake)
 include(cmake/git_version.cmake)
 
 
-configure_file(lib/CrashHandler/backtrace.h.in lib/CrashHandler/backtrace.h)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+configure_file(lib/CrashHandler/backtrace.h.in
+               generated-include/lib/CrashHandler/backtrace.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/generated-include)
 
 #if(WIN32 OR EMSCRIPTEN OR HAIKU)
 #    set(USE_SYSTEM_LIBS_DEFAULT OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ include(CheckCXXCompilerFlag)
 include(ExternalProject)
 include(CheckLibraryExists)
 include(GNUInstallDirs)
+include(FindBacktrace)
 
 include(cmake/git_info.cmake)
 message("== Current GIT hash [${GIT_COMMIT_HASH}], branch [${GIT_BRANCH}], package [${PACKAGE_SUFFIX}] ==")
@@ -86,6 +87,9 @@ include(version.cmake)
 # Default GIT version
 include(cmake/git_version.cmake)
 
+
+configure_file(lib/CrashHandler/backtrace.h.in lib/CrashHandler/backtrace.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 #if(WIN32 OR EMSCRIPTEN OR HAIKU)
 #    set(USE_SYSTEM_LIBS_DEFAULT OFF)
@@ -520,6 +524,10 @@ if(USE_STATIC_LIBC AND NOT USE_SYSTEM_LIBS)
         target_compile_options(thextech PRIVATE /MT)
         target_link_options(thextech PRIVATE /INCREMENTAL:NO /NODEFAULTLIB:MSVCRT)
     endif()
+endif()
+
+if (Backtrace_FOUND)
+    set_property(TARGET thextech APPEND_STRING PROPERTY LINK_FLAGS " ${Backtrace_LIBRARIES}")
 endif()
 
 if(WIN32)

--- a/lib/CrashHandler/backtrace.h.in
+++ b/lib/CrashHandler/backtrace.h.in
@@ -1,0 +1,4 @@
+#cmakedefine01 Backtrace_FOUND
+#if Backtrace_FOUND
+#include <${Backtrace_HEADER}>
+#endif

--- a/lib/CrashHandler/crash_handler.cpp
+++ b/lib/CrashHandler/crash_handler.cpp
@@ -26,7 +26,9 @@
 #include <cstdlib>
 #include <signal.h>
 
-#if defined(DEBUG_BUILD) && (defined(__gnu_linux__) || defined(_WIN32))
+#include <lib/CrashHandler/backtrace.h>
+
+#if defined(DEBUG_BUILD) && (Backtrace_FOUND || defined(_WIN32))
 #define PGE_ENGINE_DEBUG
 #endif
 
@@ -86,7 +88,6 @@ static int isDebuggerPresent()
 #   include <dbghelp.h>
 #   include <shlobj.h>
 #elif (defined(__linux__) && !defined(__ANDROID__) || defined(__APPLE__))
-#   include <execinfo.h>
 #   include <pwd.h>
 #   include <unistd.h>
 #elif defined(__ANDROID__)
@@ -315,7 +316,7 @@ static std::string getStacktrace()
 #if defined(_WIN32)
     GetStackWalk(bkTrace);
 
-#elif (defined(__linux__) && !defined(__ANDROID__) || defined(__APPLE__))
+#elif Backtrace_FOUND
     void  *array[400];
     int size;
     char **strings;


### PR DESCRIPTION
On some Linux distributions, such as Alpine, the `backtrace` function is not present in the standard C library, causing the build to fail.

This will make it possible to build the engine on these niche distributions, and (untested) allow BSD users to produce backtraces.