### PR TITLE
Compat autoconversion for 1.3.6.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,6 +508,7 @@ set(THEXTECH_SRC
     src/main/screen_connect.cpp
     src/main/screen_quickreconnect.cpp
     src/main/screen_textentry.cpp
+    src/main/screen_prompt.cpp
     src/main/menu_controls.cpp
     src/main/cheat_code.cpp
     src/main/outro_loop.cpp

--- a/lib/IniProcessor/ini_processing.cpp
+++ b/lib/IniProcessor/ini_processing.cpp
@@ -653,6 +653,43 @@ bool IniProcessing::hasKey(const std::string &keyName) const
     return (e != m_params.currentGroup->end());
 }
 
+bool IniProcessing::renameKey(const std::string &oldName, const std::string &newName)
+{
+    if(!m_params.opened)
+        return false;
+
+    if(!m_params.currentGroup)
+        return false;
+
+    auto it = m_params.currentGroup->find(oldName);
+    if(it != m_params.currentGroup->end())
+    {
+        std::swap((*m_params.currentGroup)[newName], it->second);
+        m_params.currentGroup->erase(it);
+        return true;
+    }
+
+    return false;
+}
+
+bool IniProcessing::deleteKey(const std::string &keyName)
+{
+    if(!m_params.opened)
+        return false;
+
+    if(!m_params.currentGroup)
+        return false;
+
+    auto it = m_params.currentGroup->find(keyName);
+    if(it != m_params.currentGroup->end())
+    {
+        m_params.currentGroup->erase(it);
+        return true;
+    }
+
+    return false;
+}
+
 std::vector<std::string> IniProcessing::allKeys() const
 {
     std::vector<std::string> keys;

--- a/lib/IniProcessor/ini_processing.cpp
+++ b/lib/IniProcessor/ini_processing.cpp
@@ -342,10 +342,10 @@ bool IniProcessing::parseHelper(char *data, size_t size)
                 value = lskip(end + 1);
                 end = find_char_or_comment(value, '\0');
 
-                #ifndef CASE_SENSITIVE_KEYS
+#ifndef CASE_SENSITIVE_KEYS
                 for(char *iter = name; *iter != '\0'; ++iter)
                     *iter = (char)tolower(*iter);
-                #endif
+#endif
 
                 if(*end == ';')
                     *end = '\0';
@@ -359,9 +359,9 @@ bool IniProcessing::parseHelper(char *data, size_t size)
                     if(!recentKeys)
                         recentKeys = &m_params.iniData["General"];
 
-                    #ifdef INIDEBUG
+#ifdef INIDEBUG
                     printf("-> [%s]; %s = %s\n", section, name, v);
-                    #endif
+#endif
                     (*recentKeys)[name] = unescapeString( removeQuotes(v, v + strlen(v)) );
                 }
             }
@@ -649,7 +649,15 @@ bool IniProcessing::hasKey(const std::string &keyName) const
     if(!m_params.currentGroup)
         return false;
 
-    auto e = m_params.currentGroup->find(keyName);
+#ifndef CASE_SENSITIVE_KEYS
+    std::string keyName1(keyName);
+    for(char *iter = &keyName1[0]; *iter != '\0'; ++iter)
+        *iter = (char)tolower(*iter);
+#else
+    auto &keyName1 = keyName;
+#endif
+
+    auto e = m_params.currentGroup->find(keyName1);
     return (e != m_params.currentGroup->end());
 }
 
@@ -661,10 +669,29 @@ bool IniProcessing::renameKey(const std::string &oldName, const std::string &new
     if(!m_params.currentGroup)
         return false;
 
-    auto it = m_params.currentGroup->find(oldName);
+    if(oldName.empty() || newName.empty())
+        return false; // Empty keys are invalid
+
+#ifndef CASE_SENSITIVE_KEYS
+    std::string oldName1(oldName);
+    for(char *iter = &oldName1[0]; *iter != '\0'; ++iter)
+        *iter = (char)tolower(*iter);
+
+    std::string newName1(newName);
+    for(char *iter = &newName1[0]; *iter != '\0'; ++iter)
+        *iter = (char)tolower(*iter);
+#else
+    auto &oldName1 = oldName;
+    auto &newName1 = newName;
+#endif
+
+    if(oldName1 == newName1)
+        return true; /* Do nothing, keys are equal */
+
+    auto it = m_params.currentGroup->find(oldName1);
     if(it != m_params.currentGroup->end())
     {
-        std::swap((*m_params.currentGroup)[newName], it->second);
+        std::swap((*m_params.currentGroup)[newName1], it->second);
         m_params.currentGroup->erase(it);
         return true;
     }
@@ -680,7 +707,18 @@ bool IniProcessing::deleteKey(const std::string &keyName)
     if(!m_params.currentGroup)
         return false;
 
-    auto it = m_params.currentGroup->find(keyName);
+    if(keyName.empty())
+        return false; // Empty keys are invalid
+
+#ifndef CASE_SENSITIVE_KEYS
+    std::string keyName1(keyName);
+    for(char *iter = &keyName1[0]; *iter != '\0'; ++iter)
+        *iter = (char)tolower(*iter);
+#else
+    auto &keyName1 = keyName;
+#endif
+
+    auto it = m_params.currentGroup->find(keyName1);
     if(it != m_params.currentGroup->end())
     {
         m_params.currentGroup->erase(it);

--- a/lib/IniProcessor/ini_processing.h
+++ b/lib/IniProcessor/ini_processing.h
@@ -92,11 +92,13 @@ private:
         if(!m_params.currentGroup)
             return params::IniKeys::iterator();
 
-        #ifndef CASE_SENSITIVE_KEYS
+#ifndef CASE_SENSITIVE_KEYS
         std::string key1(key);
         for(char *iter = &key1[0]; *iter != '\0'; ++iter)
             *iter = (char)tolower(*iter);
-        #endif
+#else
+        auto &key1 = key;
+#endif
 
         params::IniKeys::iterator e = m_params.currentGroup->find(key1);
 

--- a/lib/IniProcessor/ini_processing.h
+++ b/lib/IniProcessor/ini_processing.h
@@ -195,6 +195,21 @@ public:
     bool hasKey(const std::string &keyName) const;
 
     /**
+     * @brief Renames key to a new name, clobbering existing key at newName
+     * @param oldName current name of key
+     * @param newName new name of key
+     * @return true if rename is successful, false if oldName is not present in this section
+     */
+    bool renameKey(const std::string &oldName, const std::string &newName);
+
+    /**
+     * @brief Deletes key at keyName from current section
+     * @param keyName name of key to delete
+     * @return true if delete is successful, false if keyName is not present in this section
+     */
+    bool deleteKey(const std::string &keyName);
+
+    /**
      * @brief Get list of available keys in current groul
      * @return Array of strings
      */

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -254,7 +254,19 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
         // final condition ensures we only warn on first time the file is loaded
         if(!writable && g_config.compat_autoconvert != Config_t::AUTOCONVERT_NEVER && g_config.compat_autoconvert_warn_unwritable && (s_first_load_iter[s.fileName()] == 0 || s_first_load_iter[s.fileName()] == s_cur_load_iter))
         {
-            int response = PromptScreen::Run(fmt::format_ne(g_mainMenu.promptDeprecatedSettingUnwritable, s.fileName(), s.group().c_str(), fieldName, newName), {g_mainMenu.wordYes, g_mainMenu.wordNo});
+            std::string filename = s.fileName();
+
+            // remove AppPath if it's included
+            pLogDebug("%s %s", filename.c_str(), AppPath.c_str());
+            if(filename.compare(0, AppPath.size(), AppPath) == 0)
+            {
+                for(size_t i = AppPath.size(); i < filename.size(); i++)
+                    filename[i - AppPath.size()] = filename[i];
+
+                filename.resize(filename.size() - AppPath.size());
+            }
+
+            int response = PromptScreen::Run(fmt::format_ne(g_mainMenu.promptDeprecatedSettingUnwritable, filename, s.group().c_str(), fieldName, newName), {g_mainMenu.wordYes, g_mainMenu.wordNo});
 
             if(response == 1)
             {

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -192,7 +192,7 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
                     s.group().c_str(),
                     newName);
 
-        bool writable = true;
+        bool writable = (selWorld == 0 || LevelEditor) || (BattleMode ? SelectBattle : SelectWorld)[selWorld].editable;
 
         if(writable)
         {
@@ -230,7 +230,7 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
             {
                 pLogDebug("Updating file [%s]...", s.fileName().c_str());
                 s.renameKey(fieldName, newName);
-                s.writeIniFile();
+                writable = s.writeIniFile();
             }
 
             if(response == 2)
@@ -244,8 +244,11 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
                 SaveConfig();
             }
         }
-        // second condition ensures we only warn on first time the file is loaded
-        else if(g_config.compat_autoconvert_warn_unwritable && (s_first_load_iter[s.fileName()] == 0 || s_first_load_iter[s.fileName()] == s_cur_load_iter))
+
+        // NOTE: if saving failed above, writable is set to false even if it was originally true
+
+        // final condition ensures we only warn on first time the file is loaded
+        if(!writable && g_config.compat_autoconvert != Config_t::AUTOCONVERT_NEVER && g_config.compat_autoconvert_warn_unwritable && (s_first_load_iter[s.fileName()] == 0 || s_first_load_iter[s.fileName()] == s_cur_load_iter))
         {
             int response = PromptScreen::Run(fmt::format_ne(g_mainMenu.promptDeprecatedSettingUnwritable, s.fileName(), s.group().c_str(), fieldName, newName), {g_mainMenu.wordYes, g_mainMenu.wordNo});
 

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -198,16 +198,8 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
         {
             int response;
 
-            if(g_config.compat_autoconvert == Config_t::AUTOCONVERT_ALWAYS)
-            {
-                response = 0;
-            }
-            else if(g_config.compat_autoconvert == Config_t::AUTOCONVERT_NEVER)
-            {
-                response = 1;
-            }
             // only warn on first time the file is loaded
-            else if(s_first_load_iter[s.fileName()] != 0 && s_first_load_iter[s.fileName()] != s_cur_load_iter)
+            if(s_first_load_iter[s.fileName()] != 0 && s_first_load_iter[s.fileName()] != s_cur_load_iter)
             {
                 response = 1;
             }
@@ -218,15 +210,13 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
                     {
                         g_mainMenu.wordYes,
                         g_mainMenu.wordNo,
-                        g_mainMenu.phraseYesAlways,
-                        g_mainMenu.phraseNoNever,
                     }
                 );
 
                 s_first_load_iter[s.fileName()] = s_cur_load_iter;
             }
 
-            if(response == 0 || response == 2)
+            if(response == 0)
             {
                 pLogDebug("Updating file [%s]...", s.fileName().c_str());
 
@@ -236,23 +226,12 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
 
                 writable = s.writeIniFile();
             }
-
-            if(response == 3)
-            {
-                g_config.compat_autoconvert = Config_t::AUTOCONVERT_NEVER;
-                SaveConfig();
-            }
-            else if(response == 2)
-            {
-                g_config.compat_autoconvert = Config_t::AUTOCONVERT_ALWAYS;
-                SaveConfig();
-            }
         }
 
         // NOTE: if saving failed above, writable is set to false even if it was originally true
 
         // final condition ensures we only warn on first time the file is loaded
-        if(!writable && g_config.compat_autoconvert != Config_t::AUTOCONVERT_NEVER && g_config.compat_autoconvert_warn_unwritable && (s_first_load_iter[s.fileName()] == 0 || s_first_load_iter[s.fileName()] == s_cur_load_iter))
+        if(!writable && (s_first_load_iter[s.fileName()] == 0 || s_first_load_iter[s.fileName()] == s_cur_load_iter))
         {
             std::string filename = s.fileName();
 
@@ -266,13 +245,7 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
                 filename.resize(filename.size() - AppPath.size());
             }
 
-            int response = PromptScreen::Run(fmt::format_ne(g_mainMenu.promptDeprecatedSettingUnwritable, filename, s.group().c_str(), fieldName, newName), {g_mainMenu.wordYes, g_mainMenu.wordNo});
-
-            if(response == 1)
-            {
-                g_config.compat_autoconvert_warn_unwritable = false;
-                SaveConfig();
-            }
+            PromptScreen::Run(fmt::format_ne(g_mainMenu.promptDeprecatedSettingUnwritable, filename, s.group().c_str(), fieldName, newName), {g_mainMenu.wordOkay});
 
             s_first_load_iter[s.fileName()] = s_cur_load_iter;
         }

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -229,7 +229,11 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
             if(response == 1 || response == 3)
             {
                 pLogDebug("Updating file [%s]...", s.fileName().c_str());
-                s.renameKey(fieldName, newName);
+
+                std::string current_value;
+                s.read(fieldName, current_value, current_value);
+                s.setValue(newName, current_value);
+
                 writable = s.writeIniFile();
             }
 

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -200,33 +200,33 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
 
             if(g_config.compat_autoconvert == Config_t::AUTOCONVERT_ALWAYS)
             {
-                response = 1;
+                response = 0;
             }
             else if(g_config.compat_autoconvert == Config_t::AUTOCONVERT_NEVER)
             {
-                response = 0;
+                response = 1;
             }
             // only warn on first time the file is loaded
             else if(s_first_load_iter[s.fileName()] != 0 && s_first_load_iter[s.fileName()] != s_cur_load_iter)
             {
-                response = 0;
+                response = 1;
             }
             else
             {
                 response = PromptScreen::Run(
                     fmt::format_ne(g_mainMenu.promptDeprecatedSetting, fieldName, newName),
                     {
-                        g_mainMenu.wordNo,
                         g_mainMenu.wordYes,
-                        g_mainMenu.phraseNoNever,
+                        g_mainMenu.wordNo,
                         g_mainMenu.phraseYesAlways,
+                        g_mainMenu.phraseNoNever,
                     }
                 );
 
                 s_first_load_iter[s.fileName()] = s_cur_load_iter;
             }
 
-            if(response == 1 || response == 3)
+            if(response == 0 || response == 2)
             {
                 pLogDebug("Updating file [%s]...", s.fileName().c_str());
 
@@ -237,12 +237,12 @@ static void deprecatedWarning(IniProcessing &s, const char* fieldName, const cha
                 writable = s.writeIniFile();
             }
 
-            if(response == 2)
+            if(response == 3)
             {
                 g_config.compat_autoconvert = Config_t::AUTOCONVERT_NEVER;
                 SaveConfig();
             }
-            else if(response == 3)
+            else if(response == 2)
             {
                 g_config.compat_autoconvert = Config_t::AUTOCONVERT_ALWAYS;
                 SaveConfig();

--- a/src/config.h
+++ b/src/config.h
@@ -38,16 +38,6 @@ extern struct Config_t
     int     editor_preferred_file_format = 0;
     //! Show debug string during the loading process
     bool    loading_show_debug = false;
-    //! Compat autoconversion preference
-    enum
-    {
-        AUTOCONVERT_ASK = 0,
-        AUTOCONVERT_NEVER,
-        AUTOCONVERT_ALWAYS,
-    };
-    int     compat_autoconvert = AUTOCONVERT_ASK;
-    //! Warn user if autoconversion is impossible
-    bool    compat_autoconvert_warn_unwritable = true;
 
     /* ---- Video ----*/
 

--- a/src/config.h
+++ b/src/config.h
@@ -38,6 +38,16 @@ extern struct Config_t
     int     editor_preferred_file_format = 0;
     //! Show debug string during the loading process
     bool    loading_show_debug = false;
+    //! Compat autoconversion preference
+    enum
+    {
+        AUTOCONVERT_ASK = 0,
+        AUTOCONVERT_NEVER,
+        AUTOCONVERT_ALWAYS,
+    };
+    int     compat_autoconvert = AUTOCONVERT_ASK;
+    //! Warn user if autoconversion is impossible
+    bool    compat_autoconvert_warn_unwritable = true;
 
     /* ---- Video ----*/
 

--- a/src/game_main.h
+++ b/src/game_main.h
@@ -33,6 +33,7 @@ enum class PauseCode
     Reconnect,
     DropAdd,
     TextEntry,
+    Prompt,
 };
 
 //Public GamePaused As Boolean 'true if the game is paused

--- a/src/globals.h
+++ b/src/globals.h
@@ -1209,6 +1209,8 @@ struct SelectWorld_t
     std::string WorldFile;
 //    blockChar(1 To numCharacters) As Boolean
     RangeArrI<bool, 1, numCharacters, false> blockChar;
+// EXTRA:
+    bool editable = false;
     bool highlight = false;
     bool disabled = false;
 //End Type

--- a/src/main/game_loop.cpp
+++ b/src/main/game_loop.cpp
@@ -48,6 +48,7 @@
 #include "screen_connect.h"
 #include "screen_quickreconnect.h"
 #include "screen_textentry.h"
+#include "screen_prompt.h"
 #include "script/luna/luna.h"
 
 #include "../pseudo_vb.h"
@@ -103,7 +104,9 @@ void editorWaitForFade()
         if(canProceedFrame())
         {
             computeFrameTime1();
-            if(WorldEditor)
+            if(GamePaused == PauseCode::Prompt)
+                PromptScreen::Render();
+            else if(WorldEditor)
                 UpdateGraphics2();
             else
                 UpdateGraphics();
@@ -397,6 +400,10 @@ int PauseGame(PauseCode code, int plr)
         ConnectScreen::DropAdd_Start();
         XWindow::showCursor(0);
     }
+    else if(code == PauseCode::Prompt)
+    {
+        PromptScreen::Init();
+    }
     else if(code == PauseCode::TextEntry)
     {
         // assume TextEntryScreen has already been inited through its Run function.
@@ -432,7 +439,10 @@ int PauseGame(PauseCode code, int plr)
             g_microStats.start_task(MicroStats::Graphics);
 
             speedRun_tick();
-            if((LevelSelect && !GameMenu) || WorldEditor)
+
+            if(code == PauseCode::Prompt)
+                PromptScreen::Render();
+            else if((LevelSelect && !GameMenu) || WorldEditor)
                 UpdateGraphics2();
             else
                 UpdateGraphics();
@@ -486,6 +496,11 @@ int PauseGame(PauseCode code, int plr)
             else if(GamePaused == PauseCode::Message)
             {
                 if(MessageScreen_Logic(plr))
+                    break;
+            }
+            else if(GamePaused == PauseCode::Prompt)
+            {
+                if(PromptScreen::Logic())
                     break;
             }
             else if(GamePaused == PauseCode::Reconnect || GamePaused == PauseCode::DropAdd)

--- a/src/main/main_config.cpp
+++ b/src/main/main_config.cpp
@@ -194,6 +194,13 @@ void OpenConfig()
             {"2", Config_t::EPISODE_TITLE_TRANSPARENT}
         };
 
+        const IniProcessing::StrEnumMap compatAutoconvert
+        {
+            {"ask", Config_t::AUTOCONVERT_ASK},
+            {"never", Config_t::AUTOCONVERT_NEVER},
+            {"always", Config_t::AUTOCONVERT_ALWAYS},
+        };
+
         const IniProcessing::StrEnumMap starsShowPolicy =
         {
             {"hide", 0},
@@ -211,6 +218,8 @@ void OpenConfig()
         config.read("new-editor", g_config.enable_editor, false);
         config.read("enable-editor", g_config.enable_editor, g_config.enable_editor);
         config.read("editor-edge-scroll", g_config.editor_edge_scroll, g_config.editor_edge_scroll);
+        config.readEnum("compat-autoconvert", g_config.compat_autoconvert, g_config.compat_autoconvert, compatAutoconvert);
+        config.read("compat-autoconvert-warn-unwritable", g_config.compat_autoconvert_warn_unwritable, g_config.compat_autoconvert_warn_unwritable);
         config.endGroup();
 
 #if defined(__ANDROID__) || defined(__EMSCRIPTEN__)
@@ -275,6 +284,13 @@ void SaveConfig()
     IniProcessing config(configPath);
     IniProcessing controls(controlsPath);
 
+    std::unordered_map<int, std::string> compatAutoconvert =
+    {
+        {Config_t::AUTOCONVERT_ASK, "ask"},
+        {Config_t::AUTOCONVERT_NEVER, "never"},
+        {Config_t::AUTOCONVERT_ALWAYS, "always"},
+    };
+
     config.beginGroup("main");
     config.setValue("release", curRelease);
 #if !defined(RENDER_FULLSCREEN_ALWAYS) // Don't remember fullscreen
@@ -285,6 +301,8 @@ void SaveConfig()
     config.setValue("enable-editor", g_config.enable_editor);
     config.setValue("editor-edge-scroll", g_config.editor_edge_scroll);
     config.setValue("loading-debug", g_config.loading_show_debug);
+    config.setValue("compat-autoconvert", compatAutoconvert[g_config.compat_autoconvert]);
+    config.setValue("compat-autoconvert-warn-unwritable", g_config.compat_autoconvert_warn_unwritable);
     config.endGroup();
 
     config.beginGroup("recent");

--- a/src/main/main_config.cpp
+++ b/src/main/main_config.cpp
@@ -194,13 +194,6 @@ void OpenConfig()
             {"2", Config_t::EPISODE_TITLE_TRANSPARENT}
         };
 
-        const IniProcessing::StrEnumMap compatAutoconvert
-        {
-            {"ask", Config_t::AUTOCONVERT_ASK},
-            {"never", Config_t::AUTOCONVERT_NEVER},
-            {"always", Config_t::AUTOCONVERT_ALWAYS},
-        };
-
         const IniProcessing::StrEnumMap starsShowPolicy =
         {
             {"hide", 0},
@@ -218,8 +211,6 @@ void OpenConfig()
         config.read("new-editor", g_config.enable_editor, false);
         config.read("enable-editor", g_config.enable_editor, g_config.enable_editor);
         config.read("editor-edge-scroll", g_config.editor_edge_scroll, g_config.editor_edge_scroll);
-        config.readEnum("compat-autoconvert", g_config.compat_autoconvert, g_config.compat_autoconvert, compatAutoconvert);
-        config.read("compat-autoconvert-warn-unwritable", g_config.compat_autoconvert_warn_unwritable, g_config.compat_autoconvert_warn_unwritable);
         config.endGroup();
 
 #if defined(__ANDROID__) || defined(__EMSCRIPTEN__)
@@ -284,13 +275,6 @@ void SaveConfig()
     IniProcessing config(configPath);
     IniProcessing controls(controlsPath);
 
-    std::unordered_map<int, std::string> compatAutoconvert =
-    {
-        {Config_t::AUTOCONVERT_ASK, "ask"},
-        {Config_t::AUTOCONVERT_NEVER, "never"},
-        {Config_t::AUTOCONVERT_ALWAYS, "always"},
-    };
-
     config.beginGroup("main");
     config.setValue("release", curRelease);
 #if !defined(RENDER_FULLSCREEN_ALWAYS) // Don't remember fullscreen
@@ -301,8 +285,6 @@ void SaveConfig()
     config.setValue("enable-editor", g_config.enable_editor);
     config.setValue("editor-edge-scroll", g_config.editor_edge_scroll);
     config.setValue("loading-debug", g_config.loading_show_debug);
-    config.setValue("compat-autoconvert", compatAutoconvert[g_config.compat_autoconvert]);
-    config.setValue("compat-autoconvert-warn-unwritable", g_config.compat_autoconvert_warn_unwritable);
     config.endGroup();
 
     config.beginGroup("recent");

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -132,6 +132,11 @@ void initMainMenu()
 
     g_mainMenu.wordNo = "No";
     g_mainMenu.wordYes = "Yes";
+
+    g_mainMenu.promptDeprecatedSetting = "This file uses a deprecated compatibility flag that will be removed in version 1.3.7.\n\nReplace it with the updated flag for version 1.3.6 and newer?\n\nOld flag: \"{0}\"\nNew flag: \"{1}\"";
+    g_mainMenu.promptDeprecatedSettingUnwritable = "An unwritable file ({0}) uses a deprecated compatibility flag that will be removed in version 1.3.7.\n\nPlease update it manually and copy to your device.\n\nSection: [{1}]\nOld flag: \"{2}\"\nNew flag: \"{3}\"\n\nShow this type of message in future?";
+    g_mainMenu.phraseYesAlways = "Yes, always";
+    g_mainMenu.phraseNoNever = "No, never";
 }
 
 

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -132,11 +132,10 @@ void initMainMenu()
 
     g_mainMenu.wordNo = "No";
     g_mainMenu.wordYes = "Yes";
+    g_mainMenu.wordOkay = "Okay";
 
     g_mainMenu.promptDeprecatedSetting = "This file uses a deprecated compatibility flag that will be removed in version 1.3.7.\n\nReplace it with the updated flag for version 1.3.6 and newer?\n\nOld flag: \"{0}\"\nNew flag: \"{1}\"";
-    g_mainMenu.promptDeprecatedSettingUnwritable = "An unwritable file ({0}) uses a deprecated compatibility flag that will be removed in version 1.3.7.\n\nPlease update it manually and copy to your device.\n\nSection: [{1}]\nOld flag: \"{2}\"\nNew flag: \"{3}\"\n\nShow this type of message in future?";
-    g_mainMenu.phraseYesAlways = "Yes, always";
-    g_mainMenu.phraseNoNever = "No, never";
+    g_mainMenu.promptDeprecatedSettingUnwritable = "An unwritable file ({0}) uses a deprecated compatibility flag that will be removed in version 1.3.7.\n\nPlease update it manually and copy to your device.\n\nSection: [{1}]\nOld flag: \"{2}\"\nNew flag: \"{3}\"";
 }
 
 

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -134,8 +134,8 @@ void initMainMenu()
     g_mainMenu.wordYes = "Yes";
     g_mainMenu.wordOkay = "Okay";
 
-    g_mainMenu.promptDeprecatedSetting = "This file uses a deprecated compatibility flag that will be removed in version 1.3.7.\n\nReplace it with the updated flag for version 1.3.6 and newer?\n\nOld flag: \"{0}\"\nNew flag: \"{1}\"";
-    g_mainMenu.promptDeprecatedSettingUnwritable = "An unwritable file ({0}) uses a deprecated compatibility flag that will be removed in version 1.3.7.\n\nPlease update it manually and copy to your device.\n\nSection: [{1}]\nOld flag: \"{2}\"\nNew flag: \"{3}\"";
+    g_mainMenu.promptDeprecatedSetting = "This file uses a deprecated compatibility flag that will be removed in version 1.3.7.\n\nOld flag: \"{0}\"\nNew flag: \"{1}\"\n\n\nReplace it with the updated flag for version 1.3.6 and newer?";
+    g_mainMenu.promptDeprecatedSettingUnwritable = "An unwritable file ({0}) uses a deprecated compatibility flag that will be removed in version 1.3.7.\n\nSection: [{1}]\nOld flag: \"{2}\"\nNew flag: \"{3}\"\n\n\nPlease update it manually and copy to your device.";
 }
 
 

--- a/src/main/menu_main.h
+++ b/src/main/menu_main.h
@@ -134,14 +134,11 @@ struct MainMenuContent
 
     std::string wordYes;
     std::string wordNo;
+    std::string wordOkay;
 
     // Compat menu
     std::string promptDeprecatedSetting;
     std::string promptDeprecatedSettingUnwritable;
-    std::string phraseYesAlways;
-    std::string phraseNoNever;
-    std::string phraseShowAgain;
-    std::string phraseDoNotShowAgain;
 };
 
 extern MainMenuContent g_mainMenu;

--- a/src/main/menu_main.h
+++ b/src/main/menu_main.h
@@ -134,6 +134,14 @@ struct MainMenuContent
 
     std::string wordYes;
     std::string wordNo;
+
+    // Compat menu
+    std::string promptDeprecatedSetting;
+    std::string promptDeprecatedSettingUnwritable;
+    std::string phraseYesAlways;
+    std::string phraseNoNever;
+    std::string phraseShowAgain;
+    std::string phraseDoNotShowAgain;
 };
 
 extern MainMenuContent g_mainMenu;

--- a/src/main/screen_prompt.cpp
+++ b/src/main/screen_prompt.cpp
@@ -1,0 +1,224 @@
+/*
+ * TheXTech - A platform game engine ported from old source code for VB6
+ *
+ * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
+ * Copyright (c) 2020-2023 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "globals.h"
+#include "config.h"
+#include "gfx.h"
+#include "sound.h"
+#include "graphics.h"
+#include "npc_id.h"
+#include "controls.h"
+#include "screen_fader.h"
+#include "game_main.h"
+
+#include "main/game_globals.h"
+
+#include <Logger/logger.h>
+
+#include "core/render.h"
+#include "main/screen_prompt.h"
+
+namespace PromptScreen
+{
+
+static int8_t s_cur_item = 0;
+static std::vector<std::string> s_options;
+static int s_longest_width = 0;
+
+int Run(const std::string& prompt, std::vector<std::string>&& options)
+{
+    // initialize text prompt
+    MessageText = prompt;
+    BuildUTF8CharMap(MessageText, MessageTextMap);
+
+    // initialize options
+    s_options = options;
+
+    // perform the pause loop
+    PauseGame(PauseCode::Prompt, 0);
+    MenuCursorCanMove = false;
+    MenuMouseRelease = false;
+    MouseRelease = false;
+    ScrollRelease = false;
+
+    for(int i = 1; i <= numPlayers; i++)
+    {
+        Player[i].UnStart = false;
+        Player[i].CanJump = false;
+        Player[i].CanAltJump = false;
+    }
+
+    return s_cur_item;
+}
+
+void Init()
+{
+    PlayMusic("wmusic12", 0);
+    PlaySoundMenu(SFX_Message);
+    s_cur_item = 0;
+    MenuCursorCanMove = false;
+
+    // set the longest width
+    s_longest_width = 0;
+
+    for(const std::string& label : s_options)
+    {
+        int item_width = SuperTextPixLen(label, 3);
+        if(item_width > s_longest_width)
+            s_longest_width = item_width;
+    }
+
+    int total_menu_height = s_options.size() * 36 - 18;
+    int total_menu_width = s_longest_width + 40;
+
+    // GBA bounds
+    if(total_menu_height > 200 || total_menu_width > 480)
+        pLogDebug("Prompt options don't fit within bounds (actual size %dx%d, bounds 480x200)", total_menu_width, total_menu_height);
+
+    // setup fader
+    if(g_config.EnableInterLevelFade)
+        g_levelScreenFader.setupFader(3, 65, 0, ScreenFader::S_CIRCLE, false, ScreenW / 2, ScreenH / 2, 0);
+}
+
+void Render()
+{
+    XRender::setTargetTexture();
+
+    // reset screen
+    XRender::clearBuffer();
+
+    // display background
+    vScreenX[1] = 0;
+    vScreenY[1] = 0;
+    vScreen[1].Left = 0; vScreen[1].Top = 0; vScreen[1].Width = ScreenW; vScreen[1].Height = ScreenH;
+    level[1] = newLoc(0, 0, ScreenW, ScreenH);
+    LevelREAL[1] = newLoc(0, 0, ScreenW, ScreenH);
+    Background2[1] = 1;
+    DrawBackground(1, 1);
+
+    // draw message box
+    DrawMessage(MessageTextMap);
+
+    // (from screen_pause.cpp)
+    // draw menu box
+
+    // height includes intermediate padding but no top/bottom padding
+    // width includes cursor on left and 20px padding on right for symmetry
+    int total_menu_height = s_options.size() * 36 - 18;
+    int total_menu_width = s_longest_width + 40;
+
+    // enforce GBA bounds (480x320)
+    if(total_menu_height > 320)
+        total_menu_height = 320;
+
+    if(total_menu_width > 480)
+        total_menu_width = 480;
+
+    int menu_box_height = total_menu_height + 32;
+
+    int menu_box_width = 160;
+    if(menu_box_width - total_menu_width < 32)
+        menu_box_width = total_menu_width + 32;
+
+    int menu_box_Y = ScreenH - 24 - menu_box_height;
+
+    int menu_left_X = ScreenW / 2 - total_menu_width / 2 + 20;
+    int menu_top_Y = menu_box_Y + menu_box_height / 2 - total_menu_height / 2;
+
+    XRender::renderRect(ScreenW / 2 - menu_box_width / 2, menu_box_Y, menu_box_width, menu_box_height, 0, 0, 0, 0.8);
+
+    for(size_t i = 0; i < s_options.size(); i++)
+        SuperPrint(s_options[i], 3, menu_left_X, menu_top_Y + (i * 36));
+
+    if(GFX.PCursor.inited)
+        XRender::renderTexture(menu_left_X - 20, menu_top_Y + (s_cur_item * 36), GFX.PCursor);
+    else
+        XRender::renderTextureFL(menu_left_X - 20, menu_top_Y + (s_cur_item * 36), GFX.MCursor[1].w, GFX.MCursor[1].h, GFX.MCursor[1], 0, 0, 90.0, nullptr, X_FLIP_NONE);
+
+
+    // draw screen fader and repaint
+
+    g_levelScreenFader.draw();
+
+    XRender::repaint();
+}
+
+bool Logic()
+{
+    bool upPressed = SharedControls.MenuUp;
+    bool downPressed = SharedControls.MenuDown;
+
+    bool menuDoPress = SharedControls.MenuDo || SharedControls.Pause;
+
+    for(int i = 0; i < maxLocalPlayers; i++)
+    {
+        Controls_t &c = Player[i+1].Controls;
+
+        menuDoPress |= c.Start || c.Jump;
+
+        upPressed |= c.Up;
+        downPressed |= c.Down;
+    }
+
+    if(!upPressed && !downPressed && !menuDoPress)
+        MenuCursorCanMove = true;
+
+    if(!MenuCursorCanMove)
+        return false;
+
+    if(upPressed)
+    {
+        PlaySoundMenu(SFX_Slide);
+        s_cur_item--;
+        if(s_cur_item < 0)
+            s_cur_item = s_options.size() - 1;
+        MenuCursorCanMove = false;
+        return false;
+    }
+
+    if(downPressed)
+    {
+        PlaySoundMenu(SFX_Slide);
+        s_cur_item++;
+        if(s_cur_item >= (int)s_options.size())
+            s_cur_item = 0;
+        MenuCursorCanMove = false;
+        return false;
+    }
+
+    if(menuDoPress && s_cur_item >= 0 && s_cur_item <= 3)
+    {
+        PlaySoundMenu(SFX_Do);
+
+        if(g_config.EnableInterLevelFade)
+            g_levelScreenFader.setupFader(3, 0, 65, ScreenFader::S_CIRCLE, false, ScreenW / 2, ScreenH / 2, 0);
+        else
+            g_levelScreenFader.setupFader(65, 0, 65, ScreenFader::S_CIRCLE, false, ScreenW / 2, ScreenH / 2, 0);
+
+        editorWaitForFade();
+        return true;
+    }
+
+    g_levelScreenFader.update();
+
+    return false;
+}
+
+}; // namespace PromptScreen

--- a/src/main/screen_prompt.cpp
+++ b/src/main/screen_prompt.cpp
@@ -158,6 +158,9 @@ void Render()
     g_levelScreenFader.draw();
 
     XRender::repaint();
+
+    if(TakeScreen)
+        ScreenShot();
 }
 
 bool Logic()

--- a/src/main/screen_prompt.h
+++ b/src/main/screen_prompt.h
@@ -1,0 +1,42 @@
+/*
+ * TheXTech - A platform game engine ported from old source code for VB6
+ *
+ * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
+ * Copyright (c) 2020-2023 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SCREEN_PROMPT_H
+
+#define SCREEN_PROMPT_H
+
+#include <string>
+#include <vector>
+
+namespace PromptScreen
+{
+
+int Run(const std::string& prompt, std::vector<std::string>&& options);
+
+void Init();
+
+void Render();
+
+// if returns true, user has exited the screen
+bool Logic();
+
+} // namespace PromptScreen
+
+#endif // SCREEN_PROMPT_H


### PR DESCRIPTION
Relatively small PR that:

* Adds a flexible user Prompt screen we can use for multiple purposes
* Adds renameKey and deleteKey methods to IniPorcessing
* Tracks in SelectWorld and SelectBattle whether the path is writable
* ~~Adds config preferences for compat autoconversion and for warning the user if autoconversion fails~~
* Uses all of these to ask the user and automatically convert `compat.ini` files whenever possible. Asks the user about an individual file only once per run.

All of the strings are stored in the main menu class and should be easy to integrate with localization when ready.

Review requested for:
* Logical functionality (do we like only prompting the user once per run? are the options I added good?)
* Asthetics of the Prompt screen
* Technical implementation (from @Wohlstand)
* Any other notes

Example for a file I marked as unwritable (via `chmod -w`):

<img src="https://user-images.githubusercontent.com/72112344/228275910-6a877df1-529f-4d08-b849-b695c953975a.gif" width="400" height="300">

**Updated** screenshots of the two screens:
<img src="https://user-images.githubusercontent.com/72112344/228971298-46903813-2cde-4f78-952f-d8fde9700606.png" width="400" height="300"> <img src="https://user-images.githubusercontent.com/72112344/228971307-38899e2d-60ac-4bea-a8c1-9609000e45d0.png" width="400" height="300">
