### PR TITLE
Polishing the global strings system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,7 @@ set(THEXTECH_SRC
     src/sound.cpp
     src/frame_timer.cpp
     src/global_dirs.cpp
+    src/global_strings.cpp
     src/core/base/render_base.cpp
     src/core/base/window_base.cpp
     src/core/base/msgbox_base.cpp

--- a/src/global_strings.cpp
+++ b/src/global_strings.cpp
@@ -1,0 +1,145 @@
+/*
+ * TheXTech - A platform game engine ported from old source code for VB6
+ *
+ * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
+ * Copyright (c) 2020-2022 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "global_strings.h"
+
+
+// utilities for stringindex_t
+const std::string g_emptyString = "";
+//! Strings storage
+static std::vector<std::string> g_LevelString;
+//! Counter of usages per every string
+static std::vector<int> g_LevelStringUsages;
+//! List of free indexes appearing at the moddle of array
+static std::vector<int> g_FreeIndexes;
+//! String-To-Index map
+static std::unordered_map<std::string, int> g_uniqueStringsIds;
+//! Number of world strings
+static size_t g_numWorldString = 0;
+
+static std::vector<std::string> g_LevelString_backup;
+static std::vector<int> g_LevelStringUsages_backup;
+static std::vector<int> g_FreeIndexes_backup;
+static std::unordered_map<std::string, int> g_uniqueStringsIds_backup;
+
+
+void SaveWorldStrings()
+{
+    g_LevelString_backup = g_LevelString;
+    g_LevelStringUsages_backup = g_LevelStringUsages;
+    g_FreeIndexes_backup = g_FreeIndexes;
+    g_uniqueStringsIds_backup = g_uniqueStringsIds;
+    g_numWorldString = g_LevelString.size();
+}
+
+void RestoreWorldStrings()
+{
+    g_LevelString = g_LevelString_backup;
+    g_LevelStringUsages = g_LevelStringUsages_backup;
+    g_FreeIndexes = g_FreeIndexes_backup;
+    g_uniqueStringsIds = g_uniqueStringsIds_backup;
+}
+
+void ClearStringsBank()
+{
+    g_LevelString.clear();
+    g_LevelStringUsages.clear();
+    g_uniqueStringsIds.clear();
+    g_FreeIndexes.clear();
+    g_numWorldString = 0;
+}
+
+const std::string& GetS(stringindex_t index)
+{
+    if(index == STRINGINDEX_NONE)
+        return g_emptyString;
+
+    SDL_assert_release(index < g_LevelString.size());
+
+    return g_LevelString[index];
+}
+
+void SetS(stringindex_t& index, const std::string& target)
+{
+    if(index == STRINGINDEX_NONE && target.empty())
+        return;
+
+    SDL_assert_release(index <= STRINGINDEX_NONE);
+
+    bool stringEmpty = index == STRINGINDEX_NONE && g_LevelString.size() < MaxLevelStrings;
+
+    if(!stringEmpty)
+    {
+        SDL_assert_release(index < g_LevelString.size());
+        if(g_LevelString[index] == target)
+            return; // Do nothing, there is an attempt to set the same string
+
+        g_LevelStringUsages[index]--;
+        if(g_LevelStringUsages[index] == 0)
+        {
+            g_uniqueStringsIds.erase(g_LevelString[index]);
+            g_LevelString[index].clear();
+            g_FreeIndexes.push_back(index);
+        }
+        stringEmpty = true;
+    }
+
+    if(stringEmpty)
+    {
+        auto f = g_uniqueStringsIds.find(target);
+        if(f == g_uniqueStringsIds.end())
+        {
+            if(g_FreeIndexes.empty())
+            {
+                index = (stringindex_t)g_LevelString.size();
+                g_LevelString.push_back(target);
+                g_LevelStringUsages.push_back(1);
+            }
+            else
+            {
+                index = g_FreeIndexes.back();
+                g_FreeIndexes.pop_back();
+                g_LevelString[index] = target;
+                g_LevelStringUsages[index] = 1;
+            }
+            g_uniqueStringsIds[target] = index;
+        }
+        else
+        {
+            index = f->second;
+            g_LevelStringUsages[index]++;
+        }
+    }
+}
+
+std::string* PtrS(stringindex_t& index)
+{
+    if(index == STRINGINDEX_NONE)
+    {
+        if(g_LevelString.size() >= MaxLevelStrings)
+            return nullptr;
+        index = (stringindex_t)g_LevelString.size();
+        g_LevelString.push_back(std::string());
+    }
+
+    SDL_assert_release(index < g_LevelString.size());
+
+    return &g_LevelString[index];
+}

--- a/src/global_strings.cpp
+++ b/src/global_strings.cpp
@@ -25,6 +25,10 @@
 const std::string g_emptyString = "";
 //! Strings storage
 static std::vector<std::string> g_LevelString;
+//! Number of world strings
+static size_t g_numWorldString = 0;
+
+#ifdef STRS_UNIQUENESS_TRACKING
 //! Counter of usages per every string
 static std::vector<int> g_LevelStringUsages;
 //! List of free indexes appearing at the moddle of array
@@ -127,6 +131,13 @@ void SetS(stringindex_t& index, const std::string& target)
             g_LevelStringUsages[index]++;
         }
     }
+}
+
+stringindex_t SetS(const std::string& target)
+{
+    stringindex_t out = STRINGINDEX_NONE;
+    SetS(out, target);
+    return out;
 }
 
 std::string* PtrS(stringindex_t& index)

--- a/src/global_strings.h
+++ b/src/global_strings.h
@@ -33,6 +33,8 @@
 
 extern const std::string g_emptyString;
 
+extern size_t StringsBankSize();
+
 extern void SaveWorldStrings();
 extern void RestoreWorldStrings();
 extern void ClearStringsBank();
@@ -50,6 +52,13 @@ extern const std::string& GetS(stringindex_t index);
  * \param target Target string data to assign
  */
 extern void SetS(stringindex_t& index, const std::string& target);
+
+/*!
+ * \brief Create new string index entry or return exist matching
+ * \param target Targete string data to assing
+ * \return destinition string field
+ */
+extern stringindex_t SetS(const std::string& target);
 
 /*!
  * \brief Get string as pointer from the bank by index

--- a/src/global_strings.h
+++ b/src/global_strings.h
@@ -28,52 +28,34 @@
 #include "global_constants.h"
 #include <vector>
 #include <string>
+#include <unordered_map>
 #include <SDL2/SDL_assert.h>
 
 extern const std::string g_emptyString;
-extern std::vector<std::string> g_LevelString;
-extern size_t g_numWorldString;
 
-inline const std::string& GetS(stringindex_t index)
-{
-    if(index == STRINGINDEX_NONE)
-        return g_emptyString;
+extern void SaveWorldStrings();
+extern void RestoreWorldStrings();
+extern void ClearStringsBank();
 
-    SDL_assert_release(index < g_LevelString.size());
+/*!
+ * \brief Get string from the bank by index
+ * \param index Index of string
+ * \return Const referrence to the actual string
+ */
+extern const std::string& GetS(stringindex_t index);
 
-    return g_LevelString[index];
-}
+/*!
+ * \brief Set the string to the index
+ * \param index destinition string field
+ * \param target Target string data to assign
+ */
+extern void SetS(stringindex_t& index, const std::string& target);
 
-inline void SetS(stringindex_t& index, const std::string& target)
-{
-    if(index == STRINGINDEX_NONE && target.empty())
-        return;
-
-    if(index == STRINGINDEX_NONE && g_LevelString.size() < MaxLevelStrings)
-    {
-        index = (stringindex_t)g_LevelString.size();
-        g_LevelString.push_back(target);
-    }
-    else
-    {
-        SDL_assert_release(index < g_LevelString.size());
-        g_LevelString[index] = target;
-    }
-}
-
-inline std::string* PtrS(stringindex_t& index)
-{
-    if(index == STRINGINDEX_NONE)
-    {
-        if(g_LevelString.size() >= MaxLevelStrings)
-            return nullptr;
-        index = (stringindex_t)g_LevelString.size();
-        g_LevelString.push_back(std::string());
-    }
-
-    SDL_assert_release(index < g_LevelString.size());
-
-    return &g_LevelString[index];
-}
+/*!
+ * \brief Get string as pointer from the bank by index
+ * \param index Index of string
+ * \return Pointer to the actual string
+ */
+extern std::string* PtrS(stringindex_t& index);
 
 #endif // #ifndef GLOBAL_STRINGS_H

--- a/src/global_strings.h
+++ b/src/global_strings.h
@@ -34,6 +34,7 @@
 extern const std::string g_emptyString;
 
 extern size_t StringsBankSize();
+extern size_t StringsUnusedEntries();
 
 extern void SaveWorldStrings();
 extern void RestoreWorldStrings();
@@ -58,7 +59,13 @@ extern void SetS(stringindex_t& index, const std::string& target);
  * \param target Targete string data to assing
  * \return destinition string field
  */
-extern stringindex_t SetS(const std::string& target);
+extern stringindex_t AllocS(const std::string& target);
+
+/*!
+ * \brief Clear the string index entry
+ * \param index Target index to clear
+ */
+extern void FreeS(stringindex_t& index);
 
 /*!
  * \brief Get string as pointer from the bank by index

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -644,9 +644,3 @@ double vb6Round(double x, int decimals)
 
     return res;
 }
-
-
-// utilities for stringindex_t
-const std::string g_emptyString = "";
-std::vector<std::string> g_LevelString;
-size_t g_numWorldString;

--- a/src/main/level_file.cpp
+++ b/src/main/level_file.cpp
@@ -840,7 +840,7 @@ void ClearLevel()
     const Location_t BlankLocation = Location_t();
     const Effect_t blankEffect = Effect_t();
     NPCScore[NPCID_DRAGONCOIN] = 6;
-    g_LevelString.resize(g_numWorldString);
+    RestoreWorldStrings();
     LevelName.clear();
     ResetCompat();
     LoadNPCDefaults();

--- a/src/main/world_file.cpp
+++ b/src/main/world_file.cpp
@@ -347,7 +347,7 @@ void OpenWorld(std::string FilePath)
 //            frmWorld::txtCredits(A).Text = WorldCredits[A];
 //        frmWorld.txtStars = MaxWorldStars;
 //    }
-    g_numWorldString = g_LevelString.size();
+    SaveWorldStrings();
     resetFrameTimer();
 }
 
@@ -375,8 +375,7 @@ void ClearWorld()
     for(A = 1; A <= numWorldMusic; A++)
         WorldMusic[A] = WorldMusic_t();
 
-    g_LevelString.clear();
-    g_numWorldString = 0;
+    ClearStringsBank();
     MaxWorldStars = 0;
     numTiles = 0;
     numWorldPaths = 0;

--- a/src/script/luna/autocode.cpp
+++ b/src/script/luna/autocode.cpp
@@ -114,8 +114,8 @@ Autocode &Autocode::operator=(const Autocode &o)
     Param3 = o.Param3;
     Length = o.Length;
     // de-duplicate strings, while re-using allocated string indices if possible
-    SetS(MyString, GetS(o.MyString));
-    SetS(MyRef, GetS(o.MyRef));
+    MyString = o.MyString;
+    MyRef = o.MyRef;
 
     m_OriginalTime = o.m_OriginalTime;
     ActiveSection = o.ActiveSection;

--- a/src/script/luna/autocode.cpp
+++ b/src/script/luna/autocode.cpp
@@ -1151,6 +1151,7 @@ void Autocode::Do(bool init)
             Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("NEAR: {0}", cellobjs.size()), 3, 50, 440));
 
             Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("STRINGS: {0}", StringsBankSize()), 3, 50, 460));
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("STRINGS-Unused: {0}", StringsUnusedEntries()), 3, 50, 480));
             break;
         }
 

--- a/src/script/luna/autocode.cpp
+++ b/src/script/luna/autocode.cpp
@@ -78,7 +78,7 @@ Autocode::Autocode()
 }
 
 Autocode::Autocode(AutocodeType iType, double iTarget, double ip1, double ip2, double ip3,
-                   const std::string &ip4, double iLength, int iSection, const std::string &iVarRef)
+                   const stringindex_t& ip4, double iLength, int iSection, const stringindex_t& iVarRef)
 {
     m_Type = iType;
     Target = iTarget;
@@ -86,8 +86,8 @@ Autocode::Autocode(AutocodeType iType, double iTarget, double ip1, double ip2, d
     Param2 = ip2;
     Param3 = ip3;
     Length = iLength;
-    SetS(MyString, ip4);
-    SetS(MyRef, iVarRef);
+    MyString = ip4;
+    MyRef = iVarRef;
     m_OriginalTime = iLength;
     ftype = FT_INVALID;
     Activated = true;
@@ -1134,21 +1134,23 @@ void Autocode::Do(bool init)
         {
             Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("LunaScript (TheXTech) VERSION-{0}", LUNA_VERSION), 3, 50, 250));
             //Renderer::Get().SafePrint(, 3, 340, 250);
-            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("GLOBL-{0}", gAutoMan.m_GlobalCodes.size()), 3, 50, 300));
-            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("INIT -{0}", gAutoMan.m_InitAutocodes.size()), 3, 50, 330));
-            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("CODES-{0}", gAutoMan.m_Autocodes.size()), 3, 50, 360));
-            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("QUEUE-{0}", gAutoMan.m_CustomCodes.size()), 3, 50, 390));
-            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("SPRITE-{0}", gSpriteMan.CountSprites()), 3, 50, 420));
-            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("BLPRNT-{0}", gSpriteMan.CountBlueprints()), 3, 50, 450));
-            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("COMP-{0}", gSpriteMan.m_ComponentList.size()), 3, 50, 480));
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("Globl: {0}", gAutoMan.m_GlobalCodes.size()), 3, 50, 280));
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("Init:  {0}", gAutoMan.m_InitAutocodes.size()), 3, 50, 300));
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("Codes: {0}", gAutoMan.m_Autocodes.size()), 3, 50, 320));
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("Queue: {0}", gAutoMan.m_CustomCodes.size()), 3, 50, 340));
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("Sprites: {0}", gSpriteMan.CountSprites()), 3, 50, 360));
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("BlueePrints: {0}", gSpriteMan.CountBlueprints()), 3, 50, 380));
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("Components: {0}", gSpriteMan.m_ComponentList.size()), 3, 50, 400));
 
             int buckets = 0, cells = 0, objs = 0;
             gCellMan.CountAll(&buckets, &cells, &objs);
-            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("BCO-{0} {1} {2}", buckets, cells, objs), 3, 50, 510));
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("Buckets={0} Cells={1} Objs={2}", buckets, cells, objs), 3, 50, 420));
 
             std::list<CellObj> cellobjs;
             gCellMan.GetObjectsOfInterest(&cellobjs, demo->Location.X, demo->Location.Y, (int)demo->Location.Width, (int)demo->Location.Height);
-            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("NEAR-{0}", cellobjs.size()), 3, 50, 540));
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("NEAR: {0}", cellobjs.size()), 3, 50, 440));
+
+            Renderer::Get().AddOp(new RenderStringOp(fmt::format_ne("STRINGS: {0}", StringsBankSize()), 3, 50, 460));
             break;
         }
 

--- a/src/script/luna/autocode.h
+++ b/src/script/luna/autocode.h
@@ -217,7 +217,7 @@ public:
     // Ctors
     Autocode();
     Autocode(AutocodeType, double Target, double p1, double p2, double p3,
-             const std::string &p4, double Length, int Section, const std::string &VarRef);
+             const stringindex_t &p4, double Length, int Section, const stringindex_t &VarRef);
     Autocode(const Autocode &o);
     ~Autocode() = default;
 

--- a/src/script/luna/autocode_manager.cpp
+++ b/src/script/luna/autocode_manager.cpp
@@ -302,7 +302,7 @@ void AutocodeManager::Parse(FILE *code_file, bool add_to_globals)
 
             std::string ref_str = std::string(wrefbuf); // Get var reference string if any
 
-            Autocode newcode(ac_type, target, param1, param2, param3, ac_str, length, cur_section, ref_str);
+            Autocode newcode(ac_type, target, param1, param2, param3, SetS(ac_str), length, cur_section, SetS(ref_str));
             if(!add_to_globals)
             {
                 if(newcode.m_Type < 10000 || newcode.MyRef != STRINGINDEX_NONE)

--- a/src/script/luna/autocode_manager.cpp
+++ b/src/script/luna/autocode_manager.cpp
@@ -302,7 +302,7 @@ void AutocodeManager::Parse(FILE *code_file, bool add_to_globals)
 
             std::string ref_str = std::string(wrefbuf); // Get var reference string if any
 
-            Autocode newcode(ac_type, target, param1, param2, param3, SetS(ac_str), length, cur_section, SetS(ref_str));
+            Autocode newcode(ac_type, target, param1, param2, param3, AllocS(ac_str), length, cur_section, AllocS(ref_str));
             if(!add_to_globals)
             {
                 if(newcode.m_Type < 10000 || newcode.MyRef != STRINGINDEX_NONE)

--- a/src/script/luna/lunainput.cpp
+++ b/src/script/luna/lunainput.cpp
@@ -193,6 +193,7 @@ void Input::UpdateKeyRecords(Player_t *pPlayer)
 #define TOGGLE_DEMO_COUNTER_CHT "toggledemocounter"
 #define DELETE_ALL_RECORDS_CHT  "formatcdrive"
 #define LUNA_DEBUG_CHT          "lunadebug"
+#define LUNA_LONG_DEBUG_CHT     "lunalongdebug"
 
 void Input::CheckSpecialCheats()
 {
@@ -204,11 +205,11 @@ void Input::CheckSpecialCheats()
         return;
     }
 
-    else if(cheats_contains(LUNA_DEBUG_CHT))
+    else if(cheats_contains(LUNA_DEBUG_CHT) || cheats_contains(LUNA_LONG_DEBUG_CHT))
     {
-        const char *none = "__null";
+        int length = cheats_contains(LUNA_LONG_DEBUG_CHT) ? 99999 : 600;
         // FIXME: Replace this with the boolean toggle than adding this command infinitely times
-        gAutoMan.m_CustomCodes.emplace_back(AT_DebugPrint, 0, 0, 0, 0, none, 600, 0, none);
+        gAutoMan.m_CustomCodes.emplace_back(AT_DebugPrint, 0, 0, 0, 0, STRINGINDEX_NONE, length, 0, STRINGINDEX_NONE);
         PlaySound(SFX_Stomp);
         cheats_clearBuffer();
         return;


### PR DESCRIPTION
- Unique strings will be kept as the same indices
- Made sure if assign the same string field with another value, the new string entry will be allocated as a new unique string added
- Every known string will be tracked with usages counter and will be kept for the future use

This whole work should resolve the crash while running certain LunaDll scripts that have to add/remove code entries often: because old and duplicated strings get never removed, the whole bank gets filled with duplicates because of an infinite cycle of creating/removing string entries somewhere.

The test level that should work correctly here:
[ThroughMetro.zip](https://github.com/Wohlstand/TheXTech/files/8173468/ThroughMetro.zip)
Without changes from this PR, the whole bank of strings gets filled and crashed because of the assert failed
