### PR TITLE
Added compat flag for block resize fix and improved behavior

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ Changelog for 1.3.6.1
 -An uncolored PCursor.png is now automatically colored and used for indicating player menu selections; MCursor0.png and MCursor3.png are used as fallbacks. (@ds-sloth)
 -The pause menu cursor is now colored based on which player is in control of the pause menu. (@ds-sloth)
 -If controller inputs are displayed onscreen, Player 2's controller is now shown at the world map screen. (@ds-sloth, @0lhi)
+-Added compatibility flags for multiple early vanilla bugfixes. (@ds-sloth)
 
 Changelog for 1.3.6
 -Added an ability to toggle drawing of the HUD and other on-screen meta data using F1 key (@Wohlstand)

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -551,7 +551,10 @@ void BlockHit(int A, bool HitDown, int whatPlayer)
         {
             b.Type = newBlock;
             b.Location.Height = BlockHeight[newBlock];
-            b.Location.Width = BlockWidth[newBlock];
+
+            // Doing this check here keeps the easy bonus pickup. -- ds-sloth
+            if(!g_compatibility.fix_restored_block_move || !b.getShrinkResized())
+                b.Location.Width = BlockWidth[newBlock];
         }
 
 #if 0 // Completely disable the DEAD the code that spawns the player
@@ -667,11 +670,11 @@ void BlockHit(int A, bool HitDown, int whatPlayer)
             nn.Location.Width = NPCWidth[C];
 
             // Make block a bit smaller to allow player take a bonus easier (Redigit's idea)
-            if(fEqual(b.Location.Width, 32) && !b.wasShrinkResized)
+            if(fEqual(b.Location.Width, 32)/* && !b.getShrinkResized()*/) // moved check above so that the width is not reset to 32 in the first place
             {
                 b.Location.Width -= 0.1;
                 b.Location.X += 0.05;
-                b.wasShrinkResized = true; // Don't move it!!!
+                b.setShrinkResized();
             }
 
             nn.Location.Height = 0;

--- a/src/blocks.cpp
+++ b/src/blocks.cpp
@@ -672,7 +672,10 @@ void BlockHit(int A, bool HitDown, int whatPlayer)
             // Make block a bit smaller to allow player take a bonus easier (Redigit's idea)
             if(fEqual(b.Location.Width, 32)/* && !b.getShrinkResized()*/) // moved check above so that the width is not reset to 32 in the first place
             {
-                b.Location.Width -= 0.1;
+                // make sure Location.Width == 31.9 heuristic works on low-mem builds
+                // b.Location.Width -= 0.1;
+                b.Location.Width = 31.9;
+
                 b.Location.X += 0.05;
                 b.setShrinkResized();
             }

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -55,6 +55,7 @@ static void compatInit(Compatibility_t &c)
         }
     }
 
+    c.fix_restored_block_move = true;
     c.fix_player_slope_speed = true;
     // 1.3.4
     c.enable_last_warp_hub_resume = true;
@@ -112,6 +113,7 @@ static void compatInit(Compatibility_t &c)
 
     if(s_compatLevel >= COMPAT_SMBX2) // Make sure that bugs were same as on SMBX2 Beta 4 on this moment
     {
+        c.fix_restored_block_move = false;
         c.fix_player_slope_speed = false;
         // 1.3.4
         c.enable_last_warp_hub_resume = false;
@@ -275,6 +277,7 @@ static void loadCompatIni(Compatibility_t &c, const std::string &fileName)
     compat.beginGroup("compatibility");
     if(s_compatLevel < COMPAT_SMBX2) // Ignore options are still not been fixed at the SMBX2
     {
+        compat.read("fix-restored-block-move", c.fix_restored_block_move, c.fix_restored_block_move);
         compat.read("fix-player-slope-speed", c.fix_player_slope_speed, c.fix_player_slope_speed);
         // 1.3.4
         compat.read("enable-last-warp-hub-resume", c.enable_last_warp_hub_resume, c.enable_last_warp_hub_resume);

--- a/src/compat.h
+++ b/src/compat.h
@@ -24,6 +24,7 @@
 
 struct Compatibility_t
 {
+    bool fix_restored_block_move; // don't move powerup blocks to the right when they are hit after restoring
     bool fix_player_slope_speed;
     // 1.3.4
     bool enable_last_warp_hub_resume;
@@ -39,8 +40,8 @@ struct Compatibility_t
     bool fix_player_clip_wall_at_npc;
     bool fix_skull_raft;
     bool fix_char3_escape_shell_surf;
-    bool fix_plant_wobble;
-    bool fix_powerup_lava_bug;
+    bool fix_plant_wobble; // improves visual appearance of plants
+    bool fix_powerup_lava_bug; // powerups always die when hitting lava, instead of checking the types of arbitrary NPCs
     bool fix_keyhole_framerate;
     // 1.3.5
     bool fix_char5_vehicle_climb;

--- a/src/globals.h
+++ b/src/globals.h
@@ -768,7 +768,9 @@ struct Block_t
 
 // EXTRA: Indicate the fact that block was resized by a hit
 #if LOW_MEM
+
     inline void setShrinkResized() {}
+
     inline bool getShrinkResized()
     {
         // Because the initial block width is stored as an integer, the only way the width could be 31.9 is if it was shrink-resized from 32.
@@ -777,18 +779,23 @@ struct Block_t
         // If it fails in some case, we can switch to the below implementation, or we could use this implementation only when LOW_MEM is set.
         return Location.Width == 31.9;
     }
+
 #else
+
 private:
-    bool _wasShrinkResized = false;
+    bool m_wasShrinkResized = false;
+
 public:
     inline void setShrinkResized()
     {
-        _wasShrinkResized = true;
+        m_wasShrinkResized = true;
     }
+
     inline bool getShrinkResized()
     {
-        return _wasShrinkResized;
+        return m_wasShrinkResized;
     }
+
 #endif
 
 //End Type

--- a/src/globals.h
+++ b/src/globals.h
@@ -763,10 +763,34 @@ struct Block_t
     int standingOnPlayerY = 0;
 //    noProjClipping As Boolean
     bool noProjClipping = false;
-// EXTRA: Indicate the fact that block was resized by a hit
-    bool wasShrinkResized = false;
 //    IsReally As Integer 'the NPC that is this block
     int IsReally = 0;
+
+// EXTRA: Indicate the fact that block was resized by a hit
+#if 1
+    inline void setShrinkResized() {}
+    inline bool getShrinkResized()
+    {
+        // Because the initial block width is stored as an integer, the only way the width could be 31.9 is if it was shrink-resized from 32.
+        // The block location width isn't set to a non-integer anywhere else in the game, so this is safe.
+        // This is a heuristic and has a small CPU tradeoff, but it saves memory.
+        // If it fails in some case, we can switch to the below implementation, or we could use this implementation only when LOW_MEM is set.
+        return Location.Width == 31.9;
+    }
+#else
+private:
+    bool _wasShrinkResized = false;
+public:
+    inline void setShrinkResized()
+    {
+        _wasShrinkResized = true;
+    }
+    inline bool getShrinkResized()
+    {
+        return wasShrinkResized;
+    }
+#endif
+
 //End Type
 };
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -767,7 +767,7 @@ struct Block_t
     int IsReally = 0;
 
 // EXTRA: Indicate the fact that block was resized by a hit
-#if 1
+#if LOW_MEM
     inline void setShrinkResized() {}
     inline bool getShrinkResized()
     {
@@ -787,7 +787,7 @@ public:
     }
     inline bool getShrinkResized()
     {
-        return wasShrinkResized;
+        return _wasShrinkResized;
     }
 #endif
 

--- a/src/graphics/gfx_update.cpp
+++ b/src/graphics/gfx_update.cpp
@@ -1372,8 +1372,9 @@ void UpdateGraphics(bool skipRepaint)
                 {
                     g_stats.renderedBlocks++;
                     // Don't show a visual difference of hit-resized block in a comparison to original state
-                    double offX = block.wasShrinkResized ? 0.05 : 0.0;
-                    double offW = block.wasShrinkResized ? 0.1 : 0.0;
+                    bool wasShrinkResized = block.getShrinkResized();
+                    double offX = wasShrinkResized ? 0.05 : 0.0;
+                    double offW = wasShrinkResized ? 0.1 : 0.0;
                     XRender::renderTexture(vScreenX[Z] + block.Location.X - offX,
                                           vScreenY[Z] + block.Location.Y + block.ShakeY3,
                                           block.Location.Width + offW,
@@ -1979,8 +1980,9 @@ void UpdateGraphics(bool skipRepaint)
                 {
                     g_stats.renderedBlocks++;
                     // Don't show a visual difference of hit-resized block in a comparison to original state
-                    double offX = block.wasShrinkResized ? 0.05 : 0.0;
-                    double offW = block.wasShrinkResized ? 0.1 : 0.0;
+                    bool wasShrinkResized = block.getShrinkResized();
+                    double offX = wasShrinkResized ? 0.05 : 0.0;
+                    double offW = wasShrinkResized ? 0.1 : 0.0;
                     XRender::renderTexture(vScreenX[Z] + block.Location.X - offX,
                                           vScreenY[Z] + block.Location.Y + block.ShakeY3,
                                           block.Location.Width + offW,


### PR DESCRIPTION
This is a very small PR with a new implementation for the block resize fix.

First I want to note that this absolutely needs a compat flag. See the vanilla behavior (block-resize is fully effective on left and partially on right, and the blocks slowly move) below:

<img src="https://user-images.githubusercontent.com/72112344/212552923-326856bb-07fe-4e22-8c28-17a1842ce495.gif" width="400" height="300">

And the current `main` behavior (block-resize is not effective on left OR right, blocks move 0.05, but this is invisible) here:
<img src="https://user-images.githubusercontent.com/72112344/212552944-9e4d5b51-f61c-43f2-9a0d-6b1a04bd91b5.gif" width="400" height="300">

Here is the proposed behavior from this PR (block-resize is fully effective on both left and right, blocks do not move):
<img src="https://user-images.githubusercontent.com/72112344/212552949-5d9f3903-f763-424a-b430-baac064c7dc1.gif" width="400" height="300">

This is the test level I used: [Block Move.lvl.zip](https://github.com/Wohlstand/TheXTech/files/10420627/Block.Move.lvl.zip)

There are three implementation changes:

(1) The check for the block's previous resize was moved from the clause that checks whether the block's size is currently 32 to the clause that sets the block's width to the newBlock type's width.
(2) There is a compat flag added to preserve vanilla behavior.
(3) The `wasHitResized` flag was replaced with inline getter/setter functions, which are currently implemented with a null setter and `Location.Width == 31.9` as the getter. This should be safe because the only way for a non-integer width of a block to occur is via the hit resizing code. I also have commented getter/setter functions that keep the original `bool` flag.

Please let me know what you think!