### PR TITLE
Added UI customization by episode/level side

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ Changelog for 1.3.6 [WIP]
 -Fixed unexpected music got started after the level got entered too quick from the world map (@Wohlstand)
 -Fixed the vanilla bug: a Player can stuck in the pipe when enters it being a fairy (@Wohlstand)
 -Added an option to enable the fast walking on the world map (@ds-sloth, (@Wohlstand)
+-Added an ability to customize UI/common assets from the episode and level sides (@Wohlstand)
 
 Changes for 1.3.5.3-1
 -Fixed autostart events behaviour

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -44,10 +44,7 @@ void GFX_t::loadImage(StdPicture &img, const std::string &path)
 }
 
 GFX_t::GFX_t() noexcept
-{
-    if(m_isCustom)
-        SDL_free(m_isCustom);
-}
+{}
 
 bool GFX_t::load()
 {
@@ -116,10 +113,7 @@ bool GFX_t::load()
         return false;
     }
 
-    if(m_isCustom)
-        SDL_free(m_isCustom);
-
-    m_isCustom = (bool*)SDL_malloc(m_loadedImages.size() * sizeof(bool));
+    SDL_assert_release(m_loadedImages.size() <= m_isCustomVolume);
     SDL_memset(m_isCustom, 0, sizeof(m_loadedImages.size() * sizeof(bool)));
 
     return true;
@@ -130,12 +124,11 @@ void GFX_t::unLoad()
     for(StdPicture *p : m_loadedImages)
         XRender::deleteTexture(*p);
     m_loadedImages.clear();
-    SDL_free(m_isCustom);
-    m_isCustom = nullptr;
+    SDL_memset(m_isCustom, 0, sizeof(m_loadedImages.size() * sizeof(bool)));
 }
 
 bool& GFX_t::isCustom(size_t i)
 {
-    SDL_assert_release(m_isCustom && i < m_loadedImages.size());
+    SDL_assert_release(i < m_isCustomVolume);
     return m_isCustom[i];
 }

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -41,6 +41,7 @@ void GFX_t::loadImage(StdPicture &img, const std::string &path)
     }
 
     m_loadedImages.push_back(&img);
+    m_isCustom.push_back(false);
 }
 
 GFX_t::GFX_t() noexcept
@@ -121,4 +122,5 @@ void GFX_t::unLoad()
     for(StdPicture *p : m_loadedImages)
         XRender::deleteTexture(*p);
     m_loadedImages.clear();
+    m_isCustom.clear();
 }

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -41,11 +41,13 @@ void GFX_t::loadImage(StdPicture &img, const std::string &path)
     }
 
     m_loadedImages.push_back(&img);
-    m_isCustom.push_back(false);
 }
 
 GFX_t::GFX_t() noexcept
-{}
+{
+    if(m_isCustom)
+        SDL_free(m_isCustom);
+}
 
 bool GFX_t::load()
 {
@@ -114,6 +116,12 @@ bool GFX_t::load()
         return false;
     }
 
+    if(m_isCustom)
+        SDL_free(m_isCustom);
+
+    m_isCustom = (bool*)SDL_malloc(m_loadedImages.size() * sizeof(bool));
+    SDL_memset(m_isCustom, 0, sizeof(m_loadedImages.size() * sizeof(bool)));
+
     return true;
 }
 
@@ -122,5 +130,12 @@ void GFX_t::unLoad()
     for(StdPicture *p : m_loadedImages)
         XRender::deleteTexture(*p);
     m_loadedImages.clear();
-    m_isCustom.clear();
+    SDL_free(m_isCustom);
+    m_isCustom = nullptr;
+}
+
+bool& GFX_t::isCustom(size_t i)
+{
+    SDL_assert_release(m_isCustom && i < m_loadedImages.size());
+    return m_isCustom[i];
 }

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -34,8 +34,10 @@ class GFX_t
 {
     //! Holder of loaded textures for easier clean-up
     std::vector<StdPicture*> m_loadedImages;
+    //! Capacity of the m_isCustom array
+    static constexpr size_t m_isCustomVolume = 66;
     //! Holder of "is custom" flag
-    bool *m_isCustom = nullptr;
+    bool m_isCustom[m_isCustomVolume];
 
     /*!
      * \brief Internal function of the texture loading

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -25,6 +25,7 @@
 #include "range_arr.hpp"
 #include "std_picture.h"
 #include <vector>
+#include <deque>
 #include <string>
 
 class GFX_t
@@ -59,6 +60,9 @@ public:
     RangeArr<StdPicture, 1, 2> Tongue;
     StdPicture Warp;
     StdPicture YoshiWings;
+
+    //! Holder of "is custom" flag
+    std::deque<bool> m_isCustom;
 };
 
 //! Container of "hardcoded" (no more) graphics

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -25,13 +25,26 @@
 #include "range_arr.hpp"
 #include "std_picture.h"
 #include <vector>
-#include <deque>
 #include <string>
 
+/*!
+ * \brief Holder of commonly-used textures such as interface, font, etc.
+ */
 class GFX_t
 {
+    //! Holder of loaded textures for easier clean-up
     std::vector<StdPicture*> m_loadedImages;
+    //! Holder of "is custom" flag
+    bool *m_isCustom = nullptr;
+
+    /*!
+     * \brief Internal function of the texture loading
+     * \param img Target texture
+     * \param path Path to the texture file
+     */
     void loadImage(StdPicture &img, const std::string &path);
+
+    //! Counter of loading errors
     int m_loadErrors = 0;
 public:
     GFX_t() noexcept;
@@ -61,8 +74,7 @@ public:
     StdPicture Warp;
     StdPicture YoshiWings;
 
-    //! Holder of "is custom" flag
-    std::deque<bool> m_isCustom;
+    bool &isCustom(size_t i);
 };
 
 //! Container of "hardcoded" (no more) graphics

--- a/src/load_gfx.cpp
+++ b/src/load_gfx.cpp
@@ -83,6 +83,17 @@ static std::string getGfxDir()
     return AppPath + "graphics/";
 }
 
+/*!
+ * \brief Load the custom GFX sprite
+ * \param origPath Path to original texture
+ * \param fName file name for custommization target
+ * \param width Reference to width field (optional)
+ * \param height Reference to height field (optional)
+ * \param isCustom Reference to the "is custom" boolean
+ * \param texture Target texture to load
+ * \param world Is a world map
+ * \param skipMask Don't even try to load a masked GIF sprite
+ */
 static void loadCGFX(const std::string &origPath,
                      const std::string &fName,
                      int *width, int *height, bool& isCustom, StdPicture &texture,
@@ -479,6 +490,119 @@ void UnloadGFX()
     // Do nothing
 }
 
+static void loadCustomUIAssets()
+{
+    std::string uiRoot = AppPath + "graphics/ui/";
+    int ci = 0;
+
+     // these should all have been set previously, but will do no harm
+    g_dirEpisode.setCurDir(FileNamePath);
+    g_dirCustom.setCurDir(FileNamePath + FileName);
+    s_dirFallback.setCurDir(getGfxDir() + "fallback");
+
+    loadCGFX(uiRoot + "BMVs.png",
+             "BMVs",
+             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.BMVs, false, true);
+
+    loadCGFX(uiRoot + "BMWin.png",
+             "BMWin",
+             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.BMWin, false, true);
+
+    For(i, 1, 3)
+        loadCGFX(uiRoot + fmt::format_ne("Boot{0}.png", i),
+                 fmt::format_ne("Boot{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Boot[i], false, true);
+
+    For(i, 1, 5)
+        loadCGFX(uiRoot + fmt::format_ne("CharacterName{0}.png", i),
+                 fmt::format_ne("CharacterName{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.CharacterName[i], false, true);
+
+    loadCGFX(uiRoot + "Chat.png",
+             "Chat",
+             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Chat, false, true);
+
+    For(i, 0, 2)
+        loadCGFX(uiRoot + fmt::format_ne("Container{0}.png", i),
+                 fmt::format_ne("Container{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Container[i], false, true);
+
+    For(i, 1, 3)
+        loadCGFX(uiRoot + fmt::format_ne("ECursor{0}.png", i),
+                 fmt::format_ne("ECursor{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.ECursor[i], false, true);
+
+    For(i, 0, 9)
+        loadCGFX(uiRoot + fmt::format_ne("Font1_{0}.png", i),
+                 fmt::format_ne("Font1_{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Font1[i], false, true);
+
+    For(i, 1, 3)
+        loadCGFX(uiRoot + fmt::format_ne("Font2_{0}.png", i),
+                 fmt::format_ne("Font2_{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Font2[i], false, true);
+
+    loadCGFX(uiRoot + "Font2S.png",
+             "Font2S",
+             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Font2S, false, true);
+
+    For(i, 1, 2)
+        loadCGFX(uiRoot + fmt::format_ne("Heart{0}.png", i),
+                 fmt::format_ne("Heart{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Heart[i], false, true);
+
+    For(i, 0, 8)
+        loadCGFX(uiRoot + fmt::format_ne("Interface{0}.png", i),
+                 fmt::format_ne("Interface{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Interface[i], false, true);
+
+    loadCGFX(uiRoot + "LoadCoin.png",
+             "LoadCoin",
+             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.LoadCoin, false, true);
+
+    loadCGFX(uiRoot + "Loader.png",
+             "Loader",
+             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Loader, false, true);
+
+    For(i, 0, 3)
+        loadCGFX(uiRoot + fmt::format_ne("MCursor{0}.png", i),
+                 fmt::format_ne("MCursor{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.MCursor[i], false, true);
+
+    For(i, 1, 4)
+        loadCGFX(uiRoot + fmt::format_ne("MenuGFX{0}.png", i),
+                 fmt::format_ne("MenuGFX{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.MenuGFX[i], false, true);
+
+    loadCGFX(uiRoot + "Mount.png",
+             "Mount",
+             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Mount[2], false, true);
+
+    For(i, 0, 7)
+        loadCGFX(uiRoot + fmt::format_ne("nCursor{0}.png", i),
+                 fmt::format_ne("nCursor{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.nCursor[i], false, true);
+
+    loadCGFX(uiRoot + "TextBox.png",
+             "TextBox",
+             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.TextBox, false, true);
+
+    For(i, 1, 2)
+        loadCGFX(uiRoot + fmt::format_ne("Tongue{0}.png", i),
+                 fmt::format_ne("Tongue{0}", i),
+                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Tongue[i], false, true);
+
+    loadCGFX(uiRoot + "Warp.png",
+             "Warp",
+             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Warp, false, true);
+
+    loadCGFX(uiRoot + "YoshiWings.png",
+             "YoshiWings",
+             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.YoshiWings, false, true);
+
+    // FIXME: @ds-sloth, Please add an Editor specific textures here if needed
+}
+
 void LoadCustomGFX()
 {
     std::string GfxRoot = AppPath + "graphics/";
@@ -554,6 +678,8 @@ void LoadCustomGFX()
                      (*GFXCharacterCustom[c])[A], (*GFXCharacterBMP[c])[A]);
         }
     }
+
+    loadCustomUIAssets();
 }
 
 

--- a/src/load_gfx.cpp
+++ b/src/load_gfx.cpp
@@ -493,7 +493,7 @@ void UnloadGFX()
 static void loadCustomUIAssets()
 {
     std::string uiRoot = AppPath + "graphics/ui/";
-    int ci = 0;
+    size_t ci = 0;
 
      // these should all have been set previously, but will do no harm
     g_dirEpisode.setCurDir(FileNamePath);
@@ -502,103 +502,103 @@ static void loadCustomUIAssets()
 
     loadCGFX(uiRoot + "BMVs.png",
              "BMVs",
-             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.BMVs, false, true);
+             nullptr, nullptr, GFX.isCustom(ci++), GFX.BMVs, false, true);
 
     loadCGFX(uiRoot + "BMWin.png",
              "BMWin",
-             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.BMWin, false, true);
+             nullptr, nullptr, GFX.isCustom(ci++), GFX.BMWin, false, true);
 
     For(i, 1, 3)
         loadCGFX(uiRoot + fmt::format_ne("Boot{0}.png", i),
                  fmt::format_ne("Boot{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Boot[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.Boot[i], false, true);
 
     For(i, 1, 5)
         loadCGFX(uiRoot + fmt::format_ne("CharacterName{0}.png", i),
                  fmt::format_ne("CharacterName{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.CharacterName[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.CharacterName[i], false, true);
 
     loadCGFX(uiRoot + "Chat.png",
              "Chat",
-             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Chat, false, true);
+             nullptr, nullptr, GFX.isCustom(ci++), GFX.Chat, false, true);
 
     For(i, 0, 2)
         loadCGFX(uiRoot + fmt::format_ne("Container{0}.png", i),
                  fmt::format_ne("Container{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Container[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.Container[i], false, true);
 
     For(i, 1, 3)
         loadCGFX(uiRoot + fmt::format_ne("ECursor{0}.png", i),
                  fmt::format_ne("ECursor{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.ECursor[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.ECursor[i], false, true);
 
     For(i, 0, 9)
         loadCGFX(uiRoot + fmt::format_ne("Font1_{0}.png", i),
                  fmt::format_ne("Font1_{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Font1[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.Font1[i], false, true);
 
     For(i, 1, 3)
         loadCGFX(uiRoot + fmt::format_ne("Font2_{0}.png", i),
                  fmt::format_ne("Font2_{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Font2[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.Font2[i], false, true);
 
     loadCGFX(uiRoot + "Font2S.png",
              "Font2S",
-             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Font2S, false, true);
+             nullptr, nullptr, GFX.isCustom(ci++), GFX.Font2S, false, true);
 
     For(i, 1, 2)
         loadCGFX(uiRoot + fmt::format_ne("Heart{0}.png", i),
                  fmt::format_ne("Heart{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Heart[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.Heart[i], false, true);
 
     For(i, 0, 8)
         loadCGFX(uiRoot + fmt::format_ne("Interface{0}.png", i),
                  fmt::format_ne("Interface{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Interface[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.Interface[i], false, true);
 
     loadCGFX(uiRoot + "LoadCoin.png",
              "LoadCoin",
-             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.LoadCoin, false, true);
+             nullptr, nullptr, GFX.isCustom(ci++), GFX.LoadCoin, false, true);
 
     loadCGFX(uiRoot + "Loader.png",
              "Loader",
-             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Loader, false, true);
+             nullptr, nullptr, GFX.isCustom(ci++), GFX.Loader, false, true);
 
     For(i, 0, 3)
         loadCGFX(uiRoot + fmt::format_ne("MCursor{0}.png", i),
                  fmt::format_ne("MCursor{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.MCursor[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.MCursor[i], false, true);
 
     For(i, 1, 4)
         loadCGFX(uiRoot + fmt::format_ne("MenuGFX{0}.png", i),
                  fmt::format_ne("MenuGFX{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.MenuGFX[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.MenuGFX[i], false, true);
 
     loadCGFX(uiRoot + "Mount.png",
              "Mount",
-             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Mount[2], false, true);
+             nullptr, nullptr, GFX.isCustom(ci++), GFX.Mount[2], false, true);
 
     For(i, 0, 7)
         loadCGFX(uiRoot + fmt::format_ne("nCursor{0}.png", i),
                  fmt::format_ne("nCursor{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.nCursor[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.nCursor[i], false, true);
 
     loadCGFX(uiRoot + "TextBox.png",
              "TextBox",
-             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.TextBox, false, true);
+             nullptr, nullptr, GFX.isCustom(ci++), GFX.TextBox, false, true);
 
     For(i, 1, 2)
         loadCGFX(uiRoot + fmt::format_ne("Tongue{0}.png", i),
                  fmt::format_ne("Tongue{0}", i),
-                 nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Tongue[i], false, true);
+                 nullptr, nullptr, GFX.isCustom(ci++), GFX.Tongue[i], false, true);
 
     loadCGFX(uiRoot + "Warp.png",
              "Warp",
-             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.Warp, false, true);
+             nullptr, nullptr, GFX.isCustom(ci++), GFX.Warp, false, true);
 
     loadCGFX(uiRoot + "YoshiWings.png",
              "YoshiWings",
-             nullptr, nullptr, GFX.m_isCustom[ci++], GFX.YoshiWings, false, true);
+             nullptr, nullptr, GFX.isCustom(ci++), GFX.YoshiWings, false, true);
 
     // FIXME: @ds-sloth, Please add an Editor specific textures here if needed
 }


### PR DESCRIPTION
A very small update that adds an ability to customize UI assets from a level and/or episode side as regular CGFX.

Note: there are internal names being used to match files at UI directory rather than [repeating the list from this table](https://wohlsoft.ru/pgewiki/Hardcoded_Image_List_of_SMBX_Engine) which should be simpler for users than letting them think which thing for which, etc...