### PR TITLE
Show gamesave info on title screen

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ Changelog for 1.3.6.1
 -If controller inputs are displayed onscreen, Player 2's controller is now shown at the world map screen. (@ds-sloth, @0lhi)
 -Controls: don't continuously rumble on player hurt after getting level exit NPC. (@ds-sloth)
 -Added compatibility flags for multiple early vanilla bugfixes. (@ds-sloth)
+-Added game save info (score, lives, coins, etc) display to the main menu screen. (@ds-sloth)
 
 Changelog for 1.3.6
 -Added an ability to toggle drawing of the HUD and other on-screen meta data using F1 key (@Wohlstand)

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -1780,7 +1780,7 @@ void StartEpisode()
 
     OpenWorld(wPath);
 
-    if(SaveSlot[selSave] >= 0)
+    if(SaveSlotInfo[selSave].Progress >= 0)
     {
         if(!NoMap)
             StartLevel.clear();

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -305,8 +305,12 @@ int selSave = 0;
 int PSwitchTime = 0;
 int PSwitchStop = 0;
 int PSwitchPlayer = 0;
-RangeArrI<int, 1, 3, 0> SaveSlot;
-RangeArrI<int, 1, 3, 0> SaveStars;
+
+// RangeArrI<int, 1, maxSaveSlots, 0> SaveSlot;
+// RangeArrI<int, 1, maxSaveSlots, 0> SaveStars;
+
+RangeArr<SaveSlotInfo_t, 1, maxSaveSlots> SaveSlotInfo;
+
 int BeltDirection = 0;
 bool BeatTheGame = false;
 //int cycleCount = 0;
@@ -361,7 +365,7 @@ int Score = 0;
 RangeArrI<int, 1, 13, 0> Points;
 int MaxWorldStars = 0;
 bool Debugger = false;
-RangeArr<Player_t, 0, 10> SavedChar;
+RangeArr<SavedChar_t, 0, 10> SavedChar;
 
 bool LoadingInProcess = false;
 int LoadCoins = 0;

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -306,9 +306,6 @@ int PSwitchTime = 0;
 int PSwitchStop = 0;
 int PSwitchPlayer = 0;
 
-// RangeArrI<int, 1, maxSaveSlots, 0> SaveSlot;
-// RangeArrI<int, 1, maxSaveSlots, 0> SaveStars;
-
 RangeArr<SaveSlotInfo_t, 1, maxSaveSlots> SaveSlotInfo;
 
 int BeltDirection = 0;

--- a/src/globals.h
+++ b/src/globals.h
@@ -1678,10 +1678,70 @@ extern int PSwitchTime;
 extern int PSwitchStop;
 //Public PSwitchPlayer As Integer
 extern int PSwitchPlayer;
+
+// newly extended
+
+struct SavedChar_t
+{
+    uint16_t HeldBonus = 0;
+    uint8_t State = 1;
+    uint8_t Mount = 0;
+    uint8_t MountType = 0;
+    uint8_t Hearts = 1;
+    uint8_t Character = 1;
+
+    inline SavedChar_t& operator=(const SavedChar_t& ch) = default;
+    inline SavedChar_t& operator=(const Player_t& p)
+    {
+        HeldBonus = p.HeldBonus;
+        State = p.State;
+        Mount = p.Mount;
+        MountType = p.MountType;
+        Hearts = p.Hearts;
+        Character = p.Character;
+
+        return *this;
+    }
+    inline operator Player_t() const
+    {
+        Player_t p;
+
+        p.HeldBonus = HeldBonus;
+        p.State = State;
+        p.Mount = Mount;
+        p.MountType = MountType;
+        p.Hearts = Hearts;
+        p.Character = Character;
+
+        return p;
+    }
+};
+
+struct SaveSlotInfo_t
+{
+    int64_t Time = 0;
+    int32_t Fails = 0;
+    int32_t Score = 0;
+
+    RangeArr<SavedChar_t, 1, 5> SavedChar;
+
+    // Save progress percent, displayed at title. <0 value denotes uninitialized saves
+    int Progress = -1;
+    int Stars = 0;
+    int Lives = 3;
+    int Coins = 0;
+};
+
+// new: all save info
+extern RangeArr<SaveSlotInfo_t, 1, maxSaveSlots> SaveSlotInfo;
+
+// deprecated
 //Public SaveSlot(1 To 3) As Integer
-extern RangeArrI<int, 1, maxSaveSlots, 0> SaveSlot;
+// extern RangeArrI<int, 1, maxSaveSlots, 0> SaveSlot;
 //Public SaveStars(1 To 3) As Integer
-extern RangeArrI<int, 1, maxSaveSlots, 0> SaveStars;
+// extern RangeArrI<int, 1, maxSaveSlots, 0> SaveStars;
+
+
 //Public BeltDirection As Integer 'direction of the converyer belt blocks
 extern int BeltDirection;
 //Public BeatTheGame As Boolean 'true if the game has been beaten
@@ -1860,7 +1920,7 @@ extern int MaxWorldStars;
 //Public Debugger As Boolean 'if the debugger window is open
 extern bool Debugger;
 //Public SavedChar(0 To 10) As Player 'Saves the Player's Status
-extern RangeArr<Player_t, 0, 10> SavedChar;
+extern RangeArr<SavedChar_t, 0, 10> SavedChar;
 
 extern bool LoadingInProcess;
 //Public LoadCoins As Integer

--- a/src/globals.h
+++ b/src/globals.h
@@ -1722,6 +1722,7 @@ struct SavedChar_t
 struct SaveSlotInfo_t
 {
     int64_t Time = 0;
+    bool    FailsEnabled = false;
     int32_t Fails = 0;
     int32_t Score = 0;
 

--- a/src/main/game_info.cpp
+++ b/src/main/game_info.cpp
@@ -119,8 +119,8 @@ void initGameInfo()
         if(!config.beginGroup("fails-counter"))
             config.beginGroup("death-counter"); // Backup fallback
         {
-            config.read("enabled", gEnableDemoCounter, false);
-            config.read("title", gDemoCounterTitleDefault, "DEMOS");
+            config.read("enabled", gEnableDemoCounter, gEnableDemoCounter);
+            config.read("title", gDemoCounterTitleDefault, gDemoCounterTitleDefault);
             gDemoCounterTitle = gDemoCounterTitleDefault;
         }
         config.endGroup();

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -31,6 +31,8 @@
 #include <AppPath/app_path.h>
 #include <PGE_File_Formats/file_formats.h>
 #include <fmt_format_ne.h>
+#include <IniProcessor/ini_processing.h>
+#include <script/luna/lunacounter.h>
 
 #include "menu_main.h"
 
@@ -51,18 +53,60 @@ std::string makeGameSavePath(std::string episode, std::string world, std::string
     return ret;
 }
 
+static void s_LoadCharacter(SavedChar_t& dest, const saveCharState& s)
+{
+    dest = SavedChar_t();
+
+    if((s.state < 1) || (s.state > 10))
+        dest.State = 1;
+    else
+        dest.State = int(s.state);
+
+    dest.HeldBonus = int(s.itemID);
+
+    switch(s.mountID)
+    {
+    default:
+    case 0:
+        dest.Mount = 0;
+        dest.MountType = 0;
+        break;
+    case 1: case 2: case 3:
+        dest.Mount = int(s.mountID);
+    }
+
+    dest.MountType = int(s.mountType);
+    switch(s.mountID)
+    {
+    case 1:
+        if((s.mountType < 1) || (s.mountType > 3))
+            dest.MountType = 1;
+        break;
+    default:
+        break;
+    case 3:
+        if((s.mountType < 1) || (s.mountType > 8))
+            dest.MountType = 1;
+        break;
+    }
+
+    dest.Hearts = int(s.health);
+    dest.Character = int(s.id);
+}
+
 
 void FindSaves()
 {
 //    std::string newInput;
     const auto &w = SelectWorld[selWorld];
-    std::string episode = w.WorldPath;
+    const std::string& episode = w.WorldPath;
     GamesaveData f;
 
     for(auto A = 1; A <= maxSaveSlots; A++)
     {
-        SaveSlot[A] = -1;
-        SaveStars[A] = 0;
+        auto& info = SaveSlotInfo[A];
+
+        info = SaveSlotInfo_t();
 
         // Modern gamesave file
         std::string saveFile = makeGameSavePath(episode,
@@ -104,14 +148,61 @@ void FindSaves()
 
             // How many stars collected
             maxActive += (int(f.totalStars) * 4);
-            SaveStars[A] = int(f.gottenStars.size());
+            info.Stars = int(f.gottenStars.size());
 
-            curActive += (SaveStars[A] * 4);
+            curActive += (info.Stars * 4);
 
+            // calculate progress
             if(maxActive > 0)
-                SaveSlot[A] = int((float(curActive) / float(maxActive)) * 100);
+                info.Progress = int((float(curActive) / float(maxActive)) * 100);
             else
-                SaveSlot[A] = 100;
+                info.Progress = 100;
+
+            // load normal stats
+            info.Lives = f.lives;
+            info.Coins = f.coins;
+            info.Score = f.points;
+
+            // load saved chars
+            for(int i = 1; i <= 5; i++)
+            {
+                info.SavedChar[i] = SavedChar_t();
+                info.SavedChar[i].Character = i;
+            }
+
+            for(auto &s : f.characterStates)
+            {
+                if((s.id < 1) || (s.id > 5))
+                    continue;
+                int i = int(s.id);
+                s_LoadCharacter(info.SavedChar[i], s);
+            }
+
+            // load timer info for existing save
+            std::string savePath = makeGameSavePath(episode,
+                                                     w.WorldFile,
+                                                     fmt::format_ne("timers{0}.ini", A));
+
+            if(Files::fileExists(savePath))
+            {
+                IniProcessing timer(savePath);
+                timer.beginGroup("timers");
+                timer.read("total", info.Time, 0);
+                timer.endGroup();
+            }
+
+            // load fails for existing save
+            savePath = makeGameSavePath(episode,
+                                        w.WorldFile,
+                                        fmt::format_ne("fails-{0}.rip", A));
+
+            if(Files::fileExists(savePath))
+            {
+                gDeathCounter.counterFile = savePath;
+                gDeathCounter.TryLoadStats();
+                gDeathCounter.Recount();
+                info.Fails = gDeathCounter.mCurTotalDeaths;
+            }
         }
     }
 }
@@ -274,11 +365,7 @@ void LoadGame()
 
     for(A = 1, i = 0; A <= 5; A++, i++)
     {
-        SavedChar[A].State = 1;
-        SavedChar[A].HeldBonus = 0;
-        SavedChar[A].Mount = 0;
-        SavedChar[A].MountType = 0;
-        SavedChar[A].Hearts = 1;
+        SavedChar[A] = SavedChar_t();
         SavedChar[A].Character = A;
     }
 
@@ -288,41 +375,7 @@ void LoadGame()
             continue;
         A = int(s.id);
 
-        if((s.state < 1) || (s.state > 10))
-            SavedChar[A].State = 1;
-        else
-            SavedChar[A].State = int(s.state);
-
-        SavedChar[A].HeldBonus = int(s.itemID);
-
-        switch(s.mountID)
-        {
-        default:
-        case 0:
-            SavedChar[A].Mount = 0;
-            SavedChar[A].MountType = 0;
-            break;
-        case 1: case 2: case 3:
-            SavedChar[A].Mount = int(s.mountID);
-        }
-
-        SavedChar[A].MountType = int(s.mountType);
-        switch(s.mountID)
-        {
-        case 1:
-            if((s.mountType < 1) || (s.mountType > 3))
-                SavedChar[A].MountType = 1;
-            break;
-        default:
-            break;
-        case 3:
-            if((s.mountType < 1) || (s.mountType > 8))
-                SavedChar[A].MountType = 1;
-            break;
-        }
-
-        SavedChar[A].Hearts = int(s.health);
-        SavedChar[A].Character = A;
+        s_LoadCharacter(SavedChar[A], s);
     }
 
 

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -201,6 +201,7 @@ void FindSaves()
                 gDeathCounter.counterFile = savePath;
                 gDeathCounter.TryLoadStats();
                 gDeathCounter.Recount();
+                info.FailsEnabled = true;
                 info.Fails = gDeathCounter.mCurTotalDeaths;
             }
         }

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -57,7 +57,7 @@ static void s_LoadCharacter(SavedChar_t& dest, const saveCharState& s)
 {
     dest = SavedChar_t();
 
-    if((s.state < 1) || (s.state > 10))
+    if((s.state < 1) || (s.state > numStates))
         dest.State = 1;
     else
         dest.State = int(s.state);

--- a/src/main/gameplay_timer.h
+++ b/src/main/gameplay_timer.h
@@ -26,7 +26,6 @@
 
 class GameplayTimer
 {
-    static std::string formatTime(int64_t t);
     bool    m_cyclesInt = false;
     bool    m_cyclesFin = false;
     int64_t m_cyclesCurrent = 0;
@@ -47,6 +46,8 @@ class GameplayTimer
     bool    m_semiTransparent = false;
 
 public:
+    static std::string formatTime(int64_t t);
+
     GameplayTimer();
 
     void setSemitransparent(bool t);

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -40,6 +40,7 @@
 #include "menu_controls.h"
 
 #include "speedrunner.h"
+#include "main/gameplay_timer.h"
 #include "../game_main.h"
 #include "../sound.h"
 #include "../player.h"
@@ -58,6 +59,7 @@
 #include "screen_textentry.h"
 #include "editor/new_editor.h"
 #include "editor/write_world.h"
+#include "script/luna/luna.h"
 
 MainMenuContent g_mainMenu;
 
@@ -1557,6 +1559,54 @@ static void s_drawGameSaves()
         A++;
         SuperPrint("ERASE SAVE", 3, 300, 320 + (A * 30));
     }
+
+    if(MenuCursor < 0 || MenuCursor >= maxSaveSlots || (MenuMode != MENU_SELECT_SLOT_1P && MenuMode != MENU_SELECT_SLOT_2P) || SaveSlotInfo[MenuCursor + 1].Progress < 0)
+        return;
+
+    const auto& info = SaveSlotInfo[MenuCursor + 1];
+
+    int infobox_x = ScreenW / 2 - 240;
+    int MenuY = ScreenH - 250;
+    int infobox_y = MenuY + 145;
+
+    int row_1 = infobox_y + 10;
+    int row_2 = infobox_y + 42;
+
+    // recenter if single row
+    if(info.Time <= 0 && !gEnableDemoCounter)
+        row_1 = 26;
+
+    XRender::renderRect(infobox_x, infobox_y, 480, 68, 0, 0, 0, 0.5f);
+
+    std::string t;
+    SuperPrint(t = fmt::format_ne("Score: {0}", info.Score), 3, infobox_x + 10, row_1);
+
+    // 1-UP
+    XRender::renderTexture(infobox_x + 280, row_1, GFX.Interface[3]);
+    // times
+    XRender::renderTexture(infobox_x + 280 + 4 + GFX.Interface[3].w, row_1 + 1, GFX.Interface[1]);
+    // Lives
+    SuperPrintRightAlign(t = std::to_string(info.Lives), 1, infobox_x + 280 + 4 + 56 + GFX.Interface[3].w, row_1 + 1);
+
+    // coin
+    XRender::renderTexture(infobox_x + 480 - 10 - 56 - 4 - GFX.Interface[2].w, row_1, GFX.Interface[2]);
+    // times
+    XRender::renderTexture(infobox_x + 480 - 10 - 56, row_1 + 1, GFX.Interface[1]);
+    // coins
+    SuperPrintRightAlign(t = std::to_string(info.Coins), 1, infobox_x + 480 - 10, row_1 + 1);
+
+    if(info.Time > 0)
+    {
+        std::string t = GameplayTimer::formatTime(info.Time);
+
+        if(t.size() > 9)
+            t = t.substr(0, t.size() - 4);
+
+        SuperPrint(fmt::format_ne("Time: {0}", t), 3, infobox_x + 10, row_2);
+    }
+
+    if(gEnableDemoCounter)
+        SuperPrintRightAlign(fmt::format_ne("{0}: {1}", gDemoCounterTitle, info.Fails), 3, infobox_x + 480 - 10, row_2);
 }
 
 void mainMenuDraw()

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -1574,6 +1574,7 @@ static void s_drawGameSaves()
 
     int row_1 = infobox_y + 10;
     int row_2 = infobox_y + 42;
+    int row_c = infobox_y + 26;
 
     // recenter if single row
     if((info.Time <= 0 || g_speedRunnerMode == SPEEDRUN_MODE_OFF) && !gEnableDemoCounter)
@@ -1581,23 +1582,16 @@ static void s_drawGameSaves()
 
     XRender::renderRect(infobox_x, infobox_y, 480, 68, 0, 0, 0, 0.5f);
 
-    // Score
+    // Temp string
     std::string t;
-    SuperPrint(t = fmt::format_ne("Score: {0}", info.Score), 3, infobox_x + 10, row_1);
 
-    // Print lives on the screen (from gfx_update2.cpp)
-    XRender::renderTexture(infobox_x + 272, row_1 + 2 + 14 - GFX.Interface[3].h, GFX.Interface[3]);
-    XRender::renderTexture(infobox_x + 272 + 40, row_1 + 2 + 16 - GFX.Interface[3].h, GFX.Interface[1]);
-    SuperPrint(t = std::to_string(info.Lives), 1, infobox_x + 272 + 62, row_1 + 2);
-
-    // Print coins on the screen (from gfx_update2.cpp)
-    int coins_x = infobox_x + 480 - 10 - 36 - 62;
-    XRender::renderTexture(coins_x + 16, row_1, GFX.Interface[2]);
-    XRender::renderTexture(coins_x + 40, row_1 + 2, GFX.Interface[1]);
-    SuperPrintRightAlign(t = std::to_string(info.Coins), 1, coins_x + 62 + 36, row_1 + 2);
+    // Score
+    bool show_timer = info.Time > 0 && g_speedRunnerMode != SPEEDRUN_MODE_OFF;
+    int row_score = show_timer ? row_1 : row_c;
+    SuperPrint(t = fmt::format_ne("Score: {0}", info.Score), 3, infobox_x + 10, row_score);
 
     // Gameplay Timer
-    if(info.Time > 0 && g_speedRunnerMode != SPEEDRUN_MODE_OFF)
+    if(show_timer)
     {
         std::string t = GameplayTimer::formatTime(info.Time);
 
@@ -1606,6 +1600,20 @@ static void s_drawGameSaves()
 
         SuperPrint(fmt::format_ne("Time: {0}", t), 3, infobox_x + 10, row_2);
     }
+
+    // If demos off, put (l)ives and (c)oins on center
+    int row_lc = (gEnableDemoCounter) ? row_1 : row_c;
+
+    // Print lives on the screen (from gfx_update2.cpp)
+    XRender::renderTexture(infobox_x + 272, row_lc + 2 + 14 - GFX.Interface[3].h, GFX.Interface[3]);
+    XRender::renderTexture(infobox_x + 272 + 40, row_lc + 2 + 16 - GFX.Interface[3].h, GFX.Interface[1]);
+    SuperPrint(t = std::to_string(info.Lives), 1, infobox_x + 272 + 62, row_lc + 2);
+
+    // Print coins on the screen (from gfx_update2.cpp)
+    int coins_x = infobox_x + 480 - 10 - 36 - 62;
+    XRender::renderTexture(coins_x + 16, row_lc, GFX.Interface[2]);
+    XRender::renderTexture(coins_x + 40, row_lc + 2, GFX.Interface[1]);
+    SuperPrintRightAlign(t = std::to_string(info.Coins), 1, coins_x + 62 + 36, row_lc + 2);
 
     // Fails Counter
     if(gEnableDemoCounter)

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -1574,25 +1574,26 @@ static void s_drawGameSaves()
 
     // recenter if single row
     if(info.Time <= 0 && !gEnableDemoCounter)
-        row_1 = 26;
+        row_1 = infobox_y + 26;
 
     XRender::renderRect(infobox_x, infobox_y, 480, 68, 0, 0, 0, 0.5f);
 
+    // Score
     std::string t;
     SuperPrint(t = fmt::format_ne("Score: {0}", info.Score), 3, infobox_x + 10, row_1);
 
-    // Print lives on the screen
+    // Print lives on the screen (from gfx_update2.cpp)
     XRender::renderTexture(infobox_x + 272, row_1 + 2 + 14 - GFX.Interface[3].h, GFX.Interface[3]);
     XRender::renderTexture(infobox_x + 272 + 40, row_1 + 2 + 16 - GFX.Interface[3].h, GFX.Interface[1]);
     SuperPrint(t = std::to_string(info.Lives), 1, infobox_x + 272 + 62, row_1 + 2);
 
-    // Print coins on the screen
+    // Print coins on the screen (from gfx_update2.cpp)
     int coins_x = infobox_x + 480 - 10 - 36 - 62;
     XRender::renderTexture(coins_x + 16, row_1, GFX.Interface[2]);
     XRender::renderTexture(coins_x + 40, row_1 + 2, GFX.Interface[1]);
-
     SuperPrintRightAlign(t = std::to_string(info.Coins), 1, coins_x + 62 + 36, row_1 + 2);
 
+    // Gameplay Timer
     if(info.Time > 0)
     {
         std::string t = GameplayTimer::formatTime(info.Time);
@@ -1603,6 +1604,7 @@ static void s_drawGameSaves()
         SuperPrint(fmt::format_ne("Time: {0}", t), 3, infobox_x + 10, row_2);
     }
 
+    // Fails Counter
     if(gEnableDemoCounter)
         SuperPrintRightAlign(fmt::format_ne("{0}: {1}", gDemoCounterTitle, info.Fails), 3, infobox_x + 480 - 10, row_2);
 }

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -1576,8 +1576,10 @@ static void s_drawGameSaves()
     int row_2 = infobox_y + 42;
     int row_c = infobox_y + 26;
 
+    bool hasFails = (gEnableDemoCounter || info.FailsEnabled);
+
     // recenter if single row
-    if((info.Time <= 0 || g_speedRunnerMode == SPEEDRUN_MODE_OFF) && !gEnableDemoCounter)
+    if((info.Time <= 0 || g_speedRunnerMode == SPEEDRUN_MODE_OFF) && !hasFails)
         row_1 = infobox_y + 26;
 
     XRender::renderRect(infobox_x, infobox_y, 480, 68, 0, 0, 0, 0.5f);
@@ -1602,7 +1604,7 @@ static void s_drawGameSaves()
     }
 
     // If demos off, put (l)ives and (c)oins on center
-    int row_lc = (gEnableDemoCounter) ? row_1 : row_c;
+    int row_lc = (hasFails) ? row_1 : row_c;
 
     // Print lives on the screen (from gfx_update2.cpp)
     XRender::renderTexture(infobox_x + 272, row_lc + 2 + 14 - GFX.Interface[3].h, GFX.Interface[3]);
@@ -1616,7 +1618,7 @@ static void s_drawGameSaves()
     SuperPrintRightAlign(t = std::to_string(info.Coins), 1, coins_x + 62 + 36, row_lc + 2);
 
     // Fails Counter
-    if(gEnableDemoCounter)
+    if(hasFails)
         SuperPrintRightAlign(fmt::format_ne("{0}: {1}", gDemoCounterTitle, info.Fails), 3, infobox_x + 480 - 10, row_2);
 }
 

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -1274,7 +1274,7 @@ bool mainMenuUpdate()
 
                     if(MenuMode == MENU_SELECT_SLOT_1P_COPY_S1 || MenuMode == MENU_SELECT_SLOT_2P_COPY_S1)
                     {
-                        if(SaveSlot[slot] < 0)
+                        if(SaveSlotInfo[slot].Progress < 0)
                             PlaySoundMenu(SFX_BlockHit);
                         else
                         {
@@ -1531,10 +1531,10 @@ static void s_drawGameSaves()
 
     for(A = 1; A <= maxSaveSlots; A++)
     {
-        if(SaveSlot[A] >= 0)
+        if(SaveSlotInfo[A].Progress >= 0)
         {
-            SuperPrint(fmt::format_ne("SLOT {0} ... {1}%", A, SaveSlot[A]), 3, 300, 320 + (A * 30));
-            if(SaveStars[A] > 0)
+            SuperPrint(fmt::format_ne("SLOT {0} ... {1}%", A, SaveSlotInfo[A].Progress), 3, 300, 320 + (A * 30));
+            if(SaveSlotInfo[A].Stars > 0)
             {
                 XRender::renderTexture(560, 320 + (A * 30) + 1,
                                       GFX.Interface[5].w, GFX.Interface[5].h,
@@ -1542,7 +1542,7 @@ static void s_drawGameSaves()
                 XRender::renderTexture(560 + 24, 320 + (A * 30) + 2,
                                       GFX.Interface[1].w, GFX.Interface[1].h,
                                       GFX.Interface[1], 0, 0);
-                SuperPrint(fmt::format_ne(" {0}", SaveStars[A]), 3, 588, 320 + (A * 30));
+                SuperPrint(fmt::format_ne(" {0}", SaveSlotInfo[A].Stars), 3, 588, 320 + (A * 30));
             }
         }
         else

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -1576,7 +1576,7 @@ static void s_drawGameSaves()
     int row_2 = infobox_y + 42;
 
     // recenter if single row
-    if(info.Time <= 0 && !gEnableDemoCounter)
+    if((info.Time <= 0 || g_speedRunnerMode == SPEEDRUN_MODE_OFF) && !gEnableDemoCounter)
         row_1 = infobox_y + 26;
 
     XRender::renderRect(infobox_x, infobox_y, 480, 68, 0, 0, 0, 0.5f);
@@ -1597,7 +1597,7 @@ static void s_drawGameSaves()
     SuperPrintRightAlign(t = std::to_string(info.Coins), 1, coins_x + 62 + 36, row_1 + 2);
 
     // Gameplay Timer
-    if(info.Time > 0)
+    if(info.Time > 0 && g_speedRunnerMode != SPEEDRUN_MODE_OFF)
     {
         std::string t = GameplayTimer::formatTime(info.Time);
 

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -1581,19 +1581,17 @@ static void s_drawGameSaves()
     std::string t;
     SuperPrint(t = fmt::format_ne("Score: {0}", info.Score), 3, infobox_x + 10, row_1);
 
-    // 1-UP
-    XRender::renderTexture(infobox_x + 280, row_1, GFX.Interface[3]);
-    // times
-    XRender::renderTexture(infobox_x + 280 + 4 + GFX.Interface[3].w, row_1 + 1, GFX.Interface[1]);
-    // Lives
-    SuperPrintRightAlign(t = std::to_string(info.Lives), 1, infobox_x + 280 + 4 + 56 + GFX.Interface[3].w, row_1 + 1);
+    // Print lives on the screen
+    XRender::renderTexture(infobox_x + 272, row_1 + 2 + 14 - GFX.Interface[3].h, GFX.Interface[3]);
+    XRender::renderTexture(infobox_x + 272 + 40, row_1 + 2 + 16 - GFX.Interface[3].h, GFX.Interface[1]);
+    SuperPrint(t = std::to_string(info.Lives), 1, infobox_x + 272 + 62, row_1 + 2);
 
-    // coin
-    XRender::renderTexture(infobox_x + 480 - 10 - 56 - 4 - GFX.Interface[2].w, row_1, GFX.Interface[2]);
-    // times
-    XRender::renderTexture(infobox_x + 480 - 10 - 56, row_1 + 1, GFX.Interface[1]);
-    // coins
-    SuperPrintRightAlign(t = std::to_string(info.Coins), 1, infobox_x + 480 - 10, row_1 + 1);
+    // Print coins on the screen
+    int coins_x = infobox_x + 480 - 10 - 36 - 62;
+    XRender::renderTexture(coins_x + 16, row_1, GFX.Interface[2]);
+    XRender::renderTexture(coins_x + 40, row_1 + 2, GFX.Interface[1]);
+
+    SuperPrintRightAlign(t = std::to_string(info.Coins), 1, coins_x + 62 + 36, row_1 + 2);
 
     if(info.Time > 0)
     {

--- a/src/main/screen_connect.cpp
+++ b/src/main/screen_connect.cpp
@@ -1184,10 +1184,14 @@ bool Player_Mouse_Render(int p, int pX, int cX, int pY, int line, bool mouse, bo
         {
             if(s_context == Context::MainMenu && s_minPlayers == 1 && s_playerState[p] == PlayerState::Disconnected)
             {
-                XRender::renderRect(ScreenW / 2 - 320, pY + 2.5 * line, 640, 2.5 * line, 0, 0, 0, 0.5);
+                // MenuY + 145
+                int infobox_y = pY + 75;
 
-                SuperPrintCenter("WAITING FOR INPUT DEVICE...", 3, cX, pY + 3*line, 0.8f, 0.8f, 0.8f, 0.8f);
-                SuperPrintCenter("PRESS SELECT FOR CONTROLS OPTIONS", 3, cX, pY + 4*line, 0.8f, 0.8f, 0.8f, 0.8f);
+                XRender::renderRect(ScreenW / 2 - 240, infobox_y, 480, 68, 0, 0, 0, 0.5);
+
+                SuperPrintScreenCenter("WAITING FOR INPUT DEVICE...", 3, infobox_y + 4, 0.8f, 0.8f, 0.8f, 0.8f);
+                SuperPrintScreenCenter("PRESS SELECT FOR", 3, infobox_y + 24, 0.8f, 0.8f, 0.8f, 0.8f);
+                SuperPrintScreenCenter("CONTROLS OPTIONS", 3, infobox_y + 44, 0.8f, 0.8f, 0.8f, 0.8f);
             }
             else if(BlockFlash < 45)
                 SuperPrintCenter(g_mainMenu.phrasePressAButton, 3, cX, pY+2*line);
@@ -1227,19 +1231,23 @@ bool Player_Mouse_Render(int p, int pX, int cX, int pY, int line, bool mouse, bo
     // show the squashed info for 1P mode
     else if(render)
     {
-        XRender::renderRect(ScreenW / 2 - 320, pY + 2.5 * line, 640, 2.5 * line, 0, 0, 0, 0.5);
+        // MenuY + 145
+        int infobox_y = pY + 75;
+
+        XRender::renderRect(ScreenW / 2 - 240, infobox_y, 480, 68, 0, 0, 0, 0.5);
 
         if(p < (int)Controls::g_InputMethods.size() && Controls::g_InputMethods[p])
         {
             // global information about controller
             // Profile should never be null
             if(Controls::g_InputMethods[p]->Profile != nullptr)
-                SuperPrintCenter(Controls::g_InputMethods[p]->Name + " - " + Controls::g_InputMethods[p]->Profile->Name, 3, cX, pY + 3*line);
+                SuperPrintScreenCenter(Controls::g_InputMethods[p]->Name + " - " + Controls::g_InputMethods[p]->Profile->Name, 3, infobox_y + 4);
             else
-                SuperPrintCenter(Controls::g_InputMethods[p]->Name, 3, cX, pY + 3*line);
+                SuperPrintScreenCenter(Controls::g_InputMethods[p]->Name, 3, infobox_y + 4);
         }
 
-        SuperPrintCenter("PRESS SELECT FOR CONTROLS OPTIONS", 3, cX, pY + 4*line, 0.8f, 0.8f, 0.8f, 0.8f);
+        SuperPrintScreenCenter("PRESS SELECT FOR", 3, infobox_y + 24, 0.8f, 0.8f, 0.8f, 0.8f);
+        SuperPrintScreenCenter("CONTROLS OPTIONS", 3, infobox_y + 44, 0.8f, 0.8f, 0.8f, 0.8f);
     }
 
     return ret;

--- a/src/script/luna/lunaglobals.cpp
+++ b/src/script/luna/lunaglobals.cpp
@@ -27,8 +27,8 @@ bool gLunaEnabled = true;
 bool gShowDemoCounter = true;
 bool gEnableDemoCounter = true;
 bool gEnableDemoCounterByLC = false;
-std::string gDemoCounterTitle = "DEMOS";
-std::string gDemoCounterTitleDefault = "DEMOS";
+std::string gDemoCounterTitle = "FAILS";
+std::string gDemoCounterTitleDefault = "FAILS";
 
 
 /* Fallback dummy calls for the case when Luna Autocode has been disabled */


### PR DESCRIPTION
Small PR with just the feature described and supporting infrastructure. I believe this feature has been requested a few times and it seemed simple enough to implement.

<img src="https://user-images.githubusercontent.com/72112344/213750913-b0715435-eb5b-4317-8a7d-fbdaa78eedc3.png" width="400" height="300"> <img src="https://user-images.githubusercontent.com/72112344/213750960-5235c6e8-84bb-4c5c-a1a6-10edde1e469f.png" width="400" height="300">


Major changes:
* SaveSlot and SaveStars are replaced with a new SaveSlotInfo array which contains much more information about the gamesave.
* This information is displayed at the title screen.

Minor changes:
* SavedChar now uses a unique `SavedChar_t` instead of a `Player_t`. This is harmless because the other variables in SavedChar were only written, never read. (Note: this saves more memory than SaveSlotInfo costs.)
* Fixed some inconsistencies in the settings for the Fails counter (it was previously off by default if `gameinfo.ini` existed and on by default otherwise).
* The Fails counter now reads "Fails" unless `gameinfo.ini` requests "Demos".