### PR TITLE
Add new speedless location type

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -37,6 +37,51 @@ bool CheckCollision(const Location_t &Loc1, const Location_t &Loc2)
     return false;
 }
 
+bool CheckCollision(const SpeedlessLocation_t &Loc1, const Location_t &Loc2)
+{
+    if(
+        (Loc1.Y + Loc1.Height >= Loc2.Y) &&
+        (Loc1.Y <= Loc2.Y + Loc2.Height) &&
+        (Loc1.X <= Loc2.X + Loc2.Width) &&
+        (Loc1.X + Loc1.Width >= Loc2.X)
+    )
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool CheckCollision(const Location_t &Loc1, const SpeedlessLocation_t &Loc2)
+{
+    if(
+        (Loc1.Y + Loc1.Height >= Loc2.Y) &&
+        (Loc1.Y <= Loc2.Y + Loc2.Height) &&
+        (Loc1.X <= Loc2.X + Loc2.Width) &&
+        (Loc1.X + Loc1.Width >= Loc2.X)
+    )
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool CheckCollision(const SpeedlessLocation_t &Loc1, const SpeedlessLocation_t &Loc2)
+{
+    if(
+        (Loc1.Y + Loc1.Height >= Loc2.Y) &&
+        (Loc1.Y <= Loc2.Y + Loc2.Height) &&
+        (Loc1.X <= Loc2.X + Loc2.Width) &&
+        (Loc1.X + Loc1.Width >= Loc2.X)
+    )
+    {
+        return true;
+    }
+
+    return false;
+}
+
 // Intersect collisions
 bool CheckCollisionIntersect(const Location_t &Loc1, const Location_t &Loc2)
 {
@@ -119,7 +164,7 @@ bool NPCStartCollision(const Location_t &Loc1, const Location_t &Loc2)
 }
 
 // Warp point collisions
-bool WarpCollision(const Location_t &Loc1, const Location_t &entrance, int direction)
+bool WarpCollision(const Location_t &Loc1, const SpeedlessLocation_t &entrance, int direction)
 {
     bool hasCollision = false;
 
@@ -397,6 +442,26 @@ bool CursorCollision(const Location_t &Loc1, const Location_t &Loc2)
 
     return tempCursorCollision;
 }
+bool CursorCollision(const Location_t &Loc1, const SpeedlessLocation_t &Loc2)
+{
+    bool tempCursorCollision = false;
+
+    if(Loc1.X <= Loc2.X + Loc2.Width - 1)
+    {
+        if(Loc1.X + Loc1.Width >= Loc2.X + 1)
+        {
+            if(Loc1.Y <= Loc2.Y + Loc2.Height - 1)
+            {
+                if(Loc1.Y + Loc1.Height >= Loc2.Y + 1)
+                {
+                    tempCursorCollision = true;
+                }
+            }
+        }
+    }
+
+    return tempCursorCollision;
+}
 
 // Shakey block collision
 bool ShakeCollision(const Location_t &Loc1, const Location_t &Loc2, int ShakeY3)
@@ -447,8 +512,55 @@ bool vScreenCollision(int A, const Location_t &Loc2)
 
 }
 
+bool vScreenCollision(int A, const SpeedlessLocation_t &Loc2)
+{
+    bool tempvScreenCollision = false;
+
+    if(A == 0)
+    {
+        return true;
+    }
+    if(-vScreenX[A] <= Loc2.X + Loc2.Width)
+    {
+        if(-vScreenX[A] + vScreen[A].Width >= Loc2.X)
+        {
+            if(-vScreenY[A] <= Loc2.Y + Loc2.Height)
+            {
+                if(-vScreenY[A] + vScreen[A].Height >= Loc2.Y)
+                {
+                    tempvScreenCollision = true;
+                }
+            }
+        }
+    }
+
+    return tempvScreenCollision;
+
+}
+
 // vScreen collisions 2
 bool vScreenCollision2(int A, const Location_t &Loc2)
+{
+    bool tempvScreenCollision2 = false;
+
+    if(-vScreenX[A] + 64 <= Loc2.X + Loc2.Width)
+    {
+        if(-vScreenX[A] + vScreen[A].Width - 64 >= Loc2.X)
+        {
+            if(-vScreenY[A] + 96 <= Loc2.Y + Loc2.Height)
+            {
+                if(-vScreenY[A] + vScreen[A].Height - 64 >= Loc2.Y)
+                {
+                    tempvScreenCollision2 = true;
+                }
+            }
+        }
+    }
+
+    return tempvScreenCollision2;
+}
+
+bool vScreenCollision2(int A, const SpeedlessLocation_t &Loc2)
 {
     bool tempvScreenCollision2 = false;
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -24,62 +24,34 @@
 // 'Normal collisions
 bool CheckCollision(const Location_t &Loc1, const Location_t &Loc2)
 {
-    if(
-        (Loc1.Y + Loc1.Height >= Loc2.Y) &&
-        (Loc1.Y <= Loc2.Y + Loc2.Height) &&
-        (Loc1.X <= Loc2.X + Loc2.Width) &&
-        (Loc1.X + Loc1.Width >= Loc2.X)
-    )
-    {
-        return true;
-    }
-
-    return false;
+    return (Loc1.Y + Loc1.Height >= Loc2.Y) &&
+           (Loc1.Y <= Loc2.Y + Loc2.Height) &&
+           (Loc1.X <= Loc2.X + Loc2.Width) &&
+           (Loc1.X + Loc1.Width >= Loc2.X);
 }
 
 bool CheckCollision(const SpeedlessLocation_t &Loc1, const Location_t &Loc2)
 {
-    if(
-        (Loc1.Y + Loc1.Height >= Loc2.Y) &&
-        (Loc1.Y <= Loc2.Y + Loc2.Height) &&
-        (Loc1.X <= Loc2.X + Loc2.Width) &&
-        (Loc1.X + Loc1.Width >= Loc2.X)
-    )
-    {
-        return true;
-    }
-
-    return false;
+    return (Loc1.Y + Loc1.Height >= Loc2.Y) &&
+           (Loc1.Y <= Loc2.Y + Loc2.Height) &&
+           (Loc1.X <= Loc2.X + Loc2.Width) &&
+           (Loc1.X + Loc1.Width >= Loc2.X);
 }
 
 bool CheckCollision(const Location_t &Loc1, const SpeedlessLocation_t &Loc2)
 {
-    if(
-        (Loc1.Y + Loc1.Height >= Loc2.Y) &&
-        (Loc1.Y <= Loc2.Y + Loc2.Height) &&
-        (Loc1.X <= Loc2.X + Loc2.Width) &&
-        (Loc1.X + Loc1.Width >= Loc2.X)
-    )
-    {
-        return true;
-    }
-
-    return false;
+    return (Loc1.Y + Loc1.Height >= Loc2.Y) &&
+           (Loc1.Y <= Loc2.Y + Loc2.Height) &&
+           (Loc1.X <= Loc2.X + Loc2.Width) &&
+           (Loc1.X + Loc1.Width >= Loc2.X);
 }
 
 bool CheckCollision(const SpeedlessLocation_t &Loc1, const SpeedlessLocation_t &Loc2)
 {
-    if(
-        (Loc1.Y + Loc1.Height >= Loc2.Y) &&
-        (Loc1.Y <= Loc2.Y + Loc2.Height) &&
-        (Loc1.X <= Loc2.X + Loc2.Width) &&
-        (Loc1.X + Loc1.Width >= Loc2.X)
-    )
-    {
-        return true;
-    }
-
-    return false;
+    return (Loc1.Y + Loc1.Height >= Loc2.Y) &&
+           (Loc1.Y <= Loc2.Y + Loc2.Height) &&
+           (Loc1.X <= Loc2.X + Loc2.Width) &&
+           (Loc1.X + Loc1.Width >= Loc2.X);
 }
 
 // Intersect collisions
@@ -424,43 +396,17 @@ int BootCollision(const Location_t &Loc1, const Location_t &Loc2, bool StandOn)
 // Cursor collision
 bool CursorCollision(const Location_t &Loc1, const Location_t &Loc2)
 {
-    bool tempCursorCollision = false;
-
-    if(Loc1.X <= Loc2.X + Loc2.Width - 1)
-    {
-        if(Loc1.X + Loc1.Width >= Loc2.X + 1)
-        {
-            if(Loc1.Y <= Loc2.Y + Loc2.Height - 1)
-            {
-                if(Loc1.Y + Loc1.Height >= Loc2.Y + 1)
-                {
-                    tempCursorCollision = true;
-                }
-            }
-        }
-    }
-
-    return tempCursorCollision;
+    return (Loc1.X <= Loc2.X + Loc2.Width - 1) &&
+           (Loc1.X + Loc1.Width >= Loc2.X + 1) &&
+           (Loc1.Y <= Loc2.Y + Loc2.Height - 1) &&
+           (Loc1.Y + Loc1.Height >= Loc2.Y + 1);
 }
 bool CursorCollision(const Location_t &Loc1, const SpeedlessLocation_t &Loc2)
 {
-    bool tempCursorCollision = false;
-
-    if(Loc1.X <= Loc2.X + Loc2.Width - 1)
-    {
-        if(Loc1.X + Loc1.Width >= Loc2.X + 1)
-        {
-            if(Loc1.Y <= Loc2.Y + Loc2.Height - 1)
-            {
-                if(Loc1.Y + Loc1.Height >= Loc2.Y + 1)
-                {
-                    tempCursorCollision = true;
-                }
-            }
-        }
-    }
-
-    return tempCursorCollision;
+    return (Loc1.X <= Loc2.X + Loc2.Width - 1) &&
+           (Loc1.X + Loc1.Width >= Loc2.X + 1) &&
+           (Loc1.Y <= Loc2.Y + Loc2.Height - 1) &&
+           (Loc1.Y + Loc1.Height >= Loc2.Y + 1);
 }
 
 // Shakey block collision
@@ -488,97 +434,41 @@ bool ShakeCollision(const Location_t &Loc1, const Location_t &Loc2, int ShakeY3)
 // vScreen collisions
 bool vScreenCollision(int A, const Location_t &Loc2)
 {
-    bool tempvScreenCollision = false;
-
     if(A == 0)
-    {
         return true;
-    }
-    if(-vScreenX[A] <= Loc2.X + Loc2.Width)
-    {
-        if(-vScreenX[A] + vScreen[A].Width >= Loc2.X)
-        {
-            if(-vScreenY[A] <= Loc2.Y + Loc2.Height)
-            {
-                if(-vScreenY[A] + vScreen[A].Height >= Loc2.Y)
-                {
-                    tempvScreenCollision = true;
-                }
-            }
-        }
-    }
 
-    return tempvScreenCollision;
-
+    return (-vScreenX[A] <= Loc2.X + Loc2.Width) &&
+           (-vScreenX[A] + vScreen[A].Width >= Loc2.X) &&
+           (-vScreenY[A] <= Loc2.Y + Loc2.Height) &&
+           (-vScreenY[A] + vScreen[A].Height >= Loc2.Y);
 }
 
 bool vScreenCollision(int A, const SpeedlessLocation_t &Loc2)
 {
-    bool tempvScreenCollision = false;
-
     if(A == 0)
-    {
         return true;
-    }
-    if(-vScreenX[A] <= Loc2.X + Loc2.Width)
-    {
-        if(-vScreenX[A] + vScreen[A].Width >= Loc2.X)
-        {
-            if(-vScreenY[A] <= Loc2.Y + Loc2.Height)
-            {
-                if(-vScreenY[A] + vScreen[A].Height >= Loc2.Y)
-                {
-                    tempvScreenCollision = true;
-                }
-            }
-        }
-    }
 
-    return tempvScreenCollision;
-
+    return (-vScreenX[A] <= Loc2.X + Loc2.Width) &&
+           (-vScreenX[A] + vScreen[A].Width >= Loc2.X) &&
+           (-vScreenY[A] <= Loc2.Y + Loc2.Height) &&
+           (-vScreenY[A] + vScreen[A].Height >= Loc2.Y);
 }
 
 // vScreen collisions 2
 bool vScreenCollision2(int A, const Location_t &Loc2)
 {
-    bool tempvScreenCollision2 = false;
-
-    if(-vScreenX[A] + 64 <= Loc2.X + Loc2.Width)
-    {
-        if(-vScreenX[A] + vScreen[A].Width - 64 >= Loc2.X)
-        {
-            if(-vScreenY[A] + 96 <= Loc2.Y + Loc2.Height)
-            {
-                if(-vScreenY[A] + vScreen[A].Height - 64 >= Loc2.Y)
-                {
-                    tempvScreenCollision2 = true;
-                }
-            }
-        }
-    }
-
-    return tempvScreenCollision2;
+    return (-vScreenX[A] + 64 <= Loc2.X + Loc2.Width) &&
+           (-vScreenX[A] + vScreen[A].Width - 64 >= Loc2.X) &&
+           (-vScreenY[A] + 96 <= Loc2.Y + Loc2.Height) &&
+           (-vScreenY[A] + vScreen[A].Height - 64 >= Loc2.Y);
 }
 
 bool vScreenCollision2(int A, const SpeedlessLocation_t &Loc2)
 {
-    bool tempvScreenCollision2 = false;
-
-    if(-vScreenX[A] + 64 <= Loc2.X + Loc2.Width)
-    {
-        if(-vScreenX[A] + vScreen[A].Width - 64 >= Loc2.X)
-        {
-            if(-vScreenY[A] + 96 <= Loc2.Y + Loc2.Height)
-            {
-                if(-vScreenY[A] + vScreen[A].Height - 64 >= Loc2.Y)
-                {
-                    tempvScreenCollision2 = true;
-                }
-            }
-        }
-    }
-
-    return tempvScreenCollision2;
+    return (-vScreenX[A] + 64 <= Loc2.X + Loc2.Width) &&
+           (-vScreenX[A] + vScreen[A].Width - 64 >= Loc2.X) &&
+           (-vScreenY[A] + 96 <= Loc2.Y + Loc2.Height) &&
+           (-vScreenY[A] + vScreen[A].Height - 64 >= Loc2.Y);
 }
 
 // Collision detection for blocks. Prevents walking on walls.

--- a/src/collision.h
+++ b/src/collision.h
@@ -39,6 +39,9 @@ enum CollisionSpot
 // Public Function CheckCollision(Loc1 As Location, Loc2 As Location) As Boolean 'Normal collisions
 // Normal collisions
 bool CheckCollision(const Location_t &Loc1, const Location_t &Loc2);
+bool CheckCollision(const SpeedlessLocation_t &Loc1, const Location_t &Loc2);
+bool CheckCollision(const Location_t &Loc1, const SpeedlessLocation_t &Loc2);
+bool CheckCollision(const SpeedlessLocation_t &Loc1, const SpeedlessLocation_t &Loc2);
 // Intersect collision
 bool CheckCollisionIntersect(const Location_t &Loc1, const Location_t &Loc2);
 // Public Function n00bCollision(Loc1 As Location, Loc2 As Location) As Boolean 'Make the game easier for the people who whine about the detection being 'off'
@@ -49,7 +52,7 @@ bool n00bCollision(const Location_t &Loc1, const Location_t &Loc2);
 bool NPCStartCollision(const Location_t &Loc1, const Location_t &Loc2);
 // Public Function WarpCollision(Loc1 As Location, A As Integer) As Boolean  'Warp point collisions
 // Warp point collisions
-bool WarpCollision(const Location_t &Loc1, const Location_t &entrance, int direction);
+bool WarpCollision(const Location_t &Loc1, const SpeedlessLocation_t &entrance, int direction);
 // Public Function FindCollision(Loc1 As Location, Loc2 As Location) As Integer 'Whats side the collision happened
 // Whats side the collision happened
 int FindCollision(const Location_t &Loc1, const Location_t &Loc2);
@@ -68,15 +71,18 @@ int BootCollision(const Location_t &Loc1, const Location_t &Loc2, bool StandOn);
 // Public Function CursorCollision(Loc1 As Location, Loc2 As Location) As Boolean 'Cursor collision
 // Cursor collision
 bool CursorCollision(const Location_t &Loc1, const Location_t &Loc2);
+bool CursorCollision(const Location_t &Loc1, const SpeedlessLocation_t &Loc2);
 // Public Function ShakeCollision(Loc1 As Location, Loc2 As Location, ShakeY3 As Integer) As Boolean 'Shakey block collision
 // Shakey block collision
 bool ShakeCollision(const Location_t &Loc1, const Location_t &Loc2, int ShakeY3);
 // Public Function vScreenCollision(A As Integer, Loc2 As Location) As Boolean  'vScreen collisions
 // vScreen collisions
 bool vScreenCollision(int A, const Location_t &Loc2);
+bool vScreenCollision(int A, const SpeedlessLocation_t &Loc2);
 // Public Function vScreenCollision2(A As Integer, Loc2 As Location) As Boolean  'vScreen collisions 2
 // vScreen collisions 2
 bool vScreenCollision2(int A, const Location_t &Loc2);
+bool vScreenCollision2(int A, const SpeedlessLocation_t &Loc2);
 // Public Function WalkingCollision(Loc1 As Location, Loc2 As Location) As Boolean 'Collision detection for blocks. Prevents walking on walls.
 // Collision detection for blocks. Prevents walking on walls.
 bool WalkingCollision(const Location_t &Loc1, const Location_t &Loc2);

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -725,7 +725,7 @@ void UpdateEditor()
                             optCursor.current = OptCursor_t::LVL_WATER;
                             OptCursorSync();
                             EditorCursor.Mode = OptCursor_t::LVL_WATER;
-                            EditorCursor.Location = Water[A].Location;
+                            EditorCursor.Location = (Location_t)Water[A].Location;
                             EditorCursor.Layer = Water[A].Layer;
                             EditorCursor.Water = Water[A];
                             Water[A] = Water[numWater];
@@ -749,7 +749,7 @@ void UpdateEditor()
                             optCursor.current = OptCursor_t::WLD_MUSIC;
                             OptCursorSync();
                             EditorCursor.Mode = OptCursor_t::WLD_MUSIC;
-                            EditorCursor.Location = WorldMusic[A].Location;
+                            EditorCursor.Location = (Location_t)WorldMusic[A].Location;
                             SetCursor();
 //                            frmMusic::optMusic(WorldMusic[A].Type).Value = true;
                             EditorCursor.WorldMusic = WorldMusic[A];
@@ -779,7 +779,7 @@ void UpdateEditor()
                             OptCursorSync();
 //                            frmPaths::WorldPath(WorldPath[A].Type).Value = true;
                             EditorCursor.Mode = OptCursor_t::WLD_PATHS;
-                            EditorCursor.Location = WorldPath[A].Location;
+                            EditorCursor.Location = (Location_t)WorldPath[A].Location;
                             EditorCursor.WorldPath = WorldPath[A];
                             SetCursor();
                             if(A != numWorldPaths)
@@ -816,7 +816,7 @@ void UpdateEditor()
                             OptCursorSync();
 //                            frmScene::Scene(Scene[A].Type).Value = true;
                             EditorCursor.Mode = OptCursor_t::WLD_SCENES;
-                            EditorCursor.Location = Scene[A].Location;
+                            EditorCursor.Location = (Location_t)Scene[A].Location;
                             EditorCursor.Scene = Scene[A];
                             SetCursor();
                             MouseMove(EditorCursor.X, EditorCursor.Y);
@@ -846,7 +846,7 @@ void UpdateEditor()
                             optCursor.current = OptCursor_t::WLD_LEVELS;
                             OptCursorSync();
                             EditorCursor.Mode = OptCursor_t::WLD_LEVELS;
-                            EditorCursor.Location = WorldLevel[A].Location;
+                            EditorCursor.Location = (Location_t)WorldLevel[A].Location;
                             EditorCursor.WorldLevel = WorldLevel[A];
                             SetCursor();
                             if(A != numWorldLevels)
@@ -873,11 +873,11 @@ void UpdateEditor()
                             optCursor.current = OptCursor_t::WLD_TILES;
                             OptCursorSync();
                             EditorCursor.Mode = OptCursor_t::WLD_TILES;
-                            EditorCursor.Location = Tile[A].Location;
+                            EditorCursor.Location = (Location_t)Tile[A].Location;
                             EditorCursor.Tile = Tile[A];
                             SetCursor();
 
-                            Location_t loc = Tile[A].Location;
+                            Location_t loc = (Location_t)Tile[A].Location;
                             int type = Tile[A].Type;
 
                             if(A != numTiles)
@@ -992,7 +992,7 @@ void UpdateEditor()
                 {
                     for(A = 1; A <= numWarps; A++)
                     {
-                        tempLocation = Warp[A].Entrance;
+                        tempLocation = (Location_t)Warp[A].Entrance;
                         tempLocation.Height = 32;
                         tempLocation.Width = 32;
                         if(CursorCollision(EditorCursor.Location, tempLocation))
@@ -1005,7 +1005,7 @@ void UpdateEditor()
                                 EditorCursor.SubMode = OptCursor_t::LVL_WARPS;
                             break;
                         }
-                        tempLocation = Warp[A].Exit;
+                        tempLocation = (Location_t)Warp[A].Exit;
                         tempLocation.Height = 32;
                         tempLocation.Width = 32;
                         if(CursorCollision(EditorCursor.Location, tempLocation))
@@ -1092,7 +1092,7 @@ void UpdateEditor()
                 {
                     for(int numWaterMax = numWater, A = 1; A <= numWaterMax; A++)
                     {
-                        tempLocation = Water[A].Location;
+                        tempLocation = (Location_t)Water[A].Location;
                         if(CursorCollision(EditorCursor.Location, tempLocation) && !Water[A].Hidden)
                         {
                             PlaySound(SFX_Smash);
@@ -1119,7 +1119,7 @@ void UpdateEditor()
                     {
                         if(CursorCollision(EditorCursor.Location, WorldMusic[A].Location))
                         {
-                            tempLocation = WorldMusic[A].Location;
+                            tempLocation = (Location_t)WorldMusic[A].Location;
                             tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
                             tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
@@ -1148,7 +1148,7 @@ void UpdateEditor()
 
                         if(CursorCollision(EditorCursor.Location, WorldPath[A].Location))
                         {
-                            tempLocation = WorldPath[A].Location;
+                            tempLocation = (Location_t)WorldPath[A].Location;
                             tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
                             tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
@@ -1181,7 +1181,7 @@ void UpdateEditor()
                         A = (*i - &Scene[1]) + 1;
                         if(CursorCollision(EditorCursor.Location, Scene[A].Location))
                         {
-                            tempLocation = Scene[A].Location;
+                            tempLocation = (Location_t)Scene[A].Location;
                             tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
                             tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
@@ -1209,7 +1209,7 @@ void UpdateEditor()
                     {
                         if(CursorCollision(EditorCursor.Location, WorldLevel[A].Location))
                         {
-                            tempLocation = WorldLevel[A].Location;
+                            tempLocation = (Location_t)WorldLevel[A].Location;
                             tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
                             tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
@@ -1237,13 +1237,13 @@ void UpdateEditor()
                     {
                         if(CursorCollision(EditorCursor.Location, Tile[A].Location))
                         {
-                            tempLocation = Tile[A].Location;
+                            tempLocation = (Location_t)Tile[A].Location;
                             tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
                             tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
                             PlaySound(SFX_ShellHit);
 
-                            Location_t loc = Tile[A].Location;
+                            Location_t loc = (Location_t)Tile[A].Location;
                             int type = Tile[A].Type;
 
                             if(A != numTiles)
@@ -1585,14 +1585,14 @@ void UpdateEditor()
 
                 if(EditorCursor.SubMode == 1 || EditorCursor.Warp.level != STRINGINDEX_NONE || EditorCursor.Warp.LevelEnt || EditorCursor.Warp.MapWarp)
                 {
-                    EditorCursor.Warp.Entrance = EditorCursor.Location;
+                    EditorCursor.Warp.Entrance = (SpeedlessLocation_t)EditorCursor.Location;
                     MouseCancel = true;
                     MouseRelease = false;
                     EditorCursor.Warp.PlacedEnt = true;
                 }
                 if(EditorCursor.SubMode == 2 || EditorCursor.Warp.level != STRINGINDEX_NONE || EditorCursor.Warp.LevelEnt || EditorCursor.Warp.MapWarp)
                 {
-                    EditorCursor.Warp.Exit = EditorCursor.Location;
+                    EditorCursor.Warp.Exit = (SpeedlessLocation_t)EditorCursor.Location;
                     MouseCancel = true;
                     MouseRelease = false;
                     EditorCursor.Warp.PlacedExit = true;
@@ -1641,7 +1641,7 @@ void UpdateEditor()
                         }
                         else
                         {
-                            Location_t loc = Tile[A].Location;
+                            Location_t loc = (Location_t)Tile[A].Location;
                             int type = Tile[A].Type;
 
                             if(A != numTiles)
@@ -1802,7 +1802,7 @@ void UpdateEditor()
 
                 if(CanPlace)
                 {
-                    EditorCursor.WorldMusic.Location = EditorCursor.Location;
+                    EditorCursor.WorldMusic.Location = (SpeedlessLocation_t)EditorCursor.Location;
                     numWorldMusic++;
                     WorldMusic[numWorldMusic] = EditorCursor.WorldMusic;
                     // de-duplicate music file
@@ -2569,7 +2569,7 @@ void SetCursor()
             EditorCursor.Tile.Type = 1;
         EditorCursor.Location.Width = TileWidth[EditorCursor.Tile.Type];
         EditorCursor.Location.Height = TileHeight[EditorCursor.Tile.Type];
-        EditorCursor.Tile.Location = EditorCursor.Location;
+        EditorCursor.Tile.Location = (SpeedlessLocation_t)EditorCursor.Location;
     }
     else if(EditorCursor.Mode == 8) // Scene
     {
@@ -2588,7 +2588,7 @@ void SetCursor()
             EditorCursor.Scene.Type = 1;
         EditorCursor.Location.Width = SceneWidth[EditorCursor.Scene.Type];
         EditorCursor.Location.Height = SceneHeight[EditorCursor.Scene.Type];
-        EditorCursor.Scene.Location = EditorCursor.Location;
+        EditorCursor.Scene.Location = (SpeedlessLocation_t)EditorCursor.Location;
     }
     else if(EditorCursor.Mode == 9) // Levels
     {
@@ -2605,7 +2605,7 @@ void SetCursor()
             EditorCursor.WorldLevel.Type = 1;
         EditorCursor.Location.Width = 32;
         EditorCursor.Location.Height = 32;
-        EditorCursor.WorldLevel.Location = EditorCursor.Location;
+        EditorCursor.WorldLevel.Location = (SpeedlessLocation_t)EditorCursor.Location;
 //        EditorCursor.WorldLevel.FileName = frmLevels::txtFilename.Text;
 //        if(EditorCursor.WorldLevel::FileName != "" && EditorCursor.WorldLevel::FileName.substr(EditorCursor.WorldLevel::FileName.Length - 4) != StringHelper::toLower(".lvl"))
 //            EditorCursor.WorldLevel.FileName = EditorCursor.WorldLevel::FileName + ".lvl";
@@ -2655,13 +2655,13 @@ void SetCursor()
             EditorCursor.WorldPath.Type = 1;
         EditorCursor.Location.Width = 32;
         EditorCursor.Location.Height = 32;
-        EditorCursor.WorldPath.Location = EditorCursor.Location;
+        EditorCursor.WorldPath.Location = (SpeedlessLocation_t)EditorCursor.Location;
     }
     else if(EditorCursor.Mode == OptCursor_t::WLD_MUSIC) // World Music
     {
         EditorCursor.Location.Height = 32;
         EditorCursor.Location.Width = 32;
-        EditorCursor.WorldMusic.Location = EditorCursor.Location;
+        EditorCursor.WorldMusic.Location = (SpeedlessLocation_t)EditorCursor.Location;
         // make it play the music
         if(g_isWorldMusicNotSame(EditorCursor.WorldMusic))
             g_playWorldMusic(EditorCursor.WorldMusic);

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -725,7 +725,7 @@ void UpdateEditor()
                             optCursor.current = OptCursor_t::LVL_WATER;
                             OptCursorSync();
                             EditorCursor.Mode = OptCursor_t::LVL_WATER;
-                            EditorCursor.Location = (Location_t)Water[A].Location;
+                            EditorCursor.Location = static_cast<Location_t>(Water[A].Location);
                             EditorCursor.Layer = Water[A].Layer;
                             EditorCursor.Water = Water[A];
                             Water[A] = Water[numWater];
@@ -749,7 +749,7 @@ void UpdateEditor()
                             optCursor.current = OptCursor_t::WLD_MUSIC;
                             OptCursorSync();
                             EditorCursor.Mode = OptCursor_t::WLD_MUSIC;
-                            EditorCursor.Location = (Location_t)WorldMusic[A].Location;
+                            EditorCursor.Location = static_cast<Location_t>(WorldMusic[A].Location);
                             SetCursor();
 //                            frmMusic::optMusic(WorldMusic[A].Type).Value = true;
                             EditorCursor.WorldMusic = WorldMusic[A];
@@ -779,7 +779,7 @@ void UpdateEditor()
                             OptCursorSync();
 //                            frmPaths::WorldPath(WorldPath[A].Type).Value = true;
                             EditorCursor.Mode = OptCursor_t::WLD_PATHS;
-                            EditorCursor.Location = (Location_t)WorldPath[A].Location;
+                            EditorCursor.Location = static_cast<Location_t>(WorldPath[A].Location);
                             EditorCursor.WorldPath = WorldPath[A];
                             SetCursor();
                             if(A != numWorldPaths)
@@ -816,7 +816,7 @@ void UpdateEditor()
                             OptCursorSync();
 //                            frmScene::Scene(Scene[A].Type).Value = true;
                             EditorCursor.Mode = OptCursor_t::WLD_SCENES;
-                            EditorCursor.Location = (Location_t)Scene[A].Location;
+                            EditorCursor.Location = static_cast<Location_t>(Scene[A].Location);
                             EditorCursor.Scene = Scene[A];
                             SetCursor();
                             MouseMove(EditorCursor.X, EditorCursor.Y);
@@ -846,7 +846,7 @@ void UpdateEditor()
                             optCursor.current = OptCursor_t::WLD_LEVELS;
                             OptCursorSync();
                             EditorCursor.Mode = OptCursor_t::WLD_LEVELS;
-                            EditorCursor.Location = (Location_t)WorldLevel[A].Location;
+                            EditorCursor.Location = static_cast<Location_t>(WorldLevel[A].Location);
                             EditorCursor.WorldLevel = WorldLevel[A];
                             SetCursor();
                             if(A != numWorldLevels)
@@ -873,11 +873,11 @@ void UpdateEditor()
                             optCursor.current = OptCursor_t::WLD_TILES;
                             OptCursorSync();
                             EditorCursor.Mode = OptCursor_t::WLD_TILES;
-                            EditorCursor.Location = (Location_t)Tile[A].Location;
+                            EditorCursor.Location = static_cast<Location_t>(Tile[A].Location);
                             EditorCursor.Tile = Tile[A];
                             SetCursor();
 
-                            Location_t loc = (Location_t)Tile[A].Location;
+                            Location_t loc = static_cast<Location_t>(Tile[A].Location);
                             int type = Tile[A].Type;
 
                             if(A != numTiles)
@@ -992,7 +992,7 @@ void UpdateEditor()
                 {
                     for(A = 1; A <= numWarps; A++)
                     {
-                        tempLocation = (Location_t)Warp[A].Entrance;
+                        tempLocation = static_cast<Location_t>(Warp[A].Entrance);
                         tempLocation.Height = 32;
                         tempLocation.Width = 32;
                         if(CursorCollision(EditorCursor.Location, tempLocation))
@@ -1005,7 +1005,7 @@ void UpdateEditor()
                                 EditorCursor.SubMode = OptCursor_t::LVL_WARPS;
                             break;
                         }
-                        tempLocation = (Location_t)Warp[A].Exit;
+                        tempLocation = static_cast<Location_t>(Warp[A].Exit);
                         tempLocation.Height = 32;
                         tempLocation.Width = 32;
                         if(CursorCollision(EditorCursor.Location, tempLocation))
@@ -1092,7 +1092,7 @@ void UpdateEditor()
                 {
                     for(int numWaterMax = numWater, A = 1; A <= numWaterMax; A++)
                     {
-                        tempLocation = (Location_t)Water[A].Location;
+                        tempLocation = static_cast<Location_t>(Water[A].Location);
                         if(CursorCollision(EditorCursor.Location, tempLocation) && !Water[A].Hidden)
                         {
                             PlaySound(SFX_Smash);
@@ -1119,7 +1119,7 @@ void UpdateEditor()
                     {
                         if(CursorCollision(EditorCursor.Location, WorldMusic[A].Location))
                         {
-                            tempLocation = (Location_t)WorldMusic[A].Location;
+                            tempLocation = static_cast<Location_t>(WorldMusic[A].Location);
                             tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
                             tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
@@ -1148,7 +1148,7 @@ void UpdateEditor()
 
                         if(CursorCollision(EditorCursor.Location, WorldPath[A].Location))
                         {
-                            tempLocation = (Location_t)WorldPath[A].Location;
+                            tempLocation = static_cast<Location_t>(WorldPath[A].Location);
                             tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
                             tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
@@ -1181,7 +1181,7 @@ void UpdateEditor()
                         A = (*i - &Scene[1]) + 1;
                         if(CursorCollision(EditorCursor.Location, Scene[A].Location))
                         {
-                            tempLocation = (Location_t)Scene[A].Location;
+                            tempLocation = static_cast<Location_t>(Scene[A].Location);
                             tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
                             tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
@@ -1209,7 +1209,7 @@ void UpdateEditor()
                     {
                         if(CursorCollision(EditorCursor.Location, WorldLevel[A].Location))
                         {
-                            tempLocation = (Location_t)WorldLevel[A].Location;
+                            tempLocation = static_cast<Location_t>(WorldLevel[A].Location);
                             tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
                             tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
@@ -1237,13 +1237,13 @@ void UpdateEditor()
                     {
                         if(CursorCollision(EditorCursor.Location, Tile[A].Location))
                         {
-                            tempLocation = (Location_t)Tile[A].Location;
+                            tempLocation = static_cast<Location_t>(Tile[A].Location);
                             tempLocation.X += tempLocation.Width / 2.0 - EffectWidth[10] / 2;
                             tempLocation.Y += tempLocation.Height / 2.0 - EffectHeight[10] / 2;
                             NewEffect(10, tempLocation);
                             PlaySound(SFX_ShellHit);
 
-                            Location_t loc = (Location_t)Tile[A].Location;
+                            Location_t loc = static_cast<Location_t>(Tile[A].Location);
                             int type = Tile[A].Type;
 
                             if(A != numTiles)
@@ -1585,14 +1585,14 @@ void UpdateEditor()
 
                 if(EditorCursor.SubMode == 1 || EditorCursor.Warp.level != STRINGINDEX_NONE || EditorCursor.Warp.LevelEnt || EditorCursor.Warp.MapWarp)
                 {
-                    EditorCursor.Warp.Entrance = (SpeedlessLocation_t)EditorCursor.Location;
+                    EditorCursor.Warp.Entrance = static_cast<SpeedlessLocation_t>(EditorCursor.Location);
                     MouseCancel = true;
                     MouseRelease = false;
                     EditorCursor.Warp.PlacedEnt = true;
                 }
                 if(EditorCursor.SubMode == 2 || EditorCursor.Warp.level != STRINGINDEX_NONE || EditorCursor.Warp.LevelEnt || EditorCursor.Warp.MapWarp)
                 {
-                    EditorCursor.Warp.Exit = (SpeedlessLocation_t)EditorCursor.Location;
+                    EditorCursor.Warp.Exit = static_cast<SpeedlessLocation_t>(EditorCursor.Location);
                     MouseCancel = true;
                     MouseRelease = false;
                     EditorCursor.Warp.PlacedExit = true;
@@ -1641,7 +1641,7 @@ void UpdateEditor()
                         }
                         else
                         {
-                            Location_t loc = (Location_t)Tile[A].Location;
+                            Location_t loc = static_cast<Location_t>(Tile[A].Location);
                             int type = Tile[A].Type;
 
                             if(A != numTiles)
@@ -1802,7 +1802,7 @@ void UpdateEditor()
 
                 if(CanPlace)
                 {
-                    EditorCursor.WorldMusic.Location = (SpeedlessLocation_t)EditorCursor.Location;
+                    EditorCursor.WorldMusic.Location = static_cast<SpeedlessLocation_t>(EditorCursor.Location);
                     numWorldMusic++;
                     WorldMusic[numWorldMusic] = EditorCursor.WorldMusic;
                     // de-duplicate music file
@@ -2569,7 +2569,7 @@ void SetCursor()
             EditorCursor.Tile.Type = 1;
         EditorCursor.Location.Width = TileWidth[EditorCursor.Tile.Type];
         EditorCursor.Location.Height = TileHeight[EditorCursor.Tile.Type];
-        EditorCursor.Tile.Location = (SpeedlessLocation_t)EditorCursor.Location;
+        EditorCursor.Tile.Location = static_cast<SpeedlessLocation_t>(EditorCursor.Location);
     }
     else if(EditorCursor.Mode == 8) // Scene
     {
@@ -2588,7 +2588,7 @@ void SetCursor()
             EditorCursor.Scene.Type = 1;
         EditorCursor.Location.Width = SceneWidth[EditorCursor.Scene.Type];
         EditorCursor.Location.Height = SceneHeight[EditorCursor.Scene.Type];
-        EditorCursor.Scene.Location = (SpeedlessLocation_t)EditorCursor.Location;
+        EditorCursor.Scene.Location = static_cast<SpeedlessLocation_t>(EditorCursor.Location);
     }
     else if(EditorCursor.Mode == 9) // Levels
     {
@@ -2605,7 +2605,7 @@ void SetCursor()
             EditorCursor.WorldLevel.Type = 1;
         EditorCursor.Location.Width = 32;
         EditorCursor.Location.Height = 32;
-        EditorCursor.WorldLevel.Location = (SpeedlessLocation_t)EditorCursor.Location;
+        EditorCursor.WorldLevel.Location = static_cast<SpeedlessLocation_t>(EditorCursor.Location);
 //        EditorCursor.WorldLevel.FileName = frmLevels::txtFilename.Text;
 //        if(EditorCursor.WorldLevel::FileName != "" && EditorCursor.WorldLevel::FileName.substr(EditorCursor.WorldLevel::FileName.Length - 4) != StringHelper::toLower(".lvl"))
 //            EditorCursor.WorldLevel.FileName = EditorCursor.WorldLevel::FileName + ".lvl";
@@ -2655,13 +2655,13 @@ void SetCursor()
             EditorCursor.WorldPath.Type = 1;
         EditorCursor.Location.Width = 32;
         EditorCursor.Location.Height = 32;
-        EditorCursor.WorldPath.Location = (SpeedlessLocation_t)EditorCursor.Location;
+        EditorCursor.WorldPath.Location = static_cast<SpeedlessLocation_t>(EditorCursor.Location);
     }
     else if(EditorCursor.Mode == OptCursor_t::WLD_MUSIC) // World Music
     {
         EditorCursor.Location.Height = 32;
         EditorCursor.Location.Width = 32;
-        EditorCursor.WorldMusic.Location = (SpeedlessLocation_t)EditorCursor.Location;
+        EditorCursor.WorldMusic.Location = static_cast<SpeedlessLocation_t>(EditorCursor.Location);
         // make it play the music
         if(g_isWorldMusicNotSame(EditorCursor.WorldMusic))
             g_playWorldMusic(EditorCursor.WorldMusic);

--- a/src/editor/magic_block.cpp
+++ b/src/editor/magic_block.cpp
@@ -256,7 +256,7 @@ int s_pick_type(ItemFamily& family, ItemRef_t A)
         }
     }
 
-    Location_t tempLoc = (Location_t)A->Location;
+    Location_t tempLoc = static_cast<Location_t>(A->Location);
 
     // 7 (top-left)
     tempLoc.X -= 31;
@@ -650,7 +650,7 @@ void MagicItem(ItemRef_t A)
     }
 
     // first, transform all nearby blocks, then transform the block itself
-    Location_t tempLoc = (Location_t)A->Location;
+    Location_t tempLoc = static_cast<Location_t>(A->Location);
     tempLoc.X -= 31;
     tempLoc.Y -= 31;
     tempLoc.Width += 62;

--- a/src/editor/magic_block.cpp
+++ b/src/editor/magic_block.cpp
@@ -256,7 +256,7 @@ int s_pick_type(ItemFamily& family, ItemRef_t A)
         }
     }
 
-    Location_t tempLoc = A->Location;
+    Location_t tempLoc = (Location_t)A->Location;
 
     // 7 (top-left)
     tempLoc.X -= 31;
@@ -650,7 +650,7 @@ void MagicItem(ItemRef_t A)
     }
 
     // first, transform all nearby blocks, then transform the block itself
-    Location_t tempLoc = A->Location;
+    Location_t tempLoc = (Location_t)A->Location;
     tempLoc.X -= 31;
     tempLoc.Y -= 31;
     tempLoc.Width += 62;

--- a/src/editor/new_editor.cpp
+++ b/src/editor/new_editor.cpp
@@ -1373,10 +1373,10 @@ void EditorScreen::UpdateEventSettingsScreen(CallMode mode)
             if(m_special_subpage == 0)
             {
                 for(int s = 0; s <= maxSections; s++)
-                    Events[m_current_event].section[s].position = level[s];
+                    Events[m_current_event].section[s].position = (SpeedlessLocation_t)level[s];
             }
             else
-                Events[m_current_event].section[m_special_subpage-1].position = level[m_special_subpage-1];
+                Events[m_current_event].section[m_special_subpage-1].position = (SpeedlessLocation_t)level[m_special_subpage-1];
             m_special_page = SPECIAL_PAGE_EVENT_SETTINGS;
         }
         SuperPrintR(mode, "NO", 3, 60, 150);
@@ -1778,7 +1778,7 @@ void EditorScreen::UpdateEventSettingsScreen(CallMode mode)
 void UpdateStartLevelEventBounds()
 {
     Events[0].AutoSection = 0;
-    Events[0].section[0].position = level[0];
+    Events[0].section[0].position = (SpeedlessLocation_t)level[0];
     // not sure why 800 is also used for height in the default code, but I will stick with it.
     if(Events[0].AutoX < 0)
         Events[0].section[0].position.X = Events[0].section[0].position.Width - 800;

--- a/src/editor/new_editor.cpp
+++ b/src/editor/new_editor.cpp
@@ -1373,10 +1373,10 @@ void EditorScreen::UpdateEventSettingsScreen(CallMode mode)
             if(m_special_subpage == 0)
             {
                 for(int s = 0; s <= maxSections; s++)
-                    Events[m_current_event].section[s].position = (SpeedlessLocation_t)level[s];
+                    Events[m_current_event].section[s].position = static_cast<SpeedlessLocation_t>(level[s]);
             }
             else
-                Events[m_current_event].section[m_special_subpage-1].position = (SpeedlessLocation_t)level[m_special_subpage-1];
+                Events[m_current_event].section[m_special_subpage-1].position = static_cast<SpeedlessLocation_t>(level[m_special_subpage-1]);
             m_special_page = SPECIAL_PAGE_EVENT_SETTINGS;
         }
         SuperPrintR(mode, "NO", 3, 60, 150);
@@ -1778,7 +1778,7 @@ void EditorScreen::UpdateEventSettingsScreen(CallMode mode)
 void UpdateStartLevelEventBounds()
 {
     Events[0].AutoSection = 0;
-    Events[0].section[0].position = (SpeedlessLocation_t)level[0];
+    Events[0].section[0].position = static_cast<SpeedlessLocation_t>(level[0]);
     // not sure why 800 is also used for height in the default code, but I will stick with it.
     if(Events[0].AutoX < 0)
         Events[0].section[0].position.X = Events[0].section[0].position.Width - 800;

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -1807,9 +1807,9 @@ void StartEpisode()
     {
         For(A, 1, numWorldPaths)
         {
-            Location_t tempLocation = WorldPath[A].Location;
+            SpeedlessLocation_t tempLocation = WorldPath[A].Location;
             {
-                Location_t &l = tempLocation;
+                SpeedlessLocation_t &l = tempLocation;
                 l.X += 4;
                 l.Y += 4;
                 l.Width -= 8;

--- a/src/globals.h
+++ b/src/globals.h
@@ -703,16 +703,16 @@ struct Background_t
 //Public Type Water
 struct Water_t
 {
+//    Location As Location
+    SpeedlessLocation_t Location;
+//    Buoy As Single 'not used
+    float Buoy = 0.0f;
 //    Layer As String
     layerindex_t Layer = LAYER_NONE;
 //    Hidden As Boolean
     bool Hidden = false;
-//    Buoy As Single 'not used
-    float Buoy = 0.0f;
 //    Quicksand As Boolean
     bool Quicksand = false;
-//    Location As Location
-    Location_t Location;
 //End Type
 };
 
@@ -853,7 +853,7 @@ struct vScreen_t
 struct WorldLevel_t
 {
 //    Location As Location
-    Location_t Location;
+    SpeedlessLocation_t Location;
 //    Type As Integer
     int Type = 0;
 //    FileName As String 'level's file
@@ -890,6 +890,10 @@ struct WorldLevel_t
 //Public Type Warp 'warps such as pipes and doors
 struct Warp_t
 {
+//    Entrance As Location 'location of warp entrance
+    SpeedlessLocation_t Entrance;
+//    Exit As Location 'location of warp exit
+    SpeedlessLocation_t Exit;
 //    Locked As Boolean 'requires a key NPC
     bool Locked = false;
 //    WarpNPC As Boolean 'allows NPC through the warp
@@ -906,10 +910,6 @@ struct Warp_t
     bool PlacedExit = false;
 //    Stars As Integer 'number of stars required to enter
     int Stars = 0;
-//    Entrance As Location 'location of warp entrance
-    Location_t Entrance;
-//    Exit As Location 'location of warp exit
-    Location_t Exit;
 //    Effect As Integer 'style of warp. door/
     int Effect = 0;
 //    level As String 'filename of the level it should warp to
@@ -949,7 +949,7 @@ struct Warp_t
 struct Tile_t
 {
 //    Location As Location
-    Location_t Location;
+    SpeedlessLocation_t Location;
 //    Type As Integer
     int Type = 0;
 //End Type
@@ -961,7 +961,7 @@ struct Tile_t
 struct Scene_t
 {
 //    Location As Location
-    Location_t Location;
+    SpeedlessLocation_t Location;
 //    Type As Integer
     int Type = 0;
 //    Active As Boolean 'if false this won't be shown. used for paths that become available on a scene
@@ -974,7 +974,7 @@ struct Scene_t
 struct WorldPath_t
 {
 //    Location As Location
-    Location_t Location;
+    SpeedlessLocation_t Location;
 //    Active As Boolean
     bool Active = false;
 //    Type As Integer
@@ -987,7 +987,7 @@ struct WorldPath_t
 struct WorldMusic_t
 {
 //    Location As Location
-    Location_t Location;
+    SpeedlessLocation_t Location;
 //    Type As Integer
     int Type = 0;
 //    EXTRA: Custom Music
@@ -1081,7 +1081,7 @@ struct WorldPlayer_t
 struct CreditLine_t
 {
 //    Location As Location
-    Location_t Location;
+    SpeedlessLocation_t Location;
 //    Text As String
     stringindex_t Text = STRINGINDEX_NONE;
 //End Type

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -763,7 +763,7 @@ void ProcEvent(eventindex_t index, bool NoEffect)
                 else if(int(s.position.X) != EventSection_t::LESet_Nothing)
                 {
                     tempLevel = level[B];
-                    level[B] = (Location_t)s.position;
+                    level[B] = static_cast<Location_t>(s.position);
 
                     if(!evt.AutoStart && !equalCase(evt.Name, "Level - Start"))
                     {
@@ -856,7 +856,7 @@ void ProcEvent(eventindex_t index, bool NoEffect)
                                 qScreenY[1] = -level[Player[C].Section].Y;
                             if(-qScreenY[1] + ScreenH /*FrmMain.ScaleHeight*/ > level[Player[C].Section].Height)
                                 qScreenY[1] = -(level[Player[C].Section].Height - ScreenH);
-                            level[B] = (Location_t)s.position;
+                            level[B] = static_cast<Location_t>(s.position);
                         }
                         else
                         {

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -763,7 +763,7 @@ void ProcEvent(eventindex_t index, bool NoEffect)
                 else if(int(s.position.X) != EventSection_t::LESet_Nothing)
                 {
                     tempLevel = level[B];
-                    level[B] = s.position;
+                    level[B] = (Location_t)s.position;
 
                     if(!evt.AutoStart && !equalCase(evt.Name, "Level - Start"))
                     {
@@ -856,7 +856,7 @@ void ProcEvent(eventindex_t index, bool NoEffect)
                                 qScreenY[1] = -level[Player[C].Section].Y;
                             if(-qScreenY[1] + ScreenH /*FrmMain.ScaleHeight*/ > level[Player[C].Section].Height)
                                 qScreenY[1] = -(level[Player[C].Section].Height - ScreenH);
-                            level[B] = s.position;
+                            level[B] = (Location_t)s.position;
                         }
                         else
                         {

--- a/src/layers.h
+++ b/src/layers.h
@@ -75,7 +75,7 @@ struct EventSection_t
     int background_id = LESet_Nothing;
 
     //! Change section borders if not (-1 - do nothing, -2 set default, any other values - set X position of left section boundary)
-    Location_t position;
+    SpeedlessLocation_t position;
 
     //! Do override current autoscroll
     bool  autoscroll = false;

--- a/src/location.h
+++ b/src/location.h
@@ -40,6 +40,33 @@ struct Location_t
 //End Type
 };
 
+//NEW: 'Holds location information for an object without speed
+struct SpeedlessLocation_t
+{
+//    X As Double
+    double X = 0.0;
+//    Y As Double
+    double Y = 0.0;
+//    Height As Double
+    double Height = 0.0;
+//    Width As Double
+    double Width = 0.0;
+
+    inline SpeedlessLocation_t() = default;
+    inline explicit SpeedlessLocation_t(const Location_t& loc) : X(loc.X), Y(loc.Y), Height(loc.Height), Width(loc.Width) {}
+
+    inline explicit operator Location_t() const
+    {
+        Location_t ret;
+        ret.X = X;
+        ret.Y = Y;
+        ret.Height = Height;
+        ret.Width = Width;
+
+        return ret;
+    }
+};
+
 //NEW: 'Holds location information for player start location, including Direction
 struct PlayerStart_t
 {

--- a/src/main/block_table.hpp
+++ b/src/main/block_table.hpp
@@ -293,7 +293,7 @@ struct screen_t
 template<class MyRef_t>
 inline Location_t extract_loc(MyRef_t obj)
 {
-    return obj->Location;
+    return (Location_t)obj->Location;
 }
 
 template<>
@@ -323,7 +323,7 @@ inline Location_t extract_loc(NPCRef_t obj)
 template<class MyRef_t>
 inline Location_t extract_loc_layer(MyRef_t obj)
 {
-    Location_t loc = obj->Location;
+    Location_t loc = (Location_t)obj->Location;
 
     if(obj->Layer != LAYER_NONE)
     {

--- a/src/main/block_table.hpp
+++ b/src/main/block_table.hpp
@@ -293,7 +293,7 @@ struct screen_t
 template<class MyRef_t>
 inline Location_t extract_loc(MyRef_t obj)
 {
-    return (Location_t)obj->Location;
+    return static_cast<Location_t>(obj->Location);
 }
 
 template<>
@@ -323,7 +323,7 @@ inline Location_t extract_loc(NPCRef_t obj)
 template<class MyRef_t>
 inline Location_t extract_loc_layer(MyRef_t obj)
 {
-    Location_t loc = (Location_t)obj->Location;
+    Location_t loc = static_cast<Location_t>(obj->Location);
 
     if(obj->Layer != LAYER_NONE)
     {

--- a/src/main/cheat_code.cpp
+++ b/src/main/cheat_code.cpp
@@ -137,7 +137,7 @@ static void moonWalk()
 
     for(int B = 1; B <= numWorldPaths; B++)
     {
-        tempLocation = WorldPath[B].Location;
+        tempLocation = (Location_t)WorldPath[B].Location;
         tempLocation.X += 4;
         tempLocation.Y += 4;
         tempLocation.Width -= 8;

--- a/src/main/cheat_code.cpp
+++ b/src/main/cheat_code.cpp
@@ -137,7 +137,7 @@ static void moonWalk()
 
     for(int B = 1; B <= numWorldPaths; B++)
     {
-        tempLocation = (Location_t)WorldPath[B].Location;
+        tempLocation = static_cast<Location_t>(WorldPath[B].Location);
         tempLocation.X += 4;
         tempLocation.Y += 4;
         tempLocation.Width -= 8;

--- a/src/main/level_file.cpp
+++ b/src/main/level_file.cpp
@@ -869,7 +869,7 @@ bool OpenLevelData(LevelData &lvl, const std::string FilePath)
                 bgo = Background_t();
                 bgo.Layer = w.Layer;
                 bgo.Hidden = w.Hidden;
-                bgo.Location = (Location_t)w.Entrance;
+                bgo.Location = static_cast<Location_t>(w.Entrance);
                 bgo.Type = 98;
                 bgo.Location.Width = 16;
                 syncLayers_BGO(B);
@@ -880,7 +880,7 @@ bool OpenLevelData(LevelData &lvl, const std::string FilePath)
                     numLocked++;
                     auto &bgo2 = Background[B];
                     bgo2 = bgo;
-                    bgo2.Location = (Location_t)w.Exit;
+                    bgo2.Location = static_cast<Location_t>(w.Exit);
                     bgo2.Location.Width = 16;
                     syncLayers_BGO(B);
                 }

--- a/src/main/level_file.cpp
+++ b/src/main/level_file.cpp
@@ -869,7 +869,7 @@ bool OpenLevelData(LevelData &lvl, const std::string FilePath)
                 bgo = Background_t();
                 bgo.Layer = w.Layer;
                 bgo.Hidden = w.Hidden;
-                bgo.Location = w.Entrance;
+                bgo.Location = (Location_t)w.Entrance;
                 bgo.Type = 98;
                 bgo.Location.Width = 16;
                 syncLayers_BGO(B);
@@ -880,7 +880,7 @@ bool OpenLevelData(LevelData &lvl, const std::string FilePath)
                     numLocked++;
                     auto &bgo2 = Background[B];
                     bgo2 = bgo;
-                    bgo2.Location = w.Exit;
+                    bgo2.Location = (Location_t)w.Exit;
                     bgo2.Location.Width = 16;
                     syncLayers_BGO(B);
                 }

--- a/src/main/world_file.cpp
+++ b/src/main/world_file.cpp
@@ -350,7 +350,7 @@ bool OpenWorld(std::string FilePath)
             if((FileRelease <= 20 && ll.Type == 1) || (FileRelease > 20 && ll.Start))
             {
                 WorldPlayer[1].Type = 1;
-                WorldPlayer[1].Location = (Location_t)WorldLevel[A].Location;
+                WorldPlayer[1].Location = static_cast<Location_t>(WorldLevel[A].Location);
                 break;
             }
         }

--- a/src/main/world_file.cpp
+++ b/src/main/world_file.cpp
@@ -350,7 +350,7 @@ bool OpenWorld(std::string FilePath)
             if((FileRelease <= 20 && ll.Type == 1) || (FileRelease > 20 && ll.Start))
             {
                 WorldPlayer[1].Type = 1;
-                WorldPlayer[1].Location = WorldLevel[A].Location;
+                WorldPlayer[1].Location = (Location_t)WorldLevel[A].Location;
                 break;
             }
         }

--- a/src/main/world_loop.cpp
+++ b/src/main/world_loop.cpp
@@ -762,7 +762,7 @@ void LevelPath(const WorldLevel_t &Lvl, int Direction, bool Skp)
     // Up
     if(Direction == 1 || Direction == 5)
     {
-        tempLocation = (Location_t)Lvl.Location;
+        tempLocation = static_cast<Location_t>(Lvl.Location);
         tempLocation.X +=  4;
         tempLocation.Y +=  4;
         tempLocation.Width -= 8;
@@ -786,7 +786,7 @@ void LevelPath(const WorldLevel_t &Lvl, int Direction, bool Skp)
     // Left
     if(Direction == 2 || Direction == 5)
     {
-        tempLocation = (Location_t)Lvl.Location;
+        tempLocation = static_cast<Location_t>(Lvl.Location);
         tempLocation.X += 4;
         tempLocation.Y += 4;
         tempLocation.Width -= 8;
@@ -810,7 +810,7 @@ void LevelPath(const WorldLevel_t &Lvl, int Direction, bool Skp)
     // Down
     if(Direction == 3 || Direction == 5)
     {
-        tempLocation = (Location_t)Lvl.Location;
+        tempLocation = static_cast<Location_t>(Lvl.Location);
         tempLocation.X += 4;
         tempLocation.Y += 4;
         tempLocation.Width -= 8;
@@ -834,7 +834,7 @@ void LevelPath(const WorldLevel_t &Lvl, int Direction, bool Skp)
     // Right
     if(Direction == 4 || Direction == 5)
     {
-        tempLocation = (Location_t)Lvl.Location;
+        tempLocation = static_cast<Location_t>(Lvl.Location);
         tempLocation.X += 4;
         tempLocation.Y += 4;
         tempLocation.Width -= 8;
@@ -940,7 +940,7 @@ void PathPath(WorldPath_t &Pth, bool Skp)
     int B = 0;
 
     Location_t tempLocation;
-    tempLocation = (Location_t)Pth.Location;
+    tempLocation = static_cast<Location_t>(Pth.Location);
     tempLocation.X += 4;
     tempLocation.Y += 4;
     tempLocation.Width -= 8;

--- a/src/main/world_loop.cpp
+++ b/src/main/world_loop.cpp
@@ -762,7 +762,7 @@ void LevelPath(const WorldLevel_t &Lvl, int Direction, bool Skp)
     // Up
     if(Direction == 1 || Direction == 5)
     {
-        tempLocation = Lvl.Location;
+        tempLocation = (Location_t)Lvl.Location;
         tempLocation.X +=  4;
         tempLocation.Y +=  4;
         tempLocation.Width -= 8;
@@ -786,7 +786,7 @@ void LevelPath(const WorldLevel_t &Lvl, int Direction, bool Skp)
     // Left
     if(Direction == 2 || Direction == 5)
     {
-        tempLocation = Lvl.Location;
+        tempLocation = (Location_t)Lvl.Location;
         tempLocation.X += 4;
         tempLocation.Y += 4;
         tempLocation.Width -= 8;
@@ -810,7 +810,7 @@ void LevelPath(const WorldLevel_t &Lvl, int Direction, bool Skp)
     // Down
     if(Direction == 3 || Direction == 5)
     {
-        tempLocation = Lvl.Location;
+        tempLocation = (Location_t)Lvl.Location;
         tempLocation.X += 4;
         tempLocation.Y += 4;
         tempLocation.Width -= 8;
@@ -834,7 +834,7 @@ void LevelPath(const WorldLevel_t &Lvl, int Direction, bool Skp)
     // Right
     if(Direction == 4 || Direction == 5)
     {
-        tempLocation = Lvl.Location;
+        tempLocation = (Location_t)Lvl.Location;
         tempLocation.X += 4;
         tempLocation.Y += 4;
         tempLocation.Width -= 8;
@@ -940,7 +940,7 @@ void PathPath(WorldPath_t &Pth, bool Skp)
     int B = 0;
 
     Location_t tempLocation;
-    tempLocation = Pth.Location;
+    tempLocation = (Location_t)Pth.Location;
     tempLocation.X += 4;
     tempLocation.Y += 4;
     tempLocation.Width -= 8;

--- a/src/npc/npc_update.cpp
+++ b/src/npc/npc_update.cpp
@@ -1018,7 +1018,7 @@ void UpdateNPCs()
                         {
                             if(NPC[A].Wet == 0 && !NPCIsACoin[NPC[A].Type])
                             {
-                                if(NPC[A].Location.SpeedY >= 1 && (!g_compatibility.fix_submerged_splash_effect || !CheckCollisionIntersect(NPC[A].Location, (Location_t)Water[B].Location)))
+                                if(NPC[A].Location.SpeedY >= 1 && (!g_compatibility.fix_submerged_splash_effect || !CheckCollisionIntersect(NPC[A].Location, static_cast<Location_t>(Water[B].Location))))
                                 {
                                     tempLocation.Width = 32;
                                     tempLocation.Height = 32;

--- a/src/npc/npc_update.cpp
+++ b/src/npc/npc_update.cpp
@@ -1018,7 +1018,7 @@ void UpdateNPCs()
                         {
                             if(NPC[A].Wet == 0 && !NPCIsACoin[NPC[A].Type])
                             {
-                                if(NPC[A].Location.SpeedY >= 1 && (!g_compatibility.fix_submerged_splash_effect || !CheckCollisionIntersect(NPC[A].Location, Water[B].Location)))
+                                if(NPC[A].Location.SpeedY >= 1 && (!g_compatibility.fix_submerged_splash_effect || !CheckCollisionIntersect(NPC[A].Location, (Location_t)Water[B].Location)))
                                 {
                                     tempLocation.Width = 32;
                                     tempLocation.Height = 32;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -5920,8 +5920,8 @@ void PlayerEffects(const int A)
 
         bool backward = p.WarpBackward;
         auto &warp = Warp[p.Warp];
-        Location_t warp_enter = Location_t(backward ? warp.Exit : warp.Entrance);
-        Location_t warp_exit = Location_t(backward ? warp.Entrance : warp.Exit);
+        Location_t warp_enter = static_cast<Location_t>(backward ? warp.Exit : warp.Entrance);
+        Location_t warp_exit = static_cast<Location_t>(backward ? warp.Entrance : warp.Exit);
         auto &warp_dir_enter = backward ? warp.Direction2 : warp.Direction;
         auto &warp_dir_exit = backward ? warp.Direction : warp.Direction2;
 
@@ -6538,8 +6538,8 @@ void PlayerEffects(const int A)
     {
         bool backward = p.WarpBackward;
         auto &warp = Warp[p.Warp];
-        Location_t warp_enter = Location_t(backward ? warp.Exit : warp.Entrance);
-        Location_t warp_exit = Location_t(backward ? warp.Entrance : warp.Exit);
+        Location_t warp_enter = static_cast<Location_t>(backward ? warp.Exit : warp.Entrance);
+        Location_t warp_exit = static_cast<Location_t>(backward ? warp.Entrance : warp.Exit);
 
         if(p.HoldingNPC > 0)
         {
@@ -6762,7 +6762,7 @@ void PlayerEffects(const int A)
             {
                 p.Effect2 = 130;
 
-                for(int c : treeBackgroundQuery((Location_t)Warp[p.Warp].Exit, SORTMODE_NONE))
+                for(int c : treeBackgroundQuery(static_cast<Location_t>(Warp[p.Warp].Exit), SORTMODE_NONE))
                 {
                     if(c > numBackground)
                         continue;
@@ -6820,7 +6820,7 @@ void PlayerEffects(const int A)
 
             if(fEqual(p.Effect2, 1900))
             {
-                for(int c : treeBackgroundQuery((Location_t)Warp[p.Warp].Exit, SORTMODE_NONE))
+                for(int c : treeBackgroundQuery(static_cast<Location_t>(Warp[p.Warp].Exit), SORTMODE_NONE))
                 {
                     if(c > numBackground)
                         continue;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -5920,8 +5920,8 @@ void PlayerEffects(const int A)
 
         bool backward = p.WarpBackward;
         auto &warp = Warp[p.Warp];
-        auto &warp_enter = backward ? warp.Exit : warp.Entrance;
-        auto &warp_exit = backward ? warp.Entrance : warp.Exit;
+        Location_t warp_enter = Location_t(backward ? warp.Exit : warp.Entrance);
+        Location_t warp_exit = Location_t(backward ? warp.Entrance : warp.Exit);
         auto &warp_dir_enter = backward ? warp.Direction2 : warp.Direction;
         auto &warp_dir_exit = backward ? warp.Direction : warp.Direction2;
 
@@ -6538,8 +6538,8 @@ void PlayerEffects(const int A)
     {
         bool backward = p.WarpBackward;
         auto &warp = Warp[p.Warp];
-        auto &warp_enter = backward ? warp.Exit : warp.Entrance;
-        auto &warp_exit = backward ? warp.Entrance : warp.Exit;
+        Location_t warp_enter = Location_t(backward ? warp.Exit : warp.Entrance);
+        Location_t warp_exit = Location_t(backward ? warp.Entrance : warp.Exit);
 
         if(p.HoldingNPC > 0)
         {
@@ -6762,7 +6762,7 @@ void PlayerEffects(const int A)
             {
                 p.Effect2 = 130;
 
-                for(int c : treeBackgroundQuery(Warp[p.Warp].Exit, SORTMODE_NONE))
+                for(int c : treeBackgroundQuery((Location_t)Warp[p.Warp].Exit, SORTMODE_NONE))
                 {
                     if(c > numBackground)
                         continue;
@@ -6820,7 +6820,7 @@ void PlayerEffects(const int A)
 
             if(fEqual(p.Effect2, 1900))
             {
-                for(int c : treeBackgroundQuery(Warp[p.Warp].Exit, SORTMODE_NONE))
+                for(int c : treeBackgroundQuery((Location_t)Warp[p.Warp].Exit, SORTMODE_NONE))
                 {
                     if(c > numBackground)
                         continue;

--- a/src/player/player_update.cpp
+++ b/src/player/player_update.cpp
@@ -3570,11 +3570,11 @@ void UpdatePlayer()
                                             Player[A].Effect = 7;
                                             Player[A].Warp = numWarps + 1;
                                             Player[A].WarpBackward = false;
-                                            Warp[numWarps + 1].Entrance = (SpeedlessLocation_t)NPC[B].Location;
+                                            Warp[numWarps + 1].Entrance = static_cast<SpeedlessLocation_t>(NPC[B].Location);
                                             tempLocation = NPC[B].Location;
                                             tempLocation.X = NPC[B].Location.X - level[Player[A].Section].X + level[NPC[B].Special2].X;
                                             tempLocation.Y = NPC[B].Location.Y - level[Player[A].Section].Y + level[NPC[B].Special2].Y;
-                                            Warp[numWarps + 1].Exit = (SpeedlessLocation_t)tempLocation;
+                                            Warp[numWarps + 1].Exit = static_cast<SpeedlessLocation_t>(tempLocation);
                                             Warp[numWarps + 1].Hidden = false;
                                             Warp[numWarps + 1].NoYoshi = false;
                                             Warp[numWarps + 1].WarpNPC = true;
@@ -3585,11 +3585,11 @@ void UpdatePlayer()
                                             // Stop
                                             Player[A].Location.X = Warp[Player[A].Warp].Entrance.X + Warp[Player[A].Warp].Entrance.Width / 2.0 - Player[A].Location.Width / 2.0;
                                             Player[A].Location.Y = Warp[Player[A].Warp].Entrance.Y + Warp[Player[A].Warp].Entrance.Height - Player[A].Location.Height;
-                                            tempLocation = (Location_t)Warp[numWarps + 1].Entrance;
+                                            tempLocation = static_cast<Location_t>(Warp[numWarps + 1].Entrance);
                                             tempLocation.Y -= 32;
                                             tempLocation.Height = 64;
                                             NewEffect(54, tempLocation);
-                                            tempLocation = (Location_t)Warp[numWarps + 1].Exit;
+                                            tempLocation = static_cast<Location_t>(Warp[numWarps + 1].Exit);
                                             tempLocation.Y -= 32;
                                             tempLocation.Height = 64;
                                             NewEffect(54, tempLocation);

--- a/src/player/player_update.cpp
+++ b/src/player/player_update.cpp
@@ -3570,11 +3570,11 @@ void UpdatePlayer()
                                             Player[A].Effect = 7;
                                             Player[A].Warp = numWarps + 1;
                                             Player[A].WarpBackward = false;
-                                            Warp[numWarps + 1].Entrance = NPC[B].Location;
+                                            Warp[numWarps + 1].Entrance = (SpeedlessLocation_t)NPC[B].Location;
                                             tempLocation = NPC[B].Location;
                                             tempLocation.X = NPC[B].Location.X - level[Player[A].Section].X + level[NPC[B].Special2].X;
                                             tempLocation.Y = NPC[B].Location.Y - level[Player[A].Section].Y + level[NPC[B].Special2].Y;
-                                            Warp[numWarps + 1].Exit = tempLocation;
+                                            Warp[numWarps + 1].Exit = (SpeedlessLocation_t)tempLocation;
                                             Warp[numWarps + 1].Hidden = false;
                                             Warp[numWarps + 1].NoYoshi = false;
                                             Warp[numWarps + 1].WarpNPC = true;
@@ -3585,11 +3585,11 @@ void UpdatePlayer()
                                             // Stop
                                             Player[A].Location.X = Warp[Player[A].Warp].Entrance.X + Warp[Player[A].Warp].Entrance.Width / 2.0 - Player[A].Location.Width / 2.0;
                                             Player[A].Location.Y = Warp[Player[A].Warp].Entrance.Y + Warp[Player[A].Warp].Entrance.Height - Player[A].Location.Height;
-                                            tempLocation = Warp[numWarps + 1].Entrance;
+                                            tempLocation = (Location_t)Warp[numWarps + 1].Entrance;
                                             tempLocation.Y -= 32;
                                             tempLocation.Height = 64;
                                             NewEffect(54, tempLocation);
-                                            tempLocation = Warp[numWarps + 1].Exit;
+                                            tempLocation = (Location_t)Warp[numWarps + 1].Exit;
                                             tempLocation.Y -= 32;
                                             tempLocation.Height = 64;
                                             NewEffect(54, tempLocation);


### PR DESCRIPTION
I nearly committed straight to main, but it does impact a few objects so I thought it would be nice to get some review.

This adds a new type `SpeedlessLocation_t` without the `SpeedX` or `SpeedY` attributes, and uses it for the `Location` attribute of objects that do not ever use these attributes. Those objects are Warp, Water, the World items, Credit Line, and Event Section.

In order to avoid any mistakes or inefficiencies, I made its conversion functions to/from `Location_t` explicit.

This change saves of 1.4 MB of RAM on the PC build, and 400 KB of RAM on the low-RAM builds. It has no gameplay effects, and none of the affected items had Autocode bindings.