### PR TITLE
Added custom memory allocator for RenderOp to optimize the real-time performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ if(USE_STATIC_LIBC)
     set(BUILD_SHARED_LIBS OFF)
 endif()
 
+include(lib/Allocator/pool-allocator.cmake)
 include(lib/DirManager/dirman.cmake)
 include(lib/FileMapper/FileMapper.cmake)
 include(lib/fmt/fmt.cmake)
@@ -263,6 +264,7 @@ set(LIB_SRC
     ${FMT_SRCS}
     ${STACK_WALKER_SRCS}
     ${MD5_SRCS}
+    ${POOLALLOC_SRCS}
     lib/CrashHandler/crash_handler.cpp
     lib/Graphics/graphics_funcs.cpp
     lib/Graphics/image_size.cpp

--- a/lib/Allocator/Allocator.h
+++ b/lib/Allocator/Allocator.h
@@ -1,0 +1,30 @@
+#ifndef ALLOCATOR_H
+#define ALLOCATOR_H
+
+#include <cstddef> // size_t
+
+class Allocator
+{
+protected:
+    std::size_t m_totalSize;
+    std::size_t m_used;
+    std::size_t m_peak;
+public:
+
+    Allocator(const std::size_t totalSize) : m_totalSize { totalSize }, m_used { 0 }, m_peak { 0 } { }
+
+    virtual ~Allocator() { m_totalSize = 0; }
+
+    virtual void* Allocate(const std::size_t size, const std::size_t alignment = 0) = 0;
+
+    virtual void Free(void* ptr) = 0;
+
+    virtual void Init() = 0;
+
+    inline std::size_t getUsed() { return m_used; };
+
+    friend class Benchmark;
+};
+
+#endif /* ALLOCATOR_H */
+

--- a/lib/Allocator/LICENSE
+++ b/lib/Allocator/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Mariano Trebino
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/Allocator/LinearAllocator.cpp
+++ b/lib/Allocator/LinearAllocator.cpp
@@ -1,0 +1,72 @@
+#include "LinearAllocator.h"
+#include "Utils.h"  /* CalculatePadding */
+#include <stdlib.h>     /* malloc, free */
+#include <cassert>   /*assert       */
+#include <algorithm>    // max
+#ifdef _DEBUG
+#include <iostream>
+#endif
+
+LinearAllocator::LinearAllocator(const std::size_t totalSize)
+    : Allocator(totalSize)
+{}
+
+void LinearAllocator::Init()
+{
+    if(m_start_ptr != nullptr)
+    {
+        free(m_start_ptr);
+    }
+
+    m_start_ptr = malloc(m_totalSize);
+    m_offset = 0;
+}
+
+LinearAllocator::~LinearAllocator()
+{
+    free(m_start_ptr);
+    m_start_ptr = nullptr;
+}
+
+void* LinearAllocator::Allocate(const std::size_t size, const std::size_t alignment)
+{
+    std::size_t padding = 0;
+    // std::size_t paddedAddress = 0;
+    const std::size_t currentAddress = (std::size_t)m_start_ptr + m_offset;
+
+    if(alignment != 0 && m_offset % alignment != 0)
+    {
+        // Alignment is required. Find the next aligned memory address and update offset
+        padding = Utils::CalculatePadding(currentAddress, alignment);
+    }
+
+    if(m_offset + padding + size > m_totalSize)
+    {
+        return nullptr;
+    }
+
+    m_offset += padding;
+    const std::size_t nextAddress = currentAddress + padding;
+    m_offset += size;
+
+#ifdef _DEBUG
+    std::cout << "A" << "\t@C " << (void*) currentAddress << "\t@R " << (void*) nextAddress << "\tO " << m_offset << "\tP " << padding << std::endl;
+#endif
+
+    m_used = m_offset;
+    m_peak = std::max(m_peak, m_used);
+
+    return (void*) nextAddress;
+}
+
+void LinearAllocator::Free(void* /*ptr*/)
+{
+    assert(false && "Use Reset() method");
+}
+
+void LinearAllocator::Reset()
+{
+    m_offset = 0;
+    m_used = 0;
+    m_peak = 0;
+}

--- a/lib/Allocator/LinearAllocator.h
+++ b/lib/Allocator/LinearAllocator.h
@@ -1,0 +1,27 @@
+#ifndef LINEARALLOCATOR_H
+#define LINEARALLOCATOR_H
+
+#include "Allocator.h"
+
+class LinearAllocator : public Allocator
+{
+protected:
+    void* m_start_ptr = nullptr;
+    std::size_t m_offset;
+public:
+    LinearAllocator(const std::size_t totalSize);
+
+    virtual ~LinearAllocator();
+
+    virtual void* Allocate(const std::size_t size, const std::size_t alignment = 0) override;
+
+    virtual void Free(void* ptr) override;
+
+    virtual void Init() override;
+
+    virtual void Reset();
+private:
+    LinearAllocator(LinearAllocator& linearAllocator);
+};
+
+#endif /* LINEARALLOCATOR_H */

--- a/lib/Allocator/PoolAllocator.cpp
+++ b/lib/Allocator/PoolAllocator.cpp
@@ -1,0 +1,69 @@
+#include "PoolAllocator.h"
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>     /* malloc, free */
+#include <algorithm>    //max
+#ifdef _DEBUG
+#include <iostream>
+#endif
+
+PoolAllocator::PoolAllocator(const std::size_t totalSize, const std::size_t chunkSize)
+    : Allocator(totalSize)
+{
+    assert(chunkSize >= 8 && "Chunk size must be greater or equal to 8");
+    assert(totalSize % chunkSize == 0 && "Total Size must be a multiple of Chunk Size");
+    this->m_chunkSize = chunkSize;
+}
+
+void PoolAllocator::Init()
+{
+    m_start_ptr = malloc(m_totalSize);
+    this->Reset();
+}
+
+PoolAllocator::~PoolAllocator()
+{
+    free(m_start_ptr);
+}
+
+void* PoolAllocator::Allocate(const std::size_t allocationSize, const std::size_t /*alignment*/)
+{
+    assert(allocationSize == this->m_chunkSize && "Allocation size must be equal to chunk size");
+
+    Node* freePosition = m_freeList.pop();
+
+    assert(freePosition != nullptr && "The pool allocator is full");
+
+    m_used += m_chunkSize;
+    m_peak = std::max(m_peak, m_used);
+#ifdef _DEBUG
+    std::cout << "A" << "\t@S " << m_start_ptr << "\t@R " << (void*) freePosition << "\tM " << m_used << std::endl;
+#endif
+
+    return (void*) freePosition;
+}
+
+void PoolAllocator::Free(void* ptr)
+{
+    m_used -= m_chunkSize;
+
+    m_freeList.push((Node*) ptr);
+
+#ifdef _DEBUG
+    std::cout << "F" << "\t@S " << m_start_ptr << "\t@F " << ptr << "\tM " << m_used << std::endl;
+#endif
+}
+
+void PoolAllocator::Reset()
+{
+    m_used = 0;
+    m_peak = 0;
+    // Create a linked-list with all free positions
+    const int nChunks = m_totalSize / m_chunkSize;
+
+    for(int i = 0; i < nChunks; ++i)
+    {
+        std::size_t address = (std::size_t) m_start_ptr + i * m_chunkSize;
+        m_freeList.push((Node*) address);
+    }
+}

--- a/lib/Allocator/PoolAllocator.h
+++ b/lib/Allocator/PoolAllocator.h
@@ -1,0 +1,30 @@
+#include "Allocator.h"
+#include "StackLinkedList.h"
+
+class PoolAllocator : public Allocator
+{
+private:
+    struct  FreeHeader
+    {};
+
+    using Node = StackLinkedList<FreeHeader>::Node;
+    StackLinkedList<FreeHeader> m_freeList;
+
+    void* m_start_ptr = nullptr;
+    std::size_t m_chunkSize;
+public:
+    PoolAllocator(const std::size_t totalSize, const std::size_t chunkSize);
+
+    virtual ~PoolAllocator();
+
+    virtual void* Allocate(const std::size_t size, const std::size_t alignment = 0) override;
+
+    virtual void Free(void* ptr) override;
+
+    virtual void Init() override;
+
+    virtual void Reset();
+private:
+    PoolAllocator(PoolAllocator& poolAllocator);
+
+};

--- a/lib/Allocator/README.md
+++ b/lib/Allocator/README.md
@@ -1,0 +1,213 @@
+Stuff taken from the repository: https://github.com/mtrebi/memory-allocators
+
+<a href='http://www.recurse.com' title='Made with love at the Recurse Center'><img src='https://cloud.githubusercontent.com/assets/2883345/11325206/336ea5f4-9150-11e5-9e90-d86ad31993d8.png' height='20px'/></a>
+
+# Table of Contents
+&nbsp;[Introduction](https://github.com/mtrebi/memory-allocators#introduction)  <br/>
+&nbsp;[Build instructions](https://github.com/mtrebi/memory-allocators#build-instructions)  <br/>
+&nbsp;[What's wrong with Malloc?](https://github.com/mtrebi/memory-allocators#whats-wrong-with-malloc)  <br/>
+&nbsp;[Custom allocators](https://github.com/mtrebi/memory-allocators#custom-allocators)  <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Linear Allocator](https://github.com/mtrebi/memory-allocators#linear-allocator)  <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Stack Allocator](https://github.com/mtrebi/memory-allocators#stack-allocator)  <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Pool Allocator](https://github.com/mtrebi/memory-allocators#pool-allocator)  <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Free list Allocator](https://github.com/mtrebi/memory-allocators#free-list-allocator)  <br/>
+&nbsp;[Benchmarks](https://github.com/mtrebi/memory-allocators#benchmarks)  <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Time complexity](https://github.com/mtrebi/memory-allocators#time-complexity)  <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Space complexity](https://github.com/mtrebi/memory-allocators#space-complexity)  <br/>
+&nbsp;[Summary](https://github.com/mtrebi/memory-allocators#summary)  <br/>
+&nbsp;[Last thoughts](https://github.com/mtrebi/memory-allocators#last-thoughts)  <br/>
+&nbsp;[Acknowledgments](https://github.com/mtrebi/memory-allocators#acknowledgments)  <br/>
+
+# Introduction
+When applications need more memory this can be allocated in the heap (rather than in the stack) in _runtime_. This memory is called 'dynamic memory' because it can't be known at compile time and its need changes during the execution. Our programs can ask for dynamic memory usin 'malloc'. Malloc returns an address to a position in memory where we can store our data. Once we're done with that data, we can call 'free' to free the memory and let others processes use it.
+
+For this project I've implemented different ways to manage by ourselves dynamic memory in C++.This means that instead of using native calls like 'malloc' or 'free' we're going to use a custom memory allocator that will do this for us but in a more efficient way.
+The goal, then, is to understand how the most common allocators work, what they offer and compare them to see which one performs better.
+
+# Build instructions
+
+```c
+git clone https://github.com/mtrebi/memory-allocators.git
+cmake -S memory-allocator -B build
+cmake --build build
+```
+
+# What's wrong with Malloc?
+* **General purpose**: Being a general purpose operation means that it must work in all cases (from 1byte to 1GB or more...). For this reason the implementation is not as efficient as it could be if the needs were more specific.
+* **Slow**: Sometimes, when allocating memory, malloc needs to change from user to kernel mode to get more memory from the system. When this happens, malloc turns out to be super slow!
+
+# Custom allocators
+Because every program has specific needs, it makes no sense to use a general purpose allocator. We can choose the right allocator that works best for us. This way we can increase our **performance**.
+
+In general, custom allocators share some features:
+* **Low number of mallocs**: Any custom allocator tries to keep the number of mallocs low. To do that, they malloc _big chunks of memory_ and then, they manage this chunk internally to provide smaller allocations.
+* **Data structures**: Secondary data structures like _Linked Lists_, _Trees_, _Stacks_ to manage these big chunks of memory. Usually they are used to keep track of the allocated and/or free portions of memory to _speed up_ operations.
+* **Constraints**: Some allocators are very specific and have constraints over the data or operations that can be performed. This allows them to achieve a high performance but can only be used in some applications.
+
+## Linear allocator
+This is the simplest kind of allocator. The idea is to keep a pointer at the first memory address of your memory chunk and move it every time an allocation is done. In this allocator, the internal fragmentation is kept to a minimum because all elements are sequentially (spatial locality) inserted and the only fragmentation between them is the alignment.
+
+### Data structure
+This allocator only requires a pointer (or an offset) to tell us the position of the last allocation. It doesn't require any extra information or data structure.
+
+![Data structure of a Linear Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/linear1.png)
+
+_Complexity: **O(1)**_
+
+### Allocate
+Simply move the pointer (or offset) forward.
+
+![Allocating memory in a Linear Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/linear2.png)
+
+_Complexity: **O(1)**_
+
+### Free
+Due to its simplicity, this allocator doesn't allow specific positions of memory to be freed. Usually, all memory is freed together.
+
+## Stack allocator
+This is a smart evolution of the Linear Allocator. The idea is to manage the memory as a Stack. So, as before, we keep a pointer to the current memory address and we move it forward for every allocation. However, we also can move it backwards when a free operation is done. As before, we keep the spatial locality principle and the fragmentation is still very low.
+
+### Data structure
+As I said, we need the pointer (or offset) to keep track of the last allocation. In order to be able to free memory, we also need to store a _header_ for each allocation that tell us the size of the allocated block. Thus, when we free, we know how many positions we have to move back the pointer.
+
+![Data structure of a Stack Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/stack1.png)
+
+_Complexity: **O(N*H) --> O(N)**_ where H is the Header size and N is the number of allocations
+
+### Allocate
+Simply move the pointer (or offset) forward and place a header right before the memory block indicating its size.
+
+![Allocating memory in a Stack Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/stack2.png)
+
+_Complexity: **O(1)**_
+
+### Free
+Simply read the block size from the header and move the pointer backwards given that size.
+
+![Freeing memory in a Stack Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/stack3.png)
+
+_Complexity: **O(1)**_
+
+## Pool allocator
+A Pool allocator is quite different from the previous ones. It splits the big memory chunk in smaller chunks of the same size and keeps track of which of them are free. When an allocation is requested it returns the free chunk size. When a freed is done, it just stores it to be used in the next allocation. This way, allocations work super fast and the fragmentation is still very low.
+
+![Splitting scheme in a Pool Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/pool1.png)
+
+### Data structure
+To keep track of the free blocks of memory, the Pool allocator uses a Linked List that links the address of each free memory block.
+
+![Linked List used in a Pool Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/pool2.png)
+
+To reduce the space needed, this **Linked List is stored in the same free blocks** (smart right?). However, this set the constraint that the data chunks must be at least as big as our nodes in the Linked List (so that, we can store the Linked List in the free memory blocks).
+
+![In memory Linked List used in a Pool Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/pool3.png)
+
+_Complexity: **O(1)**_
+
+### Allocate
+An allocation simply means to take (pop) the first free block of the Linked List.
+
+![Allocation in a Pool Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/pool4.png)
+
+The linked list doesn't have to be sorted. Its order its determined by the how the allocations and free are done.
+
+![Random State of a Linked List in a Pool Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/pool5.png)
+
+_Complexity: **O(1)**_
+
+### Free
+Free means to add (push) the freed element as the first element in the Linked List.
+
+_Complexity: **O(1)**_
+
+## Free list allocator
+
+This is a general purpose allocator that, contrary to the others, doesn't impose any restriction. It allows allocations and deallocations to be done in any order. For this reason, its performance is not as good as its predecessors. Depending on the data structure used to speed up this allocator, there are two common implementations: one that uses a Linked List and one that uses a Red black tree.
+
+### Linked list data structure
+As the name says, this implementation uses a Linked List to store, in a sorted manner, the start address of each free contiguous block in memory and its size.
+When an allocation is requested, it searches in the linked list for a block where the data can fit. Then it removes the element from the linked list and places an allocation header (used on deallocations) right before the data (as we did in the Stack allocator).
+On deallocations, we get back the allocation header to know the size of the block that we are going to free. Once we free it we insert it into the sorted linked list and we try to merge contiguous memory blocks together creating bigger blocks.
+
+*Notes: My implementation has some constraints on the size and alignment of the data that can be allocated using **this** allocator. For example, the minimum size that can be allocated should be equals or bigger than the size required of a Free Node. Otherwise, we would be wasting more space in meta-data than in real data (Something similar happens with the alignment) These constraints are related with my implementation. A better implementation would probably handle these cases. I decided not to do so because performance would be drastically affected. In these cases its probably better to use a different allocator.*
+
+![Data structure in a Free list Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/freelist_seq1.png)
+
+_Complexity: **O(N*HF + M*HA)--> O(M)**_ where N is the number of free blocks, HF is the size of the header of free blocks, M the number of allocated blocks and HA the size of the header of allocated blocks
+
+
+### Linked list Allocate
+ When an allocation is requested, we look for a block in memory where our data can fit. This means that we have to iterate our linked list until we find a block that has a size equal or bigger than the size requested (it can store this data plus the allocation header) and remove it from the linked list. This would be a **first-fit** allocation because it stops when it finds the first block where the memory fits. There is another type of search called **best-fit** that looks for the free memory block of smaller size that can handle our data. The latter operation may take more time because is always iterating through all elements but it can reduce fragmentation.
+
+![Allocating in a Free list Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/freelist_seq2.png)
+
+_Complexity: **O(N)**_ where N is the number of free blocks
+
+### Linked list Free
+First of all we get back the information about the allocation from the header. Then, we iterate the Linked List to intert the free block in the right position (because is sorted by address). Once we've inserted it, we merge contiguous blocks. We can merge in _O(1) because our Linked List is sorted. We only need to look at the previous and next elements in the linked list to see if we can merge this contiguous blocks. This operation of merging contiguous memory blocks to create bigger blocks is called _Coalescence_
+If we used instead a Sorted Linked List of free and allocated blocks, the complexity would be *O(1)* but the allocation compleixity would be *O(N) where N is the number of free and allocated blocks and space complexity would be much higher. When we free a memory block we also look at the previous and next blocks to see if we can merge them into one bigger block.
+
+![Freeing in a Free list Allocator](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/freelist_seq3.png)
+
+_Complexity: **O(N)**_ where N is the number of free blocks
+
+### Red black tree data structure
+The purpose of using a Red black tree is to speed up allocations and deallocations. In the Linked List (or sequential) implementation every time an operation was made we needed to iterate the Linked List. This was O(N) in all cases.
+
+Using Red Black trees we can reduce its complexity to O(log N) while keeping space complexity quite low because the tree data is stored inside the free memory blocks. In addition, this structure allows a **best-fit** algorithm to be used, reducing the fragmentation and keeping performance. However, an additional sorted Doubly Linked list is required to store allocated and free elements in order to be able to do coalescence operations in O(1).
+This implementation is the most common and most used in real systems because it offers high flexibility while keeping performance very high.
+
+# Benchmarks
+Now its time to make sure that all the effort in designing and implementing custom memory allocators is worth.
+I've made several benchmarks with different block sizes, number of operations, random order, etc. The time benchmark measures the time execution that takes initializing the allocator 'Init()' (malloc big chunk, setup additional data structures...) and untill the last operation (allocation or free) is performed.
+
+Here I'm only showing what I believe is relevant for the goal of this project.
+
+## Time complexity
+* **Malloc** is without doubt the **worst allocator**.Due to its general and flexible use. _**O(n)**_
+* **Free list allocator** is **A much better choice than malloc** as a general purpose allocator.It uses Linked List to speed up allocations/free. It's about three times better than malloc _**O(n)**_
+
+The next allocator are even better BUT they are no longer general purpose allocators. They **impose restrictions** in how we can use them:
+* **Pool allocator** forces us to always allocate the same size but then we can allocate and deallocate in any order. The complexity of this one is slightly better than the free list allocator, wait what? The complexity of the pool allocator was supposed to be constant not linear! And that's true. What its happening here is that the initialization of the additional data structure (the linked list) is _**O(n)**_. It has to create all memory chunks in then linked them in the linked list. This operation is hiding the truly complexity of the allocation and free operations that is _**O(1)**_.  So, take into account to initialize the Pool allocator (and all the allocators in general) before to avoid this kind of behaviors.
+* **Stack allocator** can allocate any size, but deallocations must be done in a LIFO fashion with a _**O(1)**_ complexity. In the chart the complexity is not completely constant due to init function that has to allocate the first big chunk of memory, similarly as before in the pool allocator.
+* **Linear allocator** is the simplest and the best performant allocator with a _**O(1)**_ complexity but its also the most restrictive because single free operations are not allowed. As with the stack, the complexity doesn't look completely constant due to the init function.
+
+![Time complexity of different allocators](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/operations_over_time.png)
+
+In the next chart we can see that if we don't include the Init() function in the benchmark, the overall execution time is reduced and as a consequence we can effectively see that the Linear, Stack and Pool allocators are constant while malloc and free list are clearly linear. The free list implementation using black tree can reduce the complexity to _**O(log n)**_ and therefore its position in the chart would be between the pool allocator and the free list.
+
+![Time complexity of different allocators](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/operations_over_time_no_init.png)
+
+_Note: The time complexity (in general) scales following a linear fashion regarding the size of the allocation request.
+
+## Space complexity
+As we can see, even that the space complexity for each allocator is slightly different(due to constants), in the end, all of them have the same space complexity **O(N)**. It is very clear, then, why when denoting big O, constants can be ignored: because its weight in the overall equation is very low when N grows.
+
+![Space complexity of different allocators](https://github.com/mtrebi/memory-allocators/blob/master/docs/images/operations_over_space.png)
+
+# Summary
+This is a brief summary describing when you should use each allocator. From more restrictive and efficient allocators to less efficient and general.
+
+* **Linear allocator**. If your data does not follows any specific structure. However, there's a common behavior in time: all data "expires" after a certain time and then is no longer useful and thus can be freed. Think about games for example, you can allocate data in one frame using a this allocator and free all data at the start of the next frame.
+* **Stack allocator**. The same as the Linear allocator but think if it useful to free elements in a LIFO fashion.
+* **Pool allocator**. Your data has definitely a structure. All elements of your data have the same size. This is your choice, fast and no fragmentation.
+* **Buddy allocator** (_Not implemented here_). Your data is organized in exponential sizes power-of-two (1,2,4,8,16,32...). This allocator performs extremely well when data is structure in that way, being fast and wasting little space.
+* **Free list allocator**. No structure or common behavior. This allocator allows you to allocate and free memory as you wish. This is a general purpose allocator that works much better than malloc, but is not as good as the previous allocators, given its flexibility to work in all situations.
+
+# Last thoughts
+* Avoid dynamic memory as much as possible. Its behavior is unexpected and a source of problems
+* If you are worried about performance and your application uses dynamic memory, think about using a custom allocator instead of malloc
+* Try to understand your data and its behavior to choose the right allocator for you. Specific allocators (that impose restrictions on how we can structure/use our data) are far more better than the generic ones. We saw a huge gap between the specific purpose allocator: **Linear, Stack and Pool** and the general purpose: **Free list and Malloc**
+* Always choose a less restrictive (or more general) allocator if unsure. If you later see that your data is structured you can always change to use a more restrictive one.
+
+# Future work
+* Implement every memory allocator assuming that the alignment is always 8 bytes and thus everything is always align (we no longer need headers).
+* Implement a Free list allocator using Red Black Trees to improve performance from O(N) to O(log N)
+* Implement a Buddy allocator
+* Implement a Slab allocator
+* Benchmark internal fragmentation
+* Benchmark spatial location (cache misses)
+
+# Acknowledgments
+
+Thanks to [Vanessa](https://github.com/vipyne) and [Krish](https://github.com/sigmasleep) for helping me in the different stages of this project.

--- a/lib/Allocator/StackLinkedList.h
+++ b/lib/Allocator/StackLinkedList.h
@@ -1,0 +1,26 @@
+#ifndef STACKLINKEDLIST_H
+#define STACKLINKEDLIST_H
+
+template <class T>
+class StackLinkedList
+{
+public:
+    struct Node
+    {
+        T data;
+        Node* next;
+    };
+
+    Node* head;
+
+public:
+    StackLinkedList() = default;
+    StackLinkedList(StackLinkedList& stackLinkedList) = delete;
+    void push(Node* newNode);
+    Node* pop();
+};
+
+#include "StackLinkedListImpl.h"
+
+#endif /* STACKLINKEDLIST_H */
+

--- a/lib/Allocator/StackLinkedListImpl.h
+++ b/lib/Allocator/StackLinkedListImpl.h
@@ -1,0 +1,16 @@
+#include "StackLinkedList.h"
+
+template <class T>
+void StackLinkedList<T>::push(Node* newNode)
+{
+    newNode->next = head;
+    head = newNode;
+}
+
+template <class T>
+typename StackLinkedList<T>::Node* StackLinkedList<T>::pop()
+{
+    Node* top = head;
+    head = head->next;
+    return top;
+}

--- a/lib/Allocator/Utils.h
+++ b/lib/Allocator/Utils.h
@@ -1,0 +1,42 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <cstddef>
+
+class Utils
+{
+public:
+    static std::size_t CalculatePadding(const std::size_t baseAddress, const std::size_t alignment)
+    {
+        const std::size_t multiplier = (baseAddress / alignment) + 1;
+        const std::size_t alignedAddress = multiplier * alignment;
+        const std::size_t padding = alignedAddress - baseAddress;
+        return padding;
+    }
+
+    static std::size_t CalculatePaddingWithHeader(const std::size_t baseAddress, const std::size_t alignment, const std::size_t headerSize)
+    {
+        std::size_t padding = CalculatePadding(baseAddress, alignment);
+        std::size_t neededSpace = headerSize;
+
+        if(padding < neededSpace)
+        {
+            // Header does not fit - Calculate next aligned address that header fits
+            neededSpace -= padding;
+
+            // How many alignments I need to fit the header
+            if(neededSpace % alignment > 0)
+            {
+                padding += alignment * (1 + (neededSpace / alignment));
+            }
+            else
+            {
+                padding += alignment * (neededSpace / alignment);
+            }
+        }
+
+        return padding;
+    }
+};
+
+#endif /* UTILS_H */

--- a/lib/Allocator/linear-allocator.cmake
+++ b/lib/Allocator/linear-allocator.cmake
@@ -1,0 +1,7 @@
+include_directories(${CMAKE_CURRENT_LIST_DIR})
+
+set(LINALLOC_SRCS)
+
+list(APPEND LINALLOC_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/LinearAllocator.cpp
+)

--- a/lib/Allocator/pool-allocator.cmake
+++ b/lib/Allocator/pool-allocator.cmake
@@ -1,0 +1,7 @@
+include_directories(${CMAKE_CURRENT_LIST_DIR})
+
+set(POOLALLOC_SRCS)
+
+list(APPEND POOLALLOC_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/PoolAllocator.cpp
+)

--- a/src/script/luna/luna.cpp
+++ b/src/script/luna/luna.cpp
@@ -64,6 +64,7 @@ void lunaReset()
 
     Renderer::Get().ClearAllDebugMessages();
     Renderer::Get().ClearAllLoadedImages();
+    Renderer::Get().ClearQueue();
     gSpriteMan.ResetSpriteManager();
     gCellMan.Reset();
     Input::ResetAll();

--- a/src/script/luna/lunarender.h
+++ b/src/script/luna/lunarender.h
@@ -27,11 +27,16 @@
 #include <vector>
 #include <string>
 #include <list>
+#include <Allocator/PoolAllocator.h>
 
 #include "lunaimgbox.h"
 
 class RenderOp;
 class LunaImage;
+
+const size_t c_rAllocChunkSize = 104;
+const size_t c_rAllocTotalSize = 104 * 1000;
+extern PoolAllocator g_rAlloc;
 
 struct Renderer
 {
@@ -41,11 +46,11 @@ struct Renderer
     static bool IsAltThreadActive();
 
     Renderer() noexcept;
-    ~Renderer() = default;
+    ~Renderer();
 
     bool LoadBitmapResource(const std::string &filename, int resource_code, int transparency_color); // don't give full path
     bool LoadBitmapResource(const std::string &filename, int resource_code);
-    void StoreImage(const LunaImage &bmp, int resource_code);
+    void StoreImage(LunaImage&& bmp, int resource_code);
     bool DeleteImage(int resource_code);
     LunaImage *GetImageForResourceCode(int resource_code);
 

--- a/src/script/luna/renderop.h
+++ b/src/script/luna/renderop.h
@@ -23,6 +23,8 @@
 #define RENDEROP_H
 
 #include "lunarender.h"
+#include <SDL2/SDL_assert.h>
+
 
 static const double RENDEROP_PRIORITY_MIN = -100.0;
 static const double RENDEROP_PRIORITY_MAX = 10.0;
@@ -45,10 +47,23 @@ struct RenderOpColor
 class RenderOp
 {
 public:
-    RenderOp() : m_FramesLeft(1), m_selectedCamera(0), m_renderPriority(RENDEROP_DEFAULT_PRIORITY_RENDEROP) { }
-    explicit RenderOp(double priority) : m_FramesLeft(1), m_selectedCamera(0), m_renderPriority(priority) { }
+    RenderOp() : m_FramesLeft(1), m_selectedCamera(0), m_renderPriority(RENDEROP_DEFAULT_PRIORITY_RENDEROP) {}
+    explicit RenderOp(double priority) : m_FramesLeft(1), m_selectedCamera(0), m_renderPriority(priority) {}
     virtual ~RenderOp() = default;
     virtual void Draw(Renderer* /*renderer*/) {}
+
+    inline void* operator new(size_t size)
+    {
+        // Note: If you creating any chunks with a size bigger than current size, please increase it
+        SDL_assert_release(size < c_rAllocChunkSize);
+        auto *ret = g_rAlloc.Allocate(c_rAllocChunkSize);
+        return ret;
+    }
+
+    inline void operator delete(void* memory)
+    {
+        g_rAlloc.Free(memory);
+    }
 
     int m_FramesLeft;		// How many frames until this op should be destroyed
     int m_selectedCamera;

--- a/src/script/luna/renderop_string.cpp
+++ b/src/script/luna/renderop_string.cpp
@@ -25,12 +25,31 @@ RenderStringOp::RenderStringOp() : RenderStringOp(std::string(), 1, 400.f, 400.f
 
 RenderStringOp::RenderStringOp(const std::string &str, int font_type, float X, float Y) :
     RenderOp(RENDEROP_DEFAULT_PRIORITY_TEXT),
-    m_String(str),
     m_FontType(font_type),
     m_X(X),
     m_Y(Y),
     sceneCoords(false)
-{}
+{
+    m_StringSize = str.size();
+    m_StringDup = (m_StringSize >= c_rAllocChunkSize);
+
+    if(m_StringDup) // fallback if string is longer than chunk size, that shouldn't happen usually
+        m_String = SDL_strdup(str.c_str());
+    else
+    {
+        m_String = (char*)g_rAlloc.Allocate(c_rAllocChunkSize);
+        m_StringSize = SDL_strlcpy(m_String, str.c_str(), c_rAllocChunkSize);
+    }
+}
+
+RenderStringOp::~RenderStringOp()
+{
+    if(m_StringDup)
+        SDL_free(m_String);
+    else
+        g_rAlloc.Free(m_String);
+    m_String = nullptr;
+}
 
 void RenderStringOp::Draw(Renderer *renderer)
 {
@@ -46,7 +65,7 @@ void RenderStringOp::Draw(Renderer *renderer)
     if(!sceneCoords)
         XRender::offsetViewportIgnore(true);
 
-    SuperPrint(m_String, m_FontType, x, y);
+    SuperPrint(m_StringSize, m_String, m_FontType, x, y);
 
     if(!sceneCoords)
         XRender::offsetViewportIgnore(false);

--- a/src/script/luna/renderop_string.h
+++ b/src/script/luna/renderop_string.h
@@ -33,11 +33,16 @@ public:
 
     RenderStringOp(const std::string &str, int font_type, float X, float Y);
 
-    ~RenderStringOp() override = default;
+    ~RenderStringOp() override;
 
     void Draw(Renderer *renderer) override;
 
-    std::string m_String;
+    // FIXME: Replace this with the string data index
+    // Every autocode should use the string index storage, and this thing won't be needed
+    char*  m_String = nullptr;
+    size_t m_StringSize = 0;
+    bool   m_StringDup = false;
+
     int m_FontType;
     float m_X;
     float m_Y;


### PR DESCRIPTION
Using dynamic allocation/releasing every frame is not good as the default generic-purpose allocator can affect the performance and stability. So, to keep the flexibility of dynamic allocation and improve the performance, it's reasonable to use the custom allocator for the stuff.