### PR TITLE
Tune out the RangeArr template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ option(USE_SYSTEM_SDL2 "Use SDL2 from a system even prefering system libraries" 
 option(USE_STATIC_LIBC "Link libc and libstdc++ statically" OFF)
 
 option(RANGE_ARR_USE_HEAP "Store data of RangeArr<> template in a heap" OFF)
+option(RANGE_ARR_UNSAFE_MODE "Disable all range checks at RangeArr<> template" OFF)
 
 option(ENABLE_ANTICHEAT_TRAP "Enable anti-cheating trap for the \"redigitiscool\" cheat code" OFF)
 option(ENABLE_OLD_CREDITS "Use original Redigit's credits without changes" OFF)
@@ -602,6 +603,10 @@ target_link_libraries(thextech PRIVATE A2XT_Int)
 
 if(RANGE_ARR_USE_HEAP)
     target_compile_definitions(thextech PRIVATE -DRANGE_ARR_USE_HEAP)
+endif()
+
+if(RANGE_ARR_UNSAFE_MODE)
+    target_compile_definitions(thextech PRIVATE -DRANGE_ARR_UNSAFE_MODE)
 endif()
 
 if(ENABLE_ANTICHEAT_TRAP)

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -129,13 +129,8 @@ RangeArr<WorldLevel_t, 1, maxWorldLevels> WorldLevel;
 RangeArr<Background_t, 1, (maxBackgrounds + maxWarps)> Background;
 RangeArr<Effect_t, 1, maxEffects> Effect;
 
-#ifdef THEXTECH_UNSAFE_ARRAYS
-NPC_t _NPC[maxNPCs+128+1];
-Block_t Block[maxBlocks+1];
-#else
 RangeArr<NPC_t, -128, maxNPCs> NPC;
 RangeArr<Block_t, 0, maxBlocks> Block;
-#endif
 
 RangeArr<Player_t, 0, maxPlayers> Player;
 RangeArrI<int, 0, maxPlayerFrames, 0> MarioFrameX;
@@ -157,38 +152,6 @@ RangeArrI<int, 0, maxNPCType, 0> NPCWidthGFX;
 RangeArrI<int, 0, maxNPCType, 0> NPCHeightGFX;
 RangeArr<float, 0, maxNPCType> NPCSpeedvar;
 
-#ifdef THEXTECH_UNSAFE_ARRAYS
-bool NPCIsAShell[maxNPCType+1] = {false};
-bool NPCIsABlock[maxNPCType+1] = {false};
-bool NPCIsAHit1Block[maxNPCType+1] = {false};
-bool NPCIsABonus[maxNPCType+1] = {false};
-bool NPCIsACoin[maxNPCType+1] = {false};
-bool NPCIsAVine[maxNPCType+1] = {false};
-bool NPCIsAnExit[maxNPCType+1] = {false};
-bool NPCIsAParaTroopa[maxNPCType+1] = {false};
-bool NPCIsCheep[maxNPCType+1] = {false};
-bool NPCJumpHurt[maxNPCType+1] = {false};
-bool NPCNoClipping[maxNPCType+1] = {false};
-int NPCScore[maxNPCType+1] = {0};
-bool NPCCanWalkOn[maxNPCType+1] = {false};
-bool NPCGrabFromTop[maxNPCType+1] = {false};
-bool NPCTurnsAtCliffs[maxNPCType+1] = {false};
-bool NPCWontHurt[maxNPCType+1] = {false};
-bool NPCMovesPlayer[maxNPCType+1] = {false};
-bool NPCStandsOnPlayer[maxNPCType+1] = {false};
-bool NPCIsGrabbable[maxNPCType+1] = {false};
-bool NPCIsBoot[maxNPCType+1] = {false};
-bool NPCIsYoshi[maxNPCType+1] = {false};
-bool NPCIsToad[maxNPCType+1] = {false};
-bool NPCNoYoshi[maxNPCType+1] = {false};
-bool NPCForeground[maxNPCType+1] = {false};
-bool NPCIsABot[maxNPCType+1] = {false};
-bool NPCDefaultMovement[maxNPCType+1] = {false};
-bool NPCIsVeggie[maxNPCType+1] = {false};
-bool NPCNoFireBall[maxNPCType+1] = {false};
-bool NPCNoIceBall[maxNPCType+1] = {false};
-bool NPCNoGravity[maxNPCType+1] = {false};
-#else
 RangeArrI<bool, 0, maxNPCType, false> NPCIsAShell;
 RangeArrI<bool, 0, maxNPCType, false> NPCIsABlock;
 RangeArrI<bool, 0, maxNPCType, false> NPCIsAHit1Block;
@@ -219,7 +182,6 @@ RangeArrI<bool, 0, maxNPCType, false> NPCIsVeggie;
 RangeArrI<bool, 0, maxNPCType, false> NPCNoFireBall;
 RangeArrI<bool, 0, maxNPCType, false> NPCNoIceBall;
 RangeArrI<bool, 0, maxNPCType, false> NPCNoGravity;
-#endif
 
 RangeArrI<int, 0, maxNPCType, 0> NPCFrame;
 RangeArrI<int, 0, maxNPCType, 0> NPCFrameSpeed;
@@ -601,17 +563,9 @@ void initAll()
     qScreenX.fill(0.0);
     qScreenY.fill(0.0);
 
-    for(int A = 0; A <= maxBlocks; A++)
-    {
-        Block[A] = Block_t();
-    }
-    // Block.fill(Block_t());
+    Block.fill(Block_t());
     Background.fill(Background_t());
-    for(int A = -128; A <= maxNPCs; A++)
-    {
-        NPC[A] = NPC_t();
-    }
-    // NPC.fill(NPC_t());
+    NPC.fill(NPC_t());
 }
 
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -1263,17 +1263,10 @@ extern RangeArr<Background_t, 1, (maxBackgrounds + maxWarps)> Background;
 //Public Effect(1 To maxEffects) As Effect
 extern RangeArr<Effect_t, 1, maxEffects> Effect;
 
-#ifdef THEXTECH_UNSAFE_ARRAYS
-extern NPC_t _NPC[maxNPCs+128+1];
-constexpr NPC_t* NPC = &_NPC[128];
-
-extern Block_t Block[maxBlocks+1];
-#else
 //Public NPC(-128 To maxNPCs) As NPC
 extern RangeArr<NPC_t, -128, maxNPCs> NPC;
 //Public Block(0 To maxBlocks) As Block
 extern RangeArr<Block_t, 0, maxBlocks> Block;
-#endif
 
 //Public Player(0 To maxPlayers) As Player
 extern RangeArr<Player_t, 0, maxPlayers> Player;
@@ -1314,68 +1307,6 @@ extern RangeArrI<int, 0, maxNPCType, 0> NPCHeightGFX;
 //Public NPCSpeedvar(0 To maxNPCType) As Single 'NPC Speed Change
 extern RangeArr<float, 0, maxNPCType> NPCSpeedvar;
 
-#ifdef THEXTECH_UNSAFE_ARRAYS
-//Public NPCIsAShell(0 To maxNPCType) As Boolean 'Flags the NPC type if it is a shell
-extern bool NPCIsAShell[maxNPCType+1];
-//Public NPCIsABlock(0 To maxNPCType) As Boolean 'Flag NPC as a block
-extern bool NPCIsABlock[maxNPCType+1];
-//Public NPCIsAHit1Block(0 To maxNPCType) As Boolean 'Flag NPC as a hit1 block
-extern bool NPCIsAHit1Block[maxNPCType+1];
-//Public NPCIsABonus(0 To maxNPCType) As Boolean 'Flags the NPC type if it is a bonus
-extern bool NPCIsABonus[maxNPCType+1];
-//Public NPCIsACoin(0 To maxNPCType) As Boolean 'Flags the NPC type if it is a coin
-extern bool NPCIsACoin[maxNPCType+1];
-//Public NPCIsAVine(0 To maxNPCType) As Boolean 'Flags the NPC type if it is a vine
-extern bool NPCIsAVine[maxNPCType+1];
-//Public NPCIsAnExit(0 To maxNPCType) As Boolean 'Flags the NPC type if it is a level exit
-extern bool NPCIsAnExit[maxNPCType+1];
-//Public NPCIsAParaTroopa(0 To maxNPCType) As Boolean 'Flags the NPC type as a para-troopa
-extern bool NPCIsAParaTroopa[maxNPCType+1];
-//Public NPCIsCheep(0 To maxNPCType) As Boolean 'Flags the NPC type as a cheep cheep
-extern bool NPCIsCheep[maxNPCType+1];
-//Public NPCJumpHurt(0 To maxNPCType) As Boolean 'Hurts the player even if it jumps on the NPC
-extern bool NPCJumpHurt[maxNPCType+1];
-//Public NPCNoClipping(0 To maxNPCType) As Boolean 'NPC can go through blocks
-extern bool NPCNoClipping[maxNPCType+1];
-//Public NPCScore(0 To maxNPCType) As Integer 'NPC score value
-extern int NPCScore[maxNPCType+1];
-//Public NPCCanWalkOn(0 To maxNPCType) As Boolean  'NPC can be walked on
-extern bool NPCCanWalkOn[maxNPCType+1];
-//Public NPCGrabFromTop(0 To maxNPCType) As Boolean  'NPC can be grabbed from the top
-extern bool NPCGrabFromTop[maxNPCType+1];
-//Public NPCTurnsAtCliffs(0 To maxNPCType) As Boolean  'NPC turns around at cliffs
-extern bool NPCTurnsAtCliffs[maxNPCType+1];
-//Public NPCWontHurt(0 To maxNPCType) As Boolean  'NPC wont hurt the player
-extern bool NPCWontHurt[maxNPCType+1];
-//Public NPCMovesPlayer(0 To maxNPCType) As Boolean 'Player can not walk through the NPC
-extern bool NPCMovesPlayer[maxNPCType+1];
-//Public NPCStandsOnPlayer(0 To maxNPCType) As Boolean 'for the clown car
-extern bool NPCStandsOnPlayer[maxNPCType+1];
-//Public NPCIsGrabbable(0 To maxNPCType) As Boolean 'Player can grab the NPC
-extern bool NPCIsGrabbable[maxNPCType+1];
-//Public NPCIsBoot(0 To maxNPCType) As Boolean 'npc is a kurbo's shoe
-extern bool NPCIsBoot[maxNPCType+1];
-//Public NPCIsYoshi(0 To maxNPCType) As Boolean 'npc is a yoshi
-extern bool NPCIsYoshi[maxNPCType+1];
-//Public NPCIsToad(0 To maxNPCType) As Boolean 'npc is a toad
-extern bool NPCIsToad[maxNPCType+1];
-//Public NPCNoYoshi(0 To maxNPCType) As Boolean 'Player can't eat the NPC
-extern bool NPCNoYoshi[maxNPCType+1];
-//Public NPCForeground(0 To maxNPCType) As Boolean 'draw the npc in front
-extern bool NPCForeground[maxNPCType+1];
-//Public NPCIsABot(0 To maxNPCType) As Boolean 'Zelda 2 Bot monster
-extern bool NPCIsABot[maxNPCType+1];
-//Public NPCDefaultMovement(0 To maxNPCType) As Boolean 'default NPC movement
-extern bool NPCDefaultMovement[maxNPCType+1];
-//Public NPCIsVeggie(0 To maxNPCType) As Boolean 'turnips
-extern bool NPCIsVeggie[maxNPCType+1];
-//Public NPCNoFireBall(0 To maxNPCType) As Boolean 'not hurt by fireball
-extern bool NPCNoFireBall[maxNPCType+1];
-//Public NPCNoIceBall(0 To maxNPCType) As Boolean 'not hurt by fireball
-extern bool NPCNoIceBall[maxNPCType+1];
-//Public NPCNoGravity(0 To maxNPCType) As Boolean 'not affected by gravity
-extern bool NPCNoGravity[maxNPCType+1];
-#else
 //Public NPCIsAShell(0 To maxNPCType) As Boolean 'Flags the NPC type if it is a shell
 extern RangeArrI<bool, 0, maxNPCType, false> NPCIsAShell;
 //Public NPCIsABlock(0 To maxNPCType) As Boolean 'Flag NPC as a block
@@ -1436,7 +1367,6 @@ extern RangeArrI<bool, 0, maxNPCType, false> NPCNoFireBall;
 extern RangeArrI<bool, 0, maxNPCType, false> NPCNoIceBall;
 //Public NPCNoGravity(0 To maxNPCType) As Boolean 'not affected by gravity
 extern RangeArrI<bool, 0, maxNPCType, false> NPCNoGravity;
-#endif
 
 //Public NPCFrame(0 To maxNPCType) As Integer
 extern RangeArrI<int, 0, maxNPCType, 0> NPCFrame;

--- a/src/range_arr.hpp
+++ b/src/range_arr.hpp
@@ -39,10 +39,8 @@ class RangeArr
 
 #ifdef RANGE_ARR_USE_HEAP
     T *array = nullptr;
-    T *arrayPtr = nullptr;
 #else
     T array[size];
-    T *arrayPtr = array + offset;
 #endif
 
 public:
@@ -50,7 +48,6 @@ public:
     {
 #ifdef RANGE_ARR_USE_HEAP
         array = new T[size];
-        arrayPtr = array + offset;
 #endif
     }
 
@@ -65,7 +62,6 @@ public:
     {
 #ifdef RANGE_ARR_USE_HEAP
         array = new T[size];
-        arrayPtr = array + offset;
 #endif
         for(size_t i = 0; i < size; i++)
             array[i] = o.array[i];
@@ -77,7 +73,6 @@ public:
         if(array)
             delete [] array;
         array = new T[size];
-        arrayPtr = array + offset;
 #endif
         for(size_t i = 0; i < size; i++)
             array[i] = o.array[i];
@@ -92,7 +87,7 @@ public:
 
     constexpr T *base() const
     {
-        return arrayPtr;
+        return array + offset;
     }
 
     constexpr T *baseReal() const
@@ -103,17 +98,17 @@ public:
 #ifdef RANGE_ARR_UNSAFE_MODE
     constexpr T& operator[](long index) const
     {
-        return *(arrayPtr + index);
+        return *(const_cast<T*>(array) + index + offset);
     }
 #else
     inline T& operator[](long index)
     {
 #   ifdef RANGE_ARR_USE_HEAP
-        SDL_assert_release(array && arrayPtr); // When array won't initialize
+        SDL_assert_release(array); // When array won't initialize
 #   endif
         SDL_assert_release(index <= end);
         SDL_assert_release(index >= begin);
-        return *(arrayPtr + index);
+        return *(array + index + offset);
     }
 #endif
 };
@@ -127,10 +122,8 @@ class RangeArrI
 
 #ifdef RANGE_ARR_USE_HEAP
     T *array = nullptr;
-    T *arrayPtr = nullptr;
 #else
     T array[size];
-    T *arrayPtr = array + offset;
 #endif
 
 public:
@@ -138,7 +131,6 @@ public:
     {
 #ifdef RANGE_ARR_USE_HEAP
         array = new T[size];
-        arrayPtr = array + offset;
 #endif
         for(size_t i = 0; i < size; i++)
             array[i] = defaultValue;
@@ -155,7 +147,6 @@ public:
     {
 #ifdef RANGE_ARR_USE_HEAP
         array = new T[size];
-        arrayPtr = array + offset;
 #endif
         for(size_t i = 0; i < size; i++)
             array[i] = o.array[i];
@@ -167,7 +158,6 @@ public:
         if(array)
             delete [] array;
         array = new T[size];
-        arrayPtr = array + offset;
 #endif
         for(size_t i = 0; i < size; i++)
             array[i] = o.array[i];
@@ -182,7 +172,7 @@ public:
 
     constexpr T *base() const
     {
-        return arrayPtr;
+        return array + offset;
     }
 
     constexpr T *baseReal() const
@@ -193,17 +183,17 @@ public:
 #ifdef RANGE_ARR_UNSAFE_MODE
     constexpr T& operator[](long index) const
     {
-        return *(arrayPtr + index);
+        return *(const_cast<T*>(array) + index + offset);
     }
 #else
     inline T& operator[](long index)
     {
 #   ifdef RANGE_ARR_USE_HEAP
-        SDL_assert_release(array && arrayPtr); // When array won't initialize
+        SDL_assert_release(array); // When array won't initialize
 #   endif
         SDL_assert_release(index <= end);
         SDL_assert_release(index >= begin);
-        return *(arrayPtr + index);
+        return *(array + index + offset);
     }
 #endif
 };


### PR DESCRIPTION
- Simplify [] access code
- Allow safety checks disabling
- Use "constexpr" function when safe checks got been disabled

I think, we shouldn't make duplicated declarations, just tune out the RangeArr template itself to do all dirty work easier :)