### PR TITLE
Fix two vanilla bugs that kill player via the pinched code

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,8 @@ Changelog for 1.3.6.1
 -Added game save info (score, lives, coins, etc) display to the main menu screen. (@ds-sloth)
 -Allow a single player to reconnect their controls at the menu screen. (@ds-sloth)
 -In Magic Hand mode, cursor now snaps to current layer's grid, instead of global grid. (@ds-sloth)
+-Fixed vanilla bug where player could be crushed by a sloped ceiling (@ds-sloth)
+-Fixed vanilla bug where player could be crushed by a horizontally (not vertically) moving ceiling (@ds-sloth)
 
 Changelog for 1.3.6
 -Added an ability to toggle drawing of the HUD and other on-screen meta data using F1 key (@Wohlstand)

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@ TheXTech Changelog.
 
 Changelog for 1.3.7-dev
 -Deep revision of the game's internal NPC and render logic, with up to 2x higher framerates on very large levels. (@ds-sloth)
+-Fixed vanilla bug where player could be crushed by a sloped ceiling (@ds-sloth)
+-Fixed vanilla bug where player could be crushed by a horizontally (not vertically) moving ceiling (@ds-sloth)
 -<WIP>
 
 Changelog for 1.3.6.1
@@ -34,8 +36,6 @@ Changelog for 1.3.6.1
 -Allow a single player to reconnect their controls at the menu screen. (@ds-sloth)
 -In Magic Hand mode, cursor now snaps to current layer's grid, instead of global grid. (@ds-sloth)
 -Fixed crash that could occur if player warped with >2P cheat active. (@ds-sloth)
--Fixed vanilla bug where player could be crushed by a sloped ceiling (@ds-sloth)
--Fixed vanilla bug where player could be crushed by a horizontally (not vertically) moving ceiling (@ds-sloth)
 
 Changelog for 1.3.6
 -Added an ability to toggle drawing of the HUD and other on-screen meta data using F1 key (@Wohlstand)

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -109,6 +109,7 @@ static void compatInit(Compatibility_t &c)
     c.bitblit_background_colour[1] = 0;
     c.bitblit_background_colour[2] = 0;
     c.custom_powerup_collect_score = true;
+    c.fix_player_crush_death = true;
 
 
     if(s_compatLevel >= COMPAT_SMBX2) // Make sure that bugs were same as on SMBX2 Beta 4 on this moment
@@ -153,6 +154,7 @@ static void compatInit(Compatibility_t &c)
         c.fix_npc_ceiling_speed = false;
         c.emulate_classic_block_order = true;
         c.custom_powerup_collect_score = false;
+        c.fix_player_crush_death = false;
     }
 
     if(s_compatLevel >= COMPAT_SMBX13) // Strict vanilla SMBX
@@ -339,6 +341,7 @@ static void loadCompatIni(Compatibility_t &c, const std::string &fileName)
         compat.read("fix-npc-ceiling-speed", c.fix_npc_ceiling_speed, c.fix_npc_ceiling_speed);
         compat.read("emulate-classic-block-order", c.emulate_classic_block_order, c.emulate_classic_block_order);
         // compat.read("custom-powerup-collect-score", c.custom_powerup_collect_score, c.custom_powerup_collect_score);
+        compat.read("fix-player-crush-death", c.fix_player_crush_death, c.fix_player_crush_death);
     }
     // 1.3.4
     compat.read("fix-player-filter-bounce", c.fix_player_filter_bounce, c.fix_player_filter_bounce);

--- a/src/compat.h
+++ b/src/compat.h
@@ -88,6 +88,7 @@ struct Compatibility_t
     bool fix_npc_ceiling_speed; // when an NPC hits a ceiling block, it takes its SpeedY from that block, not from an arbitrary one
     bool emulate_classic_block_order; // the quadtree should return blocks in the order they had at the beginning of the level, not their current order
     bool custom_powerup_collect_score; // collected powerups give score from npc-X.txt
+    bool fix_player_crush_death; // player should not be crushed by corners of slopes or by hitting a horizontally moving ceiling
     unsigned int bitblit_background_colour[3];
 
     // SpeedRun section

--- a/src/globals.h
+++ b/src/globals.h
@@ -29,6 +29,7 @@
 #include "std_picture.h"
 
 #include "location.h"
+#include "pinched_info.h"
 #include "range_arr.hpp"
 #include "ref_type.h"
 #include "rand.h"
@@ -252,16 +253,21 @@ struct NPC_t
     int RespawnDelay = 0;
 //    Bouce As Boolean
     bool Bouce = false;
+
 //    Pinched1 As Integer  'getting smashed by a block
-    int Pinched1 = 0;
+    // int Pinched1 = 0;
 //    Pinched2 As Integer
-    int Pinched2 = 0;
+    // int Pinched2 = 0;
 //    Pinched3 As Integer
-    int Pinched3 = 0;
+    // int Pinched3 = 0;
 //    Pinched4 As Integer
-    int Pinched4 = 0;
+    // int Pinched4 = 0;
 //    MovingPinched As Integer 'required to be smashed
-    int MovingPinched = 0;
+    // int MovingPinched = 0;
+
+    // NEW: replaces above with bitfield
+    PinchedInfo_t Pinched = PinchedInfo_t();
+
 //    NetTimeout As Integer 'for online
     // int NetTimeout = 0;    // unused since SMBX64, removed
 //    RealSpeedX As Single 'the real speed of the NPC
@@ -618,17 +624,21 @@ struct Player_t
     bool Immune2 = false;
 //    ForceHitSpot3 As Boolean 'force hitspot 3 for collision detection
     bool ForceHitSpot3 = false;
+
 //'for getting smashed by a block
 //    Pinched1 As Integer
-    int Pinched1 = 0;
+    // int Pinched1 = 0;
 //    Pinched2 As Integer
-    int Pinched2 = 0;
+    // int Pinched2 = 0;
 //    Pinched3 As Integer
-    int Pinched3 = 0;
+    // int Pinched3 = 0;
 //    Pinched4 As Integer
-    int Pinched4 = 0;
+    // int Pinched4 = 0;
 //    NPCPinched As Integer 'must be > 0 for the player to get crushed
-    int NPCPinched = 0;
+    // int NPCPinched = 0;
+
+    PinchedInfo_t Pinched = PinchedInfo_t();
+
 //    m2Speed As Single
     float m2Speed = 0.0f;
 //    HoldingNPC As Integer 'What NPC is being held

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -138,14 +138,15 @@ void Deactivate(int A)
             NPC[A].Special6 = 0;
             NPC[A].Damage = 0;
             NPC[A].HoldingPlayer = 0;
-            NPC[A].Pinched1 = 0;
-            NPC[A].Pinched2 = 0;
-            NPC[A].Pinched3 = 0;
-            NPC[A].Pinched4 = 0;
 
-            // NPC[A].Pinched = 0;    // unused since SMBX64, removed
+            // NPC[A].Pinched1 = 0;
+            // NPC[A].Pinched2 = 0;
+            // NPC[A].Pinched3 = 0;
+            // NPC[A].Pinched4 = 0;
+            // NPC[A].Pinched = 0;
+            // NPC[A].MovingPinched = 0;
 
-            NPC[A].MovingPinched = 0;
+            NPC[A].Pinched = PinchedInfo_t();
 
             // NEW now that we have the new NPC Queues
             NPCQueues::update(A);

--- a/src/npc/npc_update.cpp
+++ b/src/npc/npc_update.cpp
@@ -2219,16 +2219,16 @@ void UpdateNPCs()
                     if(NPC[A].Type == 179)
                         NPC[A].Location.Height = 24;
 
-                    if(NPC[A].Pinched1 > 0)
-                        NPC[A].Pinched1 -= 1;
-                    if(NPC[A].Pinched2 > 0)
-                        NPC[A].Pinched2 -= 1;
-                    if(NPC[A].Pinched3 > 0)
-                        NPC[A].Pinched3 -= 1;
-                    if(NPC[A].Pinched4 > 0)
-                        NPC[A].Pinched4 -= 1;
-                    if(NPC[A].MovingPinched > 0)
-                        NPC[A].MovingPinched -= 1;
+                    if(NPC[A].Pinched.Bottom1 > 0)
+                        NPC[A].Pinched.Bottom1 -= 1;
+                    if(NPC[A].Pinched.Left2 > 0)
+                        NPC[A].Pinched.Left2 -= 1;
+                    if(NPC[A].Pinched.Top3 > 0)
+                        NPC[A].Pinched.Top3 -= 1;
+                    if(NPC[A].Pinched.Right4 > 0)
+                        NPC[A].Pinched.Right4 -= 1;
+                    if(NPC[A].Pinched.Moving > 0)
+                        NPC[A].Pinched.Moving -= 1;
 
                     newY = 0;
                     UNUSED(newY);
@@ -2833,20 +2833,20 @@ void UpdateNPCs()
                                                             NPCHit(A, 3, A);
 
                                                         if(Block[B].Location.SpeedX != 0 && (HitSpot == 2 || HitSpot == 4))
-                                                            NPC[A].MovingPinched = 2;
+                                                            NPC[A].Pinched.Moving = 2;
                                                         if(Block[B].Location.SpeedY != 0 && (HitSpot == 1 || HitSpot == 3))
-                                                            NPC[A].MovingPinched = 2;
+                                                            NPC[A].Pinched.Moving = 2;
 
                                                         if(NPC[A].TimeLeft > 1)
                                                         {
                                                             if(HitSpot == 1)
-                                                                NPC[A].Pinched1 = 2;
+                                                                NPC[A].Pinched.Bottom1 = 2;
                                                             else if(HitSpot == 2)
-                                                                NPC[A].Pinched2 = 2;
+                                                                NPC[A].Pinched.Left2 = 2;
                                                             else if(HitSpot == 3)
-                                                                NPC[A].Pinched3 = 2;
+                                                                NPC[A].Pinched.Top3 = 2;
                                                             else if(HitSpot == 4)
-                                                                NPC[A].Pinched4 = 2;
+                                                                NPC[A].Pinched.Right4 = 2;
                                                             else if(HitSpot == 5)
                                                             {
                                                                 double C = 0;
@@ -2875,18 +2875,18 @@ void UpdateNPCs()
                                                                 }
 
                                                                 if(D == 1)
-                                                                    NPC[A].Pinched1 = 2;
+                                                                    NPC[A].Pinched.Bottom1 = 2;
                                                                 if(D == 2)
-                                                                    NPC[A].Pinched2 = 2;
+                                                                    NPC[A].Pinched.Left2 = 2;
                                                                 if(D == 3)
-                                                                    NPC[A].Pinched3 = 2;
+                                                                    NPC[A].Pinched.Top3 = 2;
                                                                 if(D == 4)
-                                                                    NPC[A].Pinched4 = 2;
+                                                                    NPC[A].Pinched.Right4 = 2;
 
                                                                 if(Block[B].Location.SpeedX != 0.0 && (D == 2 || D == 4))
-                                                                    NPC[A].MovingPinched = 2;
+                                                                    NPC[A].Pinched.Moving = 2;
                                                                 if(Block[B].Location.SpeedY != 0.0 && (D == 1 || D == 3))
-                                                                    NPC[A].MovingPinched = 2;
+                                                                    NPC[A].Pinched.Moving = 2;
 
 
 
@@ -2895,9 +2895,9 @@ void UpdateNPCs()
                                                                 // If Not (.Location.X + .Location.Width - .Location.SpeedX <= Block(B).Location.X - Block(B).Location.SpeedX) Then .Pinched2 = 2
                                                                 // If Not (.Location.X - .Location.SpeedX >= Block(B).Location.X + Block(B).Location.Width - Block(B).Location.SpeedX) Then .Pinched4 = 2
                                                             }
-                                                            if(NPC[A].MovingPinched > 0)
+                                                            if(NPC[A].Pinched.Moving > 0)
                                                             {
-                                                                if((NPC[A].Pinched1 > 0 && NPC[A].Pinched3 > 0) || (NPC[A].Pinched2 > 0 && NPC[A].Pinched4 > 0))
+                                                                if((NPC[A].Pinched.Bottom1 > 0 && NPC[A].Pinched.Top3 > 0) || (NPC[A].Pinched.Left2 > 0 && NPC[A].Pinched.Right4 > 0))
                                                                 {
                                                                     if(HitSpot > 1)
                                                                         HitSpot = 0;

--- a/src/pinched_info.h
+++ b/src/pinched_info.h
@@ -1,0 +1,48 @@
+/*
+ * TheXTech - A platform game engine ported from old source code for VB6
+ *
+ * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
+ * Copyright (c) 2020-2023 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#ifndef PINCHED_INFO_H
+#define PINCHED_INFO_H
+
+// structure used to store information about whether a player / NPC is being crushed by blocks
+struct PinchedInfo_t
+{
+    unsigned Bottom1   : 2;
+    unsigned Left2     : 2;
+    unsigned Top3      : 2;
+    unsigned Right4    : 2;
+    unsigned Moving    : 2;
+    bool     MovingLR  : 1;
+    bool     MovingUD  : 1;
+
+    inline PinchedInfo_t()
+    {
+        Bottom1 = 0;
+        Left2 = 0;
+        Top3 = 0;
+        Right4 = 0;
+        Moving = 0;
+        MovingLR = false;
+        MovingUD = false;
+    }
+};
+
+#endif // #ifndef PINCHED_INFO_H

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -352,13 +352,16 @@ void SetupPlayers()
         Player[A].Location.SpeedY = 2;
         Player[A].Frame = 1;
         Player[A].FrameCount = 0;
-        Player[A].NPCPinched = 0;
-        Player[A].Pinched1 = 0;
-        Player[A].Pinched2 = 0;
-        Player[A].Pinched3 = 0;
+
+        // Player[A].NPCPinched = 0;
+        // Player[A].Pinched1 = 0;
+        // Player[A].Pinched2 = 0;
+        // Player[A].Pinched3 = 0;
+        // Player[A].Pinched4 = 0;
+        Player[A].Pinched = PinchedInfo_t();
+
         Player[A].StandingOnNPC = 0;
         Player[A].StandingOnTempNPC = 0;
-        Player[A].Pinched4 = 0;
         Player[A].HoldingNPC = 0;
         Player[A].Dead = false;
         //        if(nPlay.Online && nPlay.Mode == 0)
@@ -846,11 +849,14 @@ void KillPlayer(const int A)
     p.Location.SpeedY = 0;
     p.State = 1;
     p.Stoned = false;
-    p.Pinched1 = 0;
-    p.Pinched2 = 0;
-    p.Pinched3 = 0;
-    p.Pinched4 = 0;
-    p.NPCPinched = 0;
+
+    // p.Pinched1 = 0;
+    // p.Pinched2 = 0;
+    // p.Pinched3 = 0;
+    // p.Pinched4 = 0;
+    // p.NPCPinched = 0;
+    p.Pinched = PinchedInfo_t();
+
     p.TimeToLive = 0;
     p.Direction = 1;
     p.Frame = 1;
@@ -4489,7 +4495,7 @@ static inline bool checkWarp(Warp_t &warp, int B, Player_t &plr, int A, bool bac
 {
     bool canWarp = false;
 
-    bool onGround = !warp.stoodRequired || (plr.Pinched1 == 2 || plr.Slope != 0 || plr.StandingOnNPC != 0);
+    bool onGround = !warp.stoodRequired || (plr.Pinched.Bottom1 == 2 || plr.Slope != 0 || plr.StandingOnNPC != 0);
 
     auto &entrance      = backward ? warp.Exit        : warp.Entrance;
     auto &exit          = backward ? warp.Entrance    : warp.Exit;
@@ -5714,11 +5720,12 @@ void PlayerEffects(const int A)
     }
 
     p.TailCount = 0;
-    p.Pinched1 = 0;
-    p.Pinched2 = 0;
-    p.Pinched3 = 0;
-    p.Pinched4 = 0;
-    p.NPCPinched = 0;
+    // p.Pinched1 = 0;
+    // p.Pinched2 = 0;
+    // p.Pinched3 = 0;
+    // p.Pinched4 = 0;
+    // p.NPCPinched = 0;
+    p.Pinched = PinchedInfo_t();
     p.SwordPoke = 0;
 
     if(!p.YoshiBlue && p.Effect != 500)

--- a/src/player/player_update.cpp
+++ b/src/player/player_update.cpp
@@ -2069,7 +2069,10 @@ void UpdatePlayer()
                             Player[A].Location.SpeedX = 0;
                         Player[A].Pinched.Left2 = 2;
                         if(AutoX[Player[A].Section] != 0.0f)
+                        {
                             Player[A].Pinched.Moving = 2;
+                            Player[A].Pinched.MovingLR = true;
+                        }
                     }
                     else if(Player[A].Location.X + Player[A].Location.Width > level[Player[A].Section].Width)
                     {
@@ -2078,7 +2081,10 @@ void UpdatePlayer()
                             Player[A].Location.SpeedX = 0;
                         Player[A].Pinched.Right4 = 2;
                         if(AutoX[Player[A].Section] != 0.f)
+                        {
                             Player[A].Pinched.Moving = 2;
+                            Player[A].Pinched.MovingLR = true;
+                        }
                     }
                 }
 
@@ -2086,7 +2092,10 @@ void UpdatePlayer()
                 {
                     Player[A].Location.Y = level[Player[A].Section].Y - Player[A].Location.Height - 32;
                     if(AutoY[Player[A].Section] != 0.f)
+                    {
                         Player[A].Pinched.Moving = 3;
+                        Player[A].Pinched.MovingUD = true;
+                    }
                 }
 
                 // gives the players the sparkles when he is flying
@@ -2148,7 +2157,15 @@ void UpdatePlayer()
                 if(Player[A].Pinched.Right4 > 0)
                     Player[A].Pinched.Right4 -= 1;
                 if(Player[A].Pinched.Moving > 0)
+                {
                     Player[A].Pinched.Moving -= 1;
+
+                    if(Player[A].Pinched.Moving == 0)
+                    {
+                        Player[A].Pinched.MovingLR = false;
+                        Player[A].Pinched.MovingUD = false;
+                    }
+                }
 
                 if(Player[A].Character == 5 && Player[A].Duck && (Player[A].Location.SpeedY == Physics.PlayerGravity || Player[A].StandingOnNPC != 0 || Player[A].Slope != 0))
                 {
@@ -2547,7 +2564,10 @@ void UpdatePlayer()
                                                 Player[A].FairyTime = 0;
                                             Player[A].Pinched.Bottom1 = 2; // for players getting squashed
                                             if(Block[B].Location.SpeedY != 0)
+                                            {
                                                 Player[A].Pinched.Moving = 2;
+                                                Player[A].Pinched.MovingUD = true;
+                                            }
                                             Player[A].Vine = 0; // stop climbing because you are now walking
                                             if(Player[A].Mount == 2) // for the clown car, make a niose and pound the ground if moving down fast enough
                                             {
@@ -2628,7 +2648,10 @@ void UpdatePlayer()
                                                     Player[A].mountBump = -Player[A].mountBump + Player[A].Location.X;
                                                 Player[A].Pinched.Left2 = 2;
                                                 if(Block[B].Location.SpeedX != 0)
+                                                {
                                                     Player[A].Pinched.Moving = 2;
+                                                    Player[A].Pinched.MovingLR = true;
+                                                }
                                             }
                                         }
                                         else if(HitSpot == 4) // hit the block from the left -------.
@@ -2644,14 +2667,20 @@ void UpdatePlayer()
                                                 Player[A].mountBump = -Player[A].mountBump + Player[A].Location.X;
                                             Player[A].Pinched.Right4 = 2;
                                             if(Block[B].Location.SpeedX != 0)
+                                            {
                                                 Player[A].Pinched.Moving = 2;
+                                                Player[A].Pinched.MovingLR = true;
+                                            }
                                         }
                                         else if(HitSpot == 3) // hit the block from below
                                         {
                                             if(!Player[A].ForceHitSpot3 && !Player[A].StandUp)
                                                 Player[A].Pinched.Top3 = 2;
                                             if(Block[B].Location.SpeedY != 0)
+                                            {
                                                 Player[A].Pinched.Moving = 2;
+                                                Player[A].Pinched.MovingUD = true;
+                                            }
                                             tempHit = true;
                                             if(tempBlockHit[1] == 0)
                                                 tempBlockHit[1] = B;
@@ -2683,7 +2712,15 @@ void UpdatePlayer()
                                                 else
                                                     Player[A].Pinched.Left2 = 2;
                                                 if(Block[B].Location.SpeedX != 0 || Block[B].Location.SpeedY != 0)
+                                                {
                                                     Player[A].Pinched.Moving = 2;
+
+                                                    if(Block[B].Location.SpeedX != 0)
+                                                        Player[A].Pinched.MovingLR = true;
+
+                                                    if(Block[B].Location.SpeedY != 0)
+                                                        Player[A].Pinched.MovingUD = true;
+                                                }
                                                 tempLocation.X = Player[A].Location.X;
                                                 tempLocation.Width = Player[A].Location.Width;
                                                 tempLocation.Y = Player[A].Location.Y + Player[A].Location.Height;
@@ -3980,7 +4017,13 @@ void UpdatePlayer()
                                                         Player[A].Pinched.Right4 = 2;
 
                                                         if(NPC[B].Type != 31 && NPC[B].Type != 32 && NPC[B].Type != 57 && (NPC[B].Location.SpeedX != 0 || NPC[B].Location.SpeedY != 0 || NPC[B].BeltSpeed))
+                                                        {
                                                             Player[A].Pinched.Moving = 2;
+
+                                                            if(NPC[B].Location.SpeedX != 0 || NPC[B].BeltSpeed)
+                                                                Player[A].Pinched.MovingLR = true;
+                                                        }
+
                                                         Player[A].Location.X = NPC[B].Location.X - Player[A].Location.Width - 0.1;
                                                         tempHit2 = true;
                                                         Player[A].RunCount = 0;
@@ -4011,8 +4054,15 @@ void UpdatePlayer()
                                                     else
                                                     {
                                                         Player[A].Pinched.Left2 = 2;
+
                                                         if(NPC[B].Type != 31 && NPC[B].Type != 32 && NPC[B].Type != 57 && (NPC[B].Location.SpeedX != 0 || NPC[B].Location.SpeedY != 0 || NPC[B].BeltSpeed))
+                                                        {
                                                             Player[A].Pinched.Moving = 2;
+
+                                                            if(NPC[B].Location.SpeedX != 0 || NPC[B].BeltSpeed)
+                                                                Player[A].Pinched.MovingLR = true;
+                                                        }
+
                                                         Player[A].Location.X = NPC[B].Location.X + NPC[B].Location.Width + 0.01;
                                                         tempHit2 = true;
                                                         Player[A].RunCount = 0;
@@ -4376,7 +4426,11 @@ void UpdatePlayer()
                 // pinch code
                 if(!GodMode)
                 {
-                    if(((Player[A].Pinched.Bottom1 > 0 && Player[A].Pinched.Top3 > 0) || (Player[A].Pinched.Left2 > 0 && Player[A].Pinched.Right4 > 0)) && Player[A].Pinched.Moving > 0 && Player[A].Mount != 2)
+                    bool pinch_death = (g_compatibility.fix_player_crush_death)
+                        ? ((Player[A].Pinched.Bottom1 > 0 && Player[A].Pinched.Top3 > 0 && Player[A].Pinched.MovingUD) || (Player[A].Pinched.Left2 > 0 && Player[A].Pinched.Right4 > 0 && Player[A].Pinched.MovingLR))
+                        : (((Player[A].Pinched.Bottom1 > 0 && Player[A].Pinched.Top3 > 0) || (Player[A].Pinched.Left2 > 0 && Player[A].Pinched.Right4 > 0)) && Player[A].Pinched.Moving > 0);
+
+                    if(pinch_death && Player[A].Mount != 2)
                     {
                         if(Player[A].Mount != 2)
                             Player[A].Mount = 0;

--- a/src/player/player_update.cpp
+++ b/src/player/player_update.cpp
@@ -2562,12 +2562,21 @@ void UpdatePlayer()
                                         {
                                             if(Player[A].Fairy && (Player[A].FairyCD > 0 || Player[A].Location.SpeedY > 0))
                                                 Player[A].FairyTime = 0;
-                                            Player[A].Pinched.Bottom1 = 2; // for players getting squashed
-                                            if(Block[B].Location.SpeedY != 0)
+
+                                            // add more generous margin to prevent unfair crush death with sloped floor
+                                            bool ignore = (g_compatibility.fix_player_crush_death
+                                                && (Block[B].Location.X + Block[B].Location.Width - 2 < Player[A].Location.X
+                                                    || Player[A].Location.X + Player[A].Location.Width - 2 < Block[B].Location.X));
+
+                                            if(!ignore)
+                                                Player[A].Pinched.Bottom1 = 2; // for players getting squashed
+
+                                            if(Block[B].Location.SpeedY != 0 && !ignore)
                                             {
                                                 Player[A].Pinched.Moving = 2;
                                                 Player[A].Pinched.MovingUD = true;
                                             }
+
                                             Player[A].Vine = 0; // stop climbing because you are now walking
                                             if(Player[A].Mount == 2) // for the clown car, make a niose and pound the ground if moving down fast enough
                                             {
@@ -2674,13 +2683,20 @@ void UpdatePlayer()
                                         }
                                         else if(HitSpot == 3) // hit the block from below
                                         {
-                                            if(!Player[A].ForceHitSpot3 && !Player[A].StandUp)
+                                            // add more generous margin to prevent unfair crush death with sloped ceiling
+                                            bool ignore = (g_compatibility.fix_player_crush_death
+                                                && (Block[B].Location.X + Block[B].Location.Width - 2 < Player[A].Location.X
+                                                    || Player[A].Location.X + Player[A].Location.Width - 2 < Block[B].Location.X));
+
+                                            if(!Player[A].ForceHitSpot3 && !Player[A].StandUp && !ignore)
                                                 Player[A].Pinched.Top3 = 2;
-                                            if(Block[B].Location.SpeedY != 0)
+
+                                            if(Block[B].Location.SpeedY != 0 && !ignore)
                                             {
                                                 Player[A].Pinched.Moving = 2;
                                                 Player[A].Pinched.MovingUD = true;
                                             }
+
                                             tempHit = true;
                                             if(tempBlockHit[1] == 0)
                                                 tempBlockHit[1] = B;

--- a/src/player/player_update.cpp
+++ b/src/player/player_update.cpp
@@ -2563,15 +2563,9 @@ void UpdatePlayer()
                                             if(Player[A].Fairy && (Player[A].FairyCD > 0 || Player[A].Location.SpeedY > 0))
                                                 Player[A].FairyTime = 0;
 
-                                            // add more generous margin to prevent unfair crush death with sloped floor
-                                            bool ignore = (g_compatibility.fix_player_crush_death
-                                                && (Block[B].Location.X + Block[B].Location.Width - 2 < Player[A].Location.X
-                                                    || Player[A].Location.X + Player[A].Location.Width - 2 < Block[B].Location.X));
+                                            Player[A].Pinched.Bottom1 = 2; // for players getting squashed
 
-                                            if(!ignore)
-                                                Player[A].Pinched.Bottom1 = 2; // for players getting squashed
-
-                                            if(Block[B].Location.SpeedY != 0 && !ignore)
+                                            if(Block[B].Location.SpeedY != 0)
                                             {
                                                 Player[A].Pinched.Moving = 2;
                                                 Player[A].Pinched.MovingUD = true;

--- a/src/player/player_update.cpp
+++ b/src/player/player_update.cpp
@@ -1023,7 +1023,7 @@ void UpdatePlayer()
                     Player[A].FairyCD -= 1;
 
 
-                // the pinched variable has been always false since SMBX64
+                // the single pinched variable has been always false since SMBX64
                 if(Player[A].StandingOnNPC != 0 && /*!NPC[Player[A].StandingOnNPC].Pinched && */ !FreezeNPCs)
                 {
                     if(Player[A].StandingOnNPC < 0)
@@ -2067,18 +2067,18 @@ void UpdatePlayer()
                         Player[A].Location.X = level[Player[A].Section].X;
                         if(Player[A].Location.SpeedX < 0)
                             Player[A].Location.SpeedX = 0;
-                        Player[A].Pinched2 = 2;
+                        Player[A].Pinched.Left2 = 2;
                         if(AutoX[Player[A].Section] != 0.0f)
-                            Player[A].NPCPinched = 2;
+                            Player[A].Pinched.Moving = 2;
                     }
                     else if(Player[A].Location.X + Player[A].Location.Width > level[Player[A].Section].Width)
                     {
                         Player[A].Location.X = level[Player[A].Section].Width - Player[A].Location.Width;
                         if(Player[A].Location.SpeedX > 0)
                             Player[A].Location.SpeedX = 0;
-                        Player[A].Pinched4 = 2;
+                        Player[A].Pinched.Right4 = 2;
                         if(AutoX[Player[A].Section] != 0.f)
-                            Player[A].NPCPinched = 2;
+                            Player[A].Pinched.Moving = 2;
                     }
                 }
 
@@ -2086,7 +2086,7 @@ void UpdatePlayer()
                 {
                     Player[A].Location.Y = level[Player[A].Section].Y - Player[A].Location.Height - 32;
                     if(AutoY[Player[A].Section] != 0.f)
-                        Player[A].NPCPinched = 3;
+                        Player[A].Pinched.Moving = 3;
                 }
 
                 // gives the players the sparkles when he is flying
@@ -2139,16 +2139,16 @@ void UpdatePlayer()
                 tempSlope = 0;
                 tempSlope2 = 0;
                 tempSlope3 = 0;
-                if(Player[A].Pinched1 > 0)
-                    Player[A].Pinched1 -= 1;
-                if(Player[A].Pinched2 > 0)
-                    Player[A].Pinched2 -= 1;
-                if(Player[A].Pinched3 > 0)
-                    Player[A].Pinched3 -= 1;
-                if(Player[A].Pinched4 > 0)
-                    Player[A].Pinched4 -= 1;
-                if(Player[A].NPCPinched > 0)
-                    Player[A].NPCPinched -= 1;
+                if(Player[A].Pinched.Bottom1 > 0)
+                    Player[A].Pinched.Bottom1 -= 1;
+                if(Player[A].Pinched.Left2 > 0)
+                    Player[A].Pinched.Left2 -= 1;
+                if(Player[A].Pinched.Top3 > 0)
+                    Player[A].Pinched.Top3 -= 1;
+                if(Player[A].Pinched.Right4 > 0)
+                    Player[A].Pinched.Right4 -= 1;
+                if(Player[A].Pinched.Moving > 0)
+                    Player[A].Pinched.Moving -= 1;
 
                 if(Player[A].Character == 5 && Player[A].Duck && (Player[A].Location.SpeedY == Physics.PlayerGravity || Player[A].StandingOnNPC != 0 || Player[A].Slope != 0))
                 {
@@ -2545,9 +2545,9 @@ void UpdatePlayer()
                                         {
                                             if(Player[A].Fairy && (Player[A].FairyCD > 0 || Player[A].Location.SpeedY > 0))
                                                 Player[A].FairyTime = 0;
-                                            Player[A].Pinched1 = 2; // for players getting squashed
+                                            Player[A].Pinched.Bottom1 = 2; // for players getting squashed
                                             if(Block[B].Location.SpeedY != 0)
-                                                Player[A].NPCPinched = 2;
+                                                Player[A].Pinched.Moving = 2;
                                             Player[A].Vine = 0; // stop climbing because you are now walking
                                             if(Player[A].Mount == 2) // for the clown car, make a niose and pound the ground if moving down fast enough
                                             {
@@ -2626,9 +2626,9 @@ void UpdatePlayer()
                                                 blockPushX = Block[B].Location.SpeedX;
                                                 if(Player[A].Mount == 2)
                                                     Player[A].mountBump = -Player[A].mountBump + Player[A].Location.X;
-                                                Player[A].Pinched2 = 2;
+                                                Player[A].Pinched.Left2 = 2;
                                                 if(Block[B].Location.SpeedX != 0)
-                                                    Player[A].NPCPinched = 2;
+                                                    Player[A].Pinched.Moving = 2;
                                             }
                                         }
                                         else if(HitSpot == 4) // hit the block from the left -------.
@@ -2642,16 +2642,16 @@ void UpdatePlayer()
                                             blockPushX = Block[B].Location.SpeedX;
                                             if(Player[A].Mount == 2)
                                                 Player[A].mountBump = -Player[A].mountBump + Player[A].Location.X;
-                                            Player[A].Pinched4 = 2;
+                                            Player[A].Pinched.Right4 = 2;
                                             if(Block[B].Location.SpeedX != 0)
-                                                Player[A].NPCPinched = 2;
+                                                Player[A].Pinched.Moving = 2;
                                         }
                                         else if(HitSpot == 3) // hit the block from below
                                         {
                                             if(!Player[A].ForceHitSpot3 && !Player[A].StandUp)
-                                                Player[A].Pinched3 = 2;
+                                                Player[A].Pinched.Top3 = 2;
                                             if(Block[B].Location.SpeedY != 0)
-                                                Player[A].NPCPinched = 2;
+                                                Player[A].Pinched.Moving = 2;
                                             tempHit = true;
                                             if(tempBlockHit[1] == 0)
                                                 tempBlockHit[1] = B;
@@ -2679,11 +2679,11 @@ void UpdatePlayer()
                                             {
                                                 tempSlope3 = B;
                                                 if(Player[A].Location.X + Player[A].Location.Width / 2.0 < Block[B].Location.X + Block[B].Location.Width / 2.0)
-                                                    Player[A].Pinched4 = 2;
+                                                    Player[A].Pinched.Right4 = 2;
                                                 else
-                                                    Player[A].Pinched2 = 2;
+                                                    Player[A].Pinched.Left2 = 2;
                                                 if(Block[B].Location.SpeedX != 0 || Block[B].Location.SpeedY != 0)
-                                                    Player[A].NPCPinched = 2;
+                                                    Player[A].Pinched.Moving = 2;
                                                 tempLocation.X = Player[A].Location.X;
                                                 tempLocation.Width = Player[A].Location.Width;
                                                 tempLocation.Y = Player[A].Location.Y + Player[A].Location.Height;
@@ -2934,7 +2934,7 @@ void UpdatePlayer()
                         if(Player[A].StandingOnNPC != 0 && !movingBlock)
                         {
                             Player[A].Location.SpeedY = 1;
-                            // the Pinched variable has always been false since SMBX64
+                            // the single Pinched variable has always been false since SMBX64
                             // if(!NPC[Player[A].StandingOnNPC].Pinched && !FreezeNPCs)
                             if(!FreezeNPCs)
                                 Player[A].Location.SpeedX += -NPC[Player[A].StandingOnNPC].Location.SpeedX - NPC[Player[A].StandingOnNPC].BeltSpeed;
@@ -3206,7 +3206,7 @@ void UpdatePlayer()
                 {
                     if(!tempHit2)
                     {
-                        // the Pinched variable has always been false since SMBX64
+                        // the single Pinched variable has always been false since SMBX64
                         // if(!NPC[Player[A].StandingOnNPC].Pinched && !FreezeNPCs)
                         if(!FreezeNPCs)
                             Player[A].Location.SpeedX += -NPC[Player[A].StandingOnNPC].Location.SpeedX - NPC[Player[A].StandingOnNPC].BeltSpeed;
@@ -3977,10 +3977,10 @@ void UpdatePlayer()
                                                     D = Player[A].Location.X;
                                                     if(Player[A].Location.X + Player[A].Location.Width / 2.0 < NPC[B].Location.X + NPC[B].Location.Width / 2.0)
                                                     {
-                                                        Player[A].Pinched4 = 2;
+                                                        Player[A].Pinched.Right4 = 2;
 
                                                         if(NPC[B].Type != 31 && NPC[B].Type != 32 && NPC[B].Type != 57 && (NPC[B].Location.SpeedX != 0 || NPC[B].Location.SpeedY != 0 || NPC[B].BeltSpeed))
-                                                            Player[A].NPCPinched = 2;
+                                                            Player[A].Pinched.Moving = 2;
                                                         Player[A].Location.X = NPC[B].Location.X - Player[A].Location.Width - 0.1;
                                                         tempHit2 = true;
                                                         Player[A].RunCount = 0;
@@ -4010,9 +4010,9 @@ void UpdatePlayer()
                                                     }
                                                     else
                                                     {
-                                                        Player[A].Pinched2 = 2;
+                                                        Player[A].Pinched.Left2 = 2;
                                                         if(NPC[B].Type != 31 && NPC[B].Type != 32 && NPC[B].Type != 57 && (NPC[B].Location.SpeedX != 0 || NPC[B].Location.SpeedY != 0 || NPC[B].BeltSpeed))
-                                                            Player[A].NPCPinched = 2;
+                                                            Player[A].Pinched.Moving = 2;
                                                         Player[A].Location.X = NPC[B].Location.X + NPC[B].Location.Width + 0.01;
                                                         tempHit2 = true;
                                                         Player[A].RunCount = 0;
@@ -4376,7 +4376,7 @@ void UpdatePlayer()
                 // pinch code
                 if(!GodMode)
                 {
-                    if(((Player[A].Pinched1 > 0 && Player[A].Pinched3 > 0) || (Player[A].Pinched2 > 0 && Player[A].Pinched4 > 0)) && Player[A].NPCPinched > 0 && Player[A].Mount != 2)
+                    if(((Player[A].Pinched.Bottom1 > 0 && Player[A].Pinched.Top3 > 0) || (Player[A].Pinched.Left2 > 0 && Player[A].Pinched.Right4 > 0)) && Player[A].Pinched.Moving > 0 && Player[A].Mount != 2)
                     {
                         if(Player[A].Mount != 2)
                             Player[A].Mount = 0;

--- a/src/script/luna/mememu.cpp
+++ b/src/script/luna/mememu.cpp
@@ -1329,11 +1329,14 @@ public:
         insert(0x00000140, &Player_t::Immune);
         insert(0x00000142, &Player_t::Immune2);
         insert(0x00000144, &Player_t::ForceHitSpot3);
-        insert(0x00000146, &Player_t::Pinched1);
-        insert(0x00000148, &Player_t::Pinched2);
-        insert(0x0000014a, &Player_t::Pinched3);
-        insert(0x0000014c, &Player_t::Pinched4);
-        insert(0x0000014e, &Player_t::NPCPinched);
+
+        // handlers below
+        // insert(0x00000146, &Player_t::Pinched1);
+        // insert(0x00000148, &Player_t::Pinched2);
+        // insert(0x0000014a, &Player_t::Pinched3);
+        // insert(0x0000014c, &Player_t::Pinched4);
+        // insert(0x0000014e, &Player_t::NPCPinched);
+
         insert(0x00000150, &Player_t::m2Speed);
         insert(0x00000154, &Player_t::HoldingNPC);
         insert(0x00000156, &Player_t::CanGrabNPCs);
@@ -1365,6 +1368,25 @@ public:
             return s_locMem.getValue(&obj->Location, address - 0xC0, ftype);
         else if(address >= 0xF2 && address < 0x106) // Controls
             return s_conMem.getValue(&obj->Controls, address - 0xF2, ftype);
+        else if(address >= 0x146 && address < 0x150) // Pinched
+        {
+            switch(address)
+            {
+            case 0x146: // Pinched1
+                return valueToMem((int)obj->Pinched.Bottom1, ftype);
+            case 0x148: // Pinched2
+                return valueToMem((int)obj->Pinched.Left2, ftype);
+            case 0x14a: // Pinched3
+                return valueToMem((int)obj->Pinched.Top3, ftype);
+            case 0x14c: // Pinched4
+                return valueToMem((int)obj->Pinched.Right4, ftype);
+            case 0x14e: // NPCPinched
+                return valueToMem((int)obj->Pinched.Moving, ftype);
+            default:
+                // use default handler
+                break;
+            }
+        }
         return PlayerParent::getValue(obj, address, ftype);
     }
 
@@ -1384,6 +1406,44 @@ public:
         {
             s_conMem.setValue(&obj->Controls, address - 0xF2, value, ftype);
             return;
+        }
+        else if(address >= 0x146 && address < 0x150) // Pinched
+        {
+            int in;
+
+            memToValue(in, value, ftype);
+
+            // clamp to range
+            if(in < 0)
+                in = 0;
+            else if(in > 3)
+                in = 3;
+
+            switch(address)
+            {
+            case 0x146: // Pinched1
+                obj->Pinched.Bottom1 = in;
+                return;
+            case 0x148: // Pinched2
+                obj->Pinched.Left2 = in;
+                return;
+            case 0x14a: // Pinched3
+                obj->Pinched.Top3 = in;
+                return;
+            case 0x14c: // Pinched4
+                obj->Pinched.Right4 = in;
+                return;
+            case 0x14e: // NPCPinched
+                obj->Pinched.Moving = in;
+
+                obj->Pinched.MovingLR = (bool)in;
+                obj->Pinched.MovingUD = (bool)in;
+
+                return;
+            default:
+                // use default handler
+                break;
+            }
         }
 
         PlayerParent::setValue(obj, address, value, ftype);
@@ -1409,11 +1469,14 @@ public:
         insert(0x00000004, &NPC_t::Quicksand);
         insert(0x00000006, &NPC_t::RespawnDelay);
         insert(0x00000008, &NPC_t::Bouce);
-        insert(0x0000000a, &NPC_t::Pinched1);
-        insert(0x0000000c, &NPC_t::Pinched2);
-        insert(0x0000000e, &NPC_t::Pinched3);
-        insert(0x00000010, &NPC_t::Pinched4);
-        insert(0x00000012, &NPC_t::MovingPinched);
+
+        // handler below
+        // insert(0x0000000a, &NPC_t::Pinched1);
+        // insert(0x0000000c, &NPC_t::Pinched2);
+        // insert(0x0000000e, &NPC_t::Pinched3);
+        // insert(0x00000010, &NPC_t::Pinched4);
+        // insert(0x00000012, &NPC_t::MovingPinched);
+
         // insert(0x00000014, &NPC_t::NetTimeout); // unused since SMBX64, now removed
         insert(0x00000018, &NPC_t::RealSpeedX);
         insert(0x0000001c, &NPC_t::Wet);
@@ -1499,7 +1562,25 @@ public:
             return obj->Reset[1] ? 0xFFFF : 0;
         else if(address == 0x128)
             return obj->Reset[2] ? 0xFFFF : 0;
-
+        else if(address >= 0x0A && address < 0x14) // Pinched
+        {
+            switch(address)
+            {
+            case 0x0A: // Pinched1
+                return valueToMem((int)obj->Pinched.Bottom1, ftype);
+            case 0x0C: // Pinched2
+                return valueToMem((int)obj->Pinched.Left2, ftype);
+            case 0x0E: // Pinched3
+                return valueToMem((int)obj->Pinched.Top3, ftype);
+            case 0x10: // Pinched4
+                return valueToMem((int)obj->Pinched.Right4, ftype);
+            case 0x12: // MovingPinched
+                return valueToMem((int)obj->Pinched.Moving, ftype);
+            default:
+                // use default handler
+                break;
+            }
+        }
         return NpcParent::getValue(obj, address, ftype);
     }
 
@@ -1523,6 +1604,40 @@ public:
         else if(address == 0x128)
         {
             obj->Reset[2] = value != 0;
+        }
+        else if(address >= 0x0A && address < 0x14) // Pinched
+        {
+            int in;
+
+            memToValue(in, value, ftype);
+
+            // clamp to range
+            if(in < 0)
+                in = 0;
+            else if(in > 3)
+                in = 3;
+
+            switch(address)
+            {
+            case 0x0A: // Pinched1
+                obj->Pinched.Bottom1 = in;
+                return;
+            case 0x0C: // Pinched2
+                obj->Pinched.Left2 = in;
+                return;
+            case 0x0E: // Pinched3
+                obj->Pinched.Top3 = in;
+                return;
+            case 0x10: // Pinched4
+                obj->Pinched.Right4 = in;
+                return;
+            case 0x12: // MovingPinched
+                obj->Pinched.Moving = in;
+                return;
+            default:
+                // use default handler
+                break;
+            }
         }
 
         NpcParent::setValue(obj, address, value, ftype);

--- a/src/script/luna/mememu.cpp
+++ b/src/script/luna/mememu.cpp
@@ -1383,7 +1383,7 @@ public:
             case 0x14e: // NPCPinched
                 return valueToMem((int)obj->Pinched.Moving, ftype);
             default:
-                // use default handler
+                pLogWarning("MemEmu: Attempt to read player address 0x%x (invalid byte hacking)", address);
                 break;
             }
         }
@@ -1441,7 +1441,7 @@ public:
 
                 return;
             default:
-                // use default handler
+                pLogWarning("MemEmu: Attempt to set player address 0x%x to %d (invalid byte hacking)", address, in);
                 break;
             }
         }
@@ -1577,7 +1577,7 @@ public:
             case 0x12: // MovingPinched
                 return valueToMem((int)obj->Pinched.Moving, ftype);
             default:
-                // use default handler
+                pLogWarning("MemEmu: Attempt to read NPC address 0x%x (invalid byte hacking)", address);
                 break;
             }
         }
@@ -1635,8 +1635,8 @@ public:
                 obj->Pinched.Moving = in;
                 return;
             default:
-                // use default handler
-                break;
+                pLogWarning("MemEmu: Attempt to set NPC address 0x%x to %d (invalid byte hacking)", address, in);
+                return;
             }
         }
 


### PR DESCRIPTION
Developer-facing changes:
- Multiple Pinched values (5 integers) replaced with a single bitfield (`PinchedInfo_t`), with full mememu support. Saves ~100kb of RAM and makes NPCs more cache-friendly. Small CPU expense, but the pinched info isn't accessed in hot loops.

User-facing changes:
- Fixed vanilla bug where player could be prematurely crushed by a sloped ceiling
<img src="https://user-images.githubusercontent.com/72112344/216461071-f40fff72-b0a2-4f6e-ad06-f6b297201b8c.gif" width="400" height="300"> <img src="https://user-images.githubusercontent.com/72112344/216461077-600de83e-90b2-45fa-8362-40aac250e367.gif" width="400" height="300">

- Fixed vanilla bug where player could be crushed by a horizontally (not vertically) moving ceiling (these examples are from the same gameplay recording script, in which the Mode 3 player dies and the Mode 1 player survives)
<img src="https://user-images.githubusercontent.com/72112344/216462207-b1b8d488-ba34-40f3-985b-6085c8cf51d7.gif" width="400" height="300"> <img src="https://user-images.githubusercontent.com/72112344/216462199-705315a1-b7ce-4b97-ad61-5ddad368f1d9.gif" width="400" height="300">

I'd like to include this in 1.3.6.1, but, we should probably make a gameplay feature freeze soon because the main branch now includes the 1.3.7 performance updates.

[pinch-tests.zip](https://github.com/Wohlstand/TheXTech/files/10574388/pinch-tests.zip)