### PR TITLE
Keep old gamesave file at episode directory

### DIFF
--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -1933,17 +1933,12 @@ void DeleteSave(int world, int save)
     deleteList.push_back(makeGameSavePath(w.WorldPath, \
                                           w.WorldFile,\
                                           fmt::format_ne(f, save)));
-#define AddFileW(f) \
-    deleteList.push_back(w.WorldPath + fmt::format_ne(f, save));
 
     AddFile("save{0}.savx");
     AddFile("timers{0}.ini");
     AddFile("deaths-{0}.rip");
     AddFile("fails-{0}.rip");
     AddFile("demos-{0}.dmo");
-    // Old gamesaves
-    AddFileW("save{0}.savx");
-    AddFileW("save{0}.sav");
 
     // Clear all files in list
     for(auto &s : deleteList)
@@ -1952,8 +1947,23 @@ void DeleteSave(int world, int save)
             Files::deleteFile(s);
     }
 
+    std::string legacySave = w.WorldPath + fmt::format_ne("save{0}.sav", save);
+    std::string legacySaveLocker = makeGameSavePath(w.WorldPath,
+                                                    w.WorldFile,
+                                                    fmt::format_ne("save{0}.nosave", save));
+
+    // If legacy gamesave file exists, make the locker file to make illusion that old file got been removed
+    if(Files::fileExists(legacySave))
+    {
+        auto *f = Files::utf8_fopen(legacySaveLocker.c_str(), "wb");
+        if(f)
+        {
+            std::fprintf(f, "If this file exists, save%d.sav file is ignored.", save);
+            std::fclose(f);
+        }
+    }
+
 #undef AddFile
-#undef AddFileW
 
 #ifdef __EMSCRIPTEN__
     AppPathManager::syncFs();
@@ -1982,18 +1992,16 @@ void CopySave(int world, int src, int dst)
                                                w.WorldFile,
                                                fmt::format_ne("save{0}.savx", dst));
 
-    if(!Files::fileExists(savePathSrc)) // Attempt to import an old game-save from the episode directory
+    if(!Files::fileExists(savePathSrc))
     {
-        std::string savePathOld     = w.WorldPath + fmt::format_ne("save{0}.savx", src);
-        std::string savePathAncient = w.WorldPath + fmt::format_ne("save{0}.sav", src);
+        // Attempt to import an old game-save from the episode directory
+        std::string savePathOld = w.WorldPath + fmt::format_ne("save{0}.sav", src);
 
         GamesaveData sav;
         bool succ = false;
 
         if(Files::fileExists(savePathOld))
-            succ = FileFormats::ReadExtendedSaveFileF(savePathOld, sav);
-        else if(Files::fileExists(savePathAncient))
-            succ = FileFormats::ReadSMBX64SavFileF(savePathAncient, sav);
+            succ = FileFormats::ReadSMBX64SavFileF(savePathOld, sav);
 
         if(succ)
             FileFormats::WriteExtendedSaveFileF(savePathSrc, sav);

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -1926,7 +1926,7 @@ void StartBattleMode()
 
 void DeleteSave(int world, int save)
 {
-    auto &w = SelectWorld[world];
+    const auto &w = SelectWorld[world];
     std::vector<std::string> deleteList;
 
 #define AddFile(f) \
@@ -1983,7 +1983,7 @@ static void copySaveFile(const SelectWorld_t& w, const char*file_mask, int src, 
 
 void CopySave(int world, int src, int dst)
 {
-    auto &w = SelectWorld[world];
+    const auto &w = SelectWorld[world];
 
     std::string savePathSrc = makeGameSavePath(w.WorldPath,
                                                w.WorldFile,
@@ -1991,6 +1991,9 @@ void CopySave(int world, int src, int dst)
     std::string savePathDst = makeGameSavePath(w.WorldPath,
                                                w.WorldFile,
                                                fmt::format_ne("save{0}.savx", dst));
+    std::string legacySaveLocker = makeGameSavePath(w.WorldPath,
+                                                    w.WorldFile,
+                                                    fmt::format_ne("save{0}.nosave", dst));
 
     if(!Files::fileExists(savePathSrc))
     {
@@ -2005,6 +2008,9 @@ void CopySave(int world, int src, int dst)
 
         if(succ)
             FileFormats::WriteExtendedSaveFileF(savePathSrc, sav);
+
+        if(Files::fileExists(legacySaveLocker))
+            Files::deleteFile(legacySaveLocker);
     }
 
     Files::copyFile(savePathDst, savePathSrc, true);

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -217,11 +217,11 @@ void LoadGame()
 
     for(auto &s : sav.characterStates)
     {
-        if(s.id < 1 || s.id > 5)
+        if((s.id < 1) || (s.id > 5))
             continue;
         A = int(s.id);
 
-        if(s.state < 1 || s.state > 10)
+        if((s.state < 1) || (s.state > 10))
             SavedChar[A].State = 1;
         else
             SavedChar[A].State = int(s.state);
@@ -243,13 +243,13 @@ void LoadGame()
         switch(s.mountID)
         {
         case 1:
-            if(s.mountType < 1 || s.mountType > 3)
+            if((s.mountType < 1) || (s.mountType > 3))
                 SavedChar[A].MountType = 1;
             break;
         default:
             break;
         case 3:
-            if(s.mountType < 1 || s.mountType > 8)
+            if((s.mountType < 1) || (s.mountType > 8))
                 SavedChar[A].MountType = 1;
             break;
         }

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -54,8 +54,10 @@ std::string makeGameSavePath(std::string episode, std::string world, std::string
 void SaveGame()
 {
     int A = 0;
+
     if(Cheater)
         return;
+
     for(A = numPlayers; A >= 1; A--)
         SavedChar[Player[A].Character] = Player[A];
     for(A = numStars; A >= 1; A--)
@@ -72,11 +74,16 @@ void SaveGame()
         }
     }
 
+    const auto &w = SelectWorld[selWorld];
+
     GamesaveData sav;
 //    std::string savePath = SelectWorld[selWorld].WorldPath + fmt::format_ne("save{0}.savx", selSave);
-    std::string savePath = makeGameSavePath(SelectWorld[selWorld].WorldPath,
-                                            SelectWorld[selWorld].WorldFile,
+    std::string savePath = makeGameSavePath(w.WorldPath,
+                                            w.WorldFile,
                                             fmt::format_ne("save{0}.savx", selSave));
+    std::string legacyGamesaveLocker = makeGameSavePath(w.WorldPath,
+                                                        w.WorldFile,
+                                                        fmt::format_ne("save{0}.nosave", selSave));
 
 //    Open SelectWorld[selWorld].WorldPath + "save" + selSave + ".sav" For Output As #1;
     sav.lives = int(Lives);
@@ -124,6 +131,9 @@ void SaveGame()
 #endif
 
     FileFormats::WriteExtendedSaveFileF(savePath, sav);
+
+    if(Files::fileExists(legacyGamesaveLocker))
+        Files::deleteFile(legacyGamesaveLocker); // Remove the gamesave locker of legacy file
 
     // Also, save the speed-running states
     speedRun_saveStats();

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -153,15 +153,15 @@ void LoadGame()
     std::string savePath = makeGameSavePath(SelectWorld[selWorld].WorldPath,
                                             SelectWorld[selWorld].WorldFile,
                                             fmt::format_ne("save{0}.savx", selSave));
-    std::string savePathOld = SelectWorld[selWorld].WorldPath + fmt::format_ne("save{0}.savx", selSave);
-    std::string savePathAncient = SelectWorld[selWorld].WorldPath + fmt::format_ne("save{0}.sav", selSave);
+    std::string savePathOld = SelectWorld[selWorld].WorldPath + fmt::format_ne("save{0}.sav", selSave);
+    std::string legacySaveLocker = makeGameSavePath(w.WorldPath,
+                                                    w.WorldFile,
+                                                    fmt::format_ne("save{0}.nosave", save));
 
     if(Files::fileExists(savePath))
         FileFormats::ReadExtendedSaveFileF(savePath, sav);
-    else if(Files::fileExists(savePathOld))
-        FileFormats::ReadExtendedSaveFileF(savePathOld, sav);
-    else if(Files::fileExists(savePathAncient))
-        FileFormats::ReadSMBX64SavFileF(savePathAncient, sav);
+    if(!Files::fileExists(legacySaveLocker) && Files::fileExists(savePathOld))
+        FileFormats::ReadSMBX64SavFileF(savePathOld, sav);
     else
     {
         pLogDebug("Game save file not found: %s", savePath.c_str());

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -147,16 +147,17 @@ void LoadGame()
 {
     int A = 0;
     size_t i = 0;
+    const auto &w = SelectWorld[selWorld];
 //    std::string newInput;
 
     GamesaveData sav;
-    std::string savePath = makeGameSavePath(SelectWorld[selWorld].WorldPath,
-                                            SelectWorld[selWorld].WorldFile,
+    std::string savePath = makeGameSavePath(w.WorldPath,
+                                            w.WorldFile,
                                             fmt::format_ne("save{0}.savx", selSave));
-    std::string savePathOld = SelectWorld[selWorld].WorldPath + fmt::format_ne("save{0}.sav", selSave);
+    std::string savePathOld = w.WorldPath + fmt::format_ne("save{0}.sav", selSave);
     std::string legacySaveLocker = makeGameSavePath(w.WorldPath,
                                                     w.WorldFile,
-                                                    fmt::format_ne("save{0}.nosave", save));
+                                                    fmt::format_ne("save{0}.nosave", selSave));
 
     if(Files::fileExists(savePath))
         FileFormats::ReadExtendedSaveFileF(savePath, sav);

--- a/src/main/menu_loop.cpp
+++ b/src/main/menu_loop.cpp
@@ -571,7 +571,8 @@ void MenuLoop()
 void FindSaves()
 {
 //    std::string newInput;
-    std::string episode = SelectWorld[selWorld].WorldPath;
+    const auto &w = SelectWorld[selWorld];
+    std::string episode = w.WorldPath;
     GamesaveData f;
 
     for(auto A = 1; A <= maxSaveSlots; A++)
@@ -579,15 +580,22 @@ void FindSaves()
         SaveSlot[A] = -1;
         SaveStars[A] = 0;
 
+        // Modern gamesave file
         std::string saveFile = makeGameSavePath(episode,
-                                                SelectWorld[selWorld].WorldFile,
+                                                w.WorldFile,
                                                 fmt::format_ne("save{0}.savx", A));
-        std::string saveFileOld = episode + fmt::format_ne("save{0}.savx", A);
-        std::string saveFileAncient = episode + fmt::format_ne("save{0}.sav", A);
+        // Old gamesave location at episode's read-only directory
+        std::string saveFileOld = episode + fmt::format_ne("save{0}.sav", A);
+        // Gamesave locker to make an illusion of absence of the gamesave
+        std::string saveFileOldLocker = makeGameSavePath(w.WorldPath,
+                                                         w.WorldFile,
+                                                         fmt::format_ne("save{0}.nosave", A));
+
+        if(Files::fileExists(saveFileOldLocker))
+            continue; // Skip the blocked gamesave
 
         if((Files::fileExists(saveFile) && FileFormats::ReadExtendedSaveFileF(saveFile, f)) ||
-           (Files::fileExists(saveFileOld) && FileFormats::ReadExtendedSaveFileF(saveFileOld, f)) ||
-           (Files::fileExists(saveFileAncient) && FileFormats::ReadSMBX64SavFileF(saveFileAncient, f)))
+           (Files::fileExists(saveFileOld) && FileFormats::ReadSMBX64SavFileF(saveFileOld, f)))
         {
             int curActive = 0;
             int maxActive = 0;

--- a/src/main/menu_loop.cpp
+++ b/src/main/menu_loop.cpp
@@ -591,11 +591,8 @@ void FindSaves()
                                                          w.WorldFile,
                                                          fmt::format_ne("save{0}.nosave", A));
 
-        if(Files::fileExists(saveFileOldLocker))
-            continue; // Skip the blocked gamesave
-
         if((Files::fileExists(saveFile) && FileFormats::ReadExtendedSaveFileF(saveFile, f)) ||
-           (Files::fileExists(saveFileOld) && FileFormats::ReadSMBX64SavFileF(saveFileOld, f)))
+           (!Files::fileExists(saveFileOldLocker) && Files::fileExists(saveFileOld) && FileFormats::ReadSMBX64SavFileF(saveFileOld, f)))
         {
             int curActive = 0;
             int maxActive = 0;


### PR DESCRIPTION
Make a full sure that the episode directory will be absolutely read-only-friendly even if an old gamesave file was left in it. Instead of actual .sav file deletion, create a locker file that makes gamesave to be always empty. Once gamesave gets created, then remove that locker file.

Also, remove the support for SAVX files at the episode directory: this is fully deprecated behaviour that existed in early TheXTech versions only and is no longer used for a long time.

Fixes #436