### PR TITLE
StdPicture refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,6 +550,7 @@ set(THEXTECH_SRC
     src/rand.cpp
     src/sorting.cpp
     src/screen_fader.cpp
+    src/std_picture.cpp
     src/npc/npc_hit.cpp
     src/npc/npc_kill.cpp
     src/npc/npc_update.cpp

--- a/src/control/touchscreen.cpp
+++ b/src/control/touchscreen.cpp
@@ -92,23 +92,20 @@ namespace Controls
 void TouchScreenGFX_t::loadImage(StdPicture& img, const std::string& fileName)
 {
     std::string imgPath = m_gfxPath + fileName;
-#ifdef __ANDROID__
 
+#ifdef __ANDROID__
     if(!Files::fileExists(imgPath)) // If not exists at assets, do load bundled
         imgPath = "buttons/" + fileName;
-
 #endif
 
     pLogDebug("Loading texture %s...", imgPath.c_str());
-    img = XRender::LoadPicture(imgPath);
+    XRender::LoadPicture(img, imgPath);
 
     if(!img.inited)
     {
         pLogWarning("Failed to load texture: %s...", imgPath.c_str());
         m_loadErrors++;
     }
-
-    m_loadedImages.push_back(&img);
 }
 
 TouchScreenGFX_t::TouchScreenGFX_t()
@@ -174,14 +171,6 @@ TouchScreenGFX_t::TouchScreenGFX_t()
     }
 
     m_success = true;
-}
-
-TouchScreenGFX_t::~TouchScreenGFX_t()
-{
-    for(StdPicture* p : m_loadedImages)
-        XRender::deleteTexture(*p);
-
-    m_loadedImages.clear();
 }
 
 /*------------------------------------------*\

--- a/src/control/touchscreen.h
+++ b/src/control/touchscreen.h
@@ -46,15 +46,14 @@ class InputMethod_TouchScreen;
 
 class TouchScreenGFX_t
 {
-    std::vector<StdPicture *> m_loadedImages;
     void loadImage(StdPicture &img, const std::string &fileName);
     std::string m_gfxPath;
     int m_loadErrors = 0;
+
 public:
     bool m_success = false;
 
     TouchScreenGFX_t();
-    ~TouchScreenGFX_t();
 
     enum
     {

--- a/src/core/16m/packloader.cpp
+++ b/src/core/16m/packloader.cpp
@@ -85,7 +85,7 @@ static inline void pfree(packindex_t pack)
     }
 }
 
-void setup(StdPicture& tex, const std::string& pack_path, uint32_t pack_offset)
+void setup(StdPicture_Sub& tex, const std::string& pack_path, uint32_t pack_offset)
 {
     auto it = s_pack_map.find(pack_path);
 
@@ -116,7 +116,7 @@ void decref(uint8_t pack)
         pfree(pack);
 }
 
-FILE* getf(const StdPicture& tex, int index)
+FILE* getf(const StdPicture_Sub& tex, int index)
 {
     // XMsgBox::errorMsgBox("was called", "open");
 
@@ -146,8 +146,8 @@ FILE* getf(const StdPicture& tex, int index)
             int prev_logical_w = tex.w;
             int prev_logical_h = index * 2048;
 
-            prev_logical_w >>= (1 + (tex.d.flags & 15));
-            prev_logical_h >>= (1 + (tex.d.flags & 15));
+            prev_logical_w >>= (1 + (tex.l.flags & 15));
+            prev_logical_h >>= (1 + (tex.l.flags & 15));
 
             // 4bpp
             offset += prev_logical_w * prev_logical_h / 2;
@@ -165,7 +165,7 @@ FILE* getf(const StdPicture& tex, int index)
     return nullptr;
 }
 
-void finalizef(FILE* f, const StdPicture& tex)
+void finalizef(FILE* f, const StdPicture_Sub& tex)
 {
     if(tex.l.pack == PACK_NONE)
         fclose(f);

--- a/src/core/16m/packloader.h
+++ b/src/core/16m/packloader.h
@@ -26,19 +26,19 @@
 #include <string>
 #include <cstdio>
 
-struct StdPicture;
+struct StdPicture_Sub;
 
 namespace PackLoader
 {
     using packindex_t = uint8_t;
     constexpr packindex_t PACK_NONE = -1;
 
-    void setup(StdPicture& tex, const std::string& pack_path, uint32_t pack_offset);
+    void setup(StdPicture_Sub& tex, const std::string& pack_path, uint32_t pack_offset);
     void incref(packindex_t pack);
     void decref(packindex_t pack);
 
-    FILE* getf(const StdPicture& tex, int index);
-    void finalizef(FILE* f, const StdPicture& tex);
+    FILE* getf(const StdPicture_Sub& tex, int index);
+    void finalizef(FILE* f, const StdPicture_Sub& tex);
 
     class packref_t
     {

--- a/src/core/16m/picture_data_16m.h
+++ b/src/core/16m/picture_data_16m.h
@@ -29,6 +29,8 @@
 #define X_IMG_EXT ".dsg"
 #define X_NO_PNG_GIF
 
+struct StdPicture;
+
 /*!
  * \brief Platform specific picture data. Fields should not be used directly
  */
@@ -37,11 +39,18 @@ struct StdPictureData
 
     bool attempted_load = false;
 
-    int flags = 0;
-
     int texture[3] = {0, 0, 0};
     uint16_t tex_w[3] = {0, 0, 0};
     uint16_t tex_h[3] = {0, 0, 0};
+
+    //! The previous texture in the render chain (nullptr if this is the tail or unloaded)
+    StdPicture* last_texture = nullptr;
+
+    //! The next texture in the render chain (nullptr if this is the head or unloaded)
+    StdPicture* next_texture = nullptr;
+
+    //! The last frame that the texture was rendered (not accessed if not in the render chain)
+    uint32_t last_draw_frame = 0;
 
     inline bool reallyHasTexture()
     {

--- a/src/core/16m/picture_load_16m.h
+++ b/src/core/16m/picture_load_16m.h
@@ -27,8 +27,6 @@
 
 #include "core/16m/packloader.h"
 
-struct StdPicture;
-
 /*!
  * \brief Generic image loading store.
  *
@@ -39,18 +37,12 @@ struct StdPictureLoad
     //! Is this a lazy-loaded texture?
     bool lazyLoaded = false;
 
+    //! Generic information about texture type
+    int flags = 0;
+
     //! Pack index (PACK_NONE if not a pack)
     PackLoader::packref_t pack;
     uint32_t pack_offset = 0;
-
-    //! The previous texture in the render chain (nullptr if this is the tail or unloaded)
-    StdPicture* last_texture = nullptr;
-
-    //! The next texture in the render chain (nullptr if this is the head or unloaded)
-    StdPicture* next_texture = nullptr;
-
-    //! The last frame that the texture was rendered (not accessed if not in the render chain)
-    uint32_t last_draw_frame;
 
     //! Path to find image (could be a pack)
     std::string path = "";

--- a/src/core/3ds/picture_data_3ds.h
+++ b/src/core/3ds/picture_data_3ds.h
@@ -28,14 +28,24 @@
 
 #define X_IMG_EXT ".t3x"
 
+struct StdPicture;
+
 /*!
  * \brief Platform specific picture data. Fields should not be used directly
  */
 struct StdPictureData
 {
 
+    //! The previous texture in the render chain (nullptr if this is the tail or unloaded)
+    StdPicture* last_texture = nullptr;
+
+    //! The next texture in the render chain (nullptr if this is the head or unloaded)
+    StdPicture* next_texture = nullptr;
+
+    //! The last frame that the texture was rendered (not accessed if not in the render chain)
     uint32_t last_draw_frame = 0;
 
+    //! Loaded texture data
     C2D_SpriteSheet texture[6] = {nullptr};
     C2D_Image image[6];
 

--- a/src/core/3ds/picture_load_3ds.h
+++ b/src/core/3ds/picture_load_3ds.h
@@ -20,12 +20,10 @@
 
 #pragma once
 
-#ifndef STD_PICTURE_LOAD_H
-#define STD_PICTURE_LOAD_H
+#ifndef STD_PICTURE_LOAD_3DS_H
+#define STD_PICTURE_LOAD_3DS_H
 
 #include <string>
-
-struct StdPicture;
 
 /*!
  * \brief Generic image loading store.
@@ -37,24 +35,20 @@ struct StdPictureLoad
     //! Is this a lazy-loaded texture?
     bool lazyLoaded = false;
 
-    //! The previous texture in the render chain (nullptr if this is the tail or unloaded)
-    StdPicture* last_texture = nullptr;
-
-    //! The next texture in the render chain (nullptr if this is the head or unloaded)
-    StdPicture* next_texture = nullptr;
-
-    //! The last frame that the texture was rendered (not accessed if not in the render chain)
-    uint32_t last_draw_frame;
-
     //! Path to find image
     std::string path = "";
+
+    //! Path to find mask (if any)
     std::string mask_path = "";
 
     // Transparent color for BMP and JPEG
     bool     colorKey = false;
     uint8_t  keyRgb[3] = {0 /*R*/, 0 /*G*/, 0 /*B*/};
 
-    inline void clear() {}
+    inline bool canLoad() const
+    {
+        return lazyLoaded;
+    }
 };
 
-#endif // #ifndef STD_PICTURE_LOAD_H
+#endif // #ifndef STD_PICTURE_LOAD_3DS_H

--- a/src/core/3ds/render_3ds.cpp
+++ b/src/core/3ds/render_3ds.cpp
@@ -168,8 +168,13 @@ void s_ensureInFrame()
 
 void s_clearAllTextures()
 {
-    for(StdPicture* p = g_render_chain_tail; p != nullptr; p = p->l.next_texture)
-        deleteTexture(*p);
+    for(StdPicture* p = g_render_chain_tail; p != nullptr;)
+    {
+        StdPicture* last_p = p;
+        p = p->d.next_texture;
+
+        unloadTexture(*last_p);
+    }
 }
 
 FIBITMAP* robust_FILoad(const std::string& path, const std::string& maskPath, int* orig_w = nullptr, int* orig_h = nullptr)
@@ -312,8 +317,11 @@ static C2D_Image s_RawToSwizzledRGBA(const uint8_t* src, uint32_t wsrc, uint32_t
     return img;
 }
 
-void s_loadTexture(StdPicture& target, void* data, int width, int height, int pitch, bool mask, bool downscale = true)
+void s_loadTexture(StdPicture& target, void* data, int width, int height, int pitch, bool mask)
 {
+    // downscale if logical width matches the actual width of the texture, otherwise don't
+    bool downscale = (width >= target.w);
+
     int max_size = (downscale ? 2048 : 1024);
 
     pLogDebug("Loading %s %d, w %d h %d p %d", target.l.path.c_str(), (int)mask, width, height, pitch);
@@ -739,109 +747,10 @@ void minport_ApplyViewport()
     }
 }
 
-StdPicture LoadPicture(const std::string& path, const std::string& maskPath, const std::string& maskFallbackPath, bool downscale)
+void lazyLoadPictureFromList(StdPicture_Sub& target, FILE* f, const std::string& dir)
 {
-    (void)maskPath;
-    (void)maskFallbackPath;
-
-    StdPicture target;
-    C2D_SpriteSheet sourceImage;
-
     if(!GameIsActive)
-        return target; // do nothing when game is closed
-
-    target.inited = false;
-    target.l.path = path;
-
-    if(target.l.path.empty())
-        return target;
-
-    if(maskPath.empty() && !maskFallbackPath.empty() && Files::fileExists(maskFallbackPath))
-        target.l.mask_path = maskFallbackPath;
-    else
-        target.l.mask_path = maskPath;
-
-    target.inited = true;
-
-    // must be true to make it safe for the renderer to lazy-unload
-    target.l.lazyLoaded = true;
-
-    if(Files::hasSuffix(target.l.path, ".t3x"))
-    {
-        sourceImage = C2D_SpriteSheetLoad(target.l.path.c_str());
-
-        if(sourceImage)
-        {
-            s_loadTexture(target, sourceImage);
-            s_num_textures_loaded ++;
-        }
-    }
-    else
-    {
-        FIBITMAP* FI_tex = nullptr;
-        FIBITMAP* FI_mask = nullptr;
-
-        if(Files::hasSuffix(target.l.mask_path, "m.gif"))
-        {
-            FI_tex = robust_FILoad(target.l.path, "", &target.w, &target.h);
-
-            if(FI_tex)
-                FI_mask = robust_FILoad(target.l.mask_path, "");
-        }
-        else
-        {
-            FI_tex = robust_FILoad(target.l.path, target.l.mask_path, &target.w, &target.h);
-        }
-
-        if(!downscale)
-        {
-            target.w *= 2;
-            target.h *= 2;
-        }
-
-        if(!FI_tex)
-        {
-            pLogWarning("Permanently failed to load %s", target.l.path.c_str());
-            pLogWarning("Error: %d (%s)", errno, strerror(errno));
-        }
-        else
-        {
-            s_loadTexture(target, FreeImage_GetBits(FI_tex), FreeImage_GetWidth(FI_tex), FreeImage_GetHeight(FI_tex), FreeImage_GetPitch(FI_tex), false, downscale);
-            FreeImage_Unload(FI_tex);
-
-            if(FI_mask)
-            {
-                s_loadTexture(target, FreeImage_GetBits(FI_mask), FreeImage_GetWidth(FI_mask), FreeImage_GetHeight(FI_mask), FreeImage_GetPitch(FI_mask), true, downscale);
-                FreeImage_Unload(FI_mask);
-            }
-        }
-    }
-
-    if(!target.d.hasTexture())
-    {
-        pLogWarning("FAILED TO LOAD!!! %s", path.c_str());
-        target.inited = false;
-    }
-
-    return target;
-}
-
-StdPicture LoadPicture(const std::string& path, const std::string& maskPath, const std::string& maskFallbackPath)
-{
-    return LoadPicture(path, maskPath, maskFallbackPath, true);
-}
-
-StdPicture LoadPicture_1x(const std::string& path, const std::string& maskPath, const std::string& maskFallbackPath)
-{
-    return LoadPicture(path, maskPath, maskFallbackPath, false);
-}
-
-StdPicture lazyLoadPictureFromList(FILE* f, const std::string& dir)
-{
-    StdPicture target;
-
-    if(!GameIsActive)
-        return target; // do nothing when game is closed
+        return; // do nothing when game is closed
 
     int length;
 
@@ -850,13 +759,13 @@ StdPicture lazyLoadPictureFromList(FILE* f, const std::string& dir)
     if(fscanf(f, "%255[^\n]%n%*[^\n]\n", filename, &length) != 1)
     {
         pLogWarning("Could not load image path from load list");
-        return target;
+        return;
     }
 
     if(length == 255)
     {
         pLogWarning("Image path %s was truncated in load list", filename);
-        return target;
+        return;
     }
 
     target.inited = true;
@@ -870,7 +779,7 @@ StdPicture lazyLoadPictureFromList(FILE* f, const std::string& dir)
     {
         pLogWarning("Could not load image %s dimensions from load list", filename);
         target.inited = false;
-        return target;
+        return;
     }
 
     // pLogDebug("Successfully loaded %s (%d %d)", target.l.path.c_str(), w, h);
@@ -878,22 +787,20 @@ StdPicture lazyLoadPictureFromList(FILE* f, const std::string& dir)
     target.w = w;
     target.h = h;
 
-    return target;
+    return;
 }
 
 
-StdPicture lazyLoadPicture(const std::string& path, const std::string& maskPath, const std::string& maskFallbackPath)
+void lazyLoadPicture(StdPicture_Sub& target, const std::string& path, int scaleFactor, const std::string& maskPath, const std::string& maskFallbackPath)
 {
-    StdPicture target;
-
     if(!GameIsActive)
-        return target; // do nothing when game is closed
+        return; // do nothing when game is closed
 
     target.inited = false;
     target.l.path = path;
 
     if(target.l.path.empty())
-        return target;
+        return;
 
     if(maskPath.empty() && !maskFallbackPath.empty() && Files::fileExists(maskFallbackPath))
         target.l.mask_path = maskFallbackPath;
@@ -924,13 +831,11 @@ StdPicture lazyLoadPicture(const std::string& path, const std::string& maskPath,
             if(fclose(fs))
                 pLogWarning("lazyLoadPicture: Couldn't close file.");
         }
-        // lazy load and unload to read dimensions if it doesn't exist.
-        // unload is essential because lazy load would save the address incorrectly.
         else
         {
-            pLogWarning("lazyLoadPicture: Couldn't open size file.");
-            lazyLoad(target);
-            lazyUnLoad(target);
+            pLogWarning("lazyLoadPicture: Couldn't open size file. Giving up.");
+            target.inited = false;
+            return;
         }
     }
     else
@@ -951,12 +856,10 @@ StdPicture lazyLoadPicture(const std::string& path, const std::string& maskPath,
         }
         else
         {
-            target.w = tSize.w();
-            target.h = tSize.h();
+            target.w = tSize.w() * scaleFactor;
+            target.h = tSize.h() * scaleFactor;
         }
     }
-
-    return target;
 }
 
 static C2D_SpriteSheet s_tryHardToLoadC2D_SpriteSheet(const char* path)
@@ -1094,44 +997,18 @@ void lazyPreLoad(StdPicture& target)
     lazyLoad(target);
 }
 
-void lazyUnLoad(StdPicture& target)
-{
-    if(!target.inited || !target.l.lazyLoaded || !target.d.hasTexture())
-        return;
-
-    deleteTexture(target, true);
-}
-
 void loadTexture(StdPicture& target, uint32_t width, uint32_t height, uint8_t *RGBApixels, uint32_t pitch)
 {
-    s_loadTexture(target, RGBApixels, width, height, pitch, false, true);
+    s_loadTexture(target, RGBApixels, width, height, pitch, false);
     target.inited = true;
     target.l.lazyLoaded = false;
-    target.w = width;
-    target.h = height;
-//    target.frame_w = width;
-//    target.frame_h = height;
 }
 
-void loadTexture_1x(StdPicture& target, uint32_t width, uint32_t height, uint8_t *RGBApixels, uint32_t pitch)
+void unloadTexture(StdPicture& tx)
 {
-    s_loadTexture(target, RGBApixels, width, height, pitch, false, false);
-    target.inited = true;
-    target.l.lazyLoaded = false;
-    target.w = width * 2;
-    target.h = height * 2;
-//    target.frame_w = width * 2;
-//    target.frame_h = height * 2;
-}
-
-void deleteTexture(StdPicture& tx, bool lazyUnload)
-{
-    if(!tx.inited)
-        return;
-
     minport_unlinkTexture(&tx);
 
-    if(tx.d.texture[0])
+    if(tx.d.hasTexture())
         s_num_textures_loaded --;
 
     for(int i = 0; i < 6; i++)
@@ -1151,15 +1028,8 @@ void deleteTexture(StdPicture& tx, bool lazyUnload)
         tx.d.texture[i] = nullptr;
     }
 
-    if(!lazyUnload)
-    {
-        tx.inited = false;
-        tx.l.lazyLoaded = false;
-        tx.w = 0;
-        tx.h = 0;
-//        tx.frame_w = 0;
-//        tx.frame_h = 0;
-    }
+    if(!tx.l.canLoad())
+        static_cast<StdPicture_Sub&>(tx) = StdPicture_Sub();
 }
 
 void minport_RenderBoxFilled(int x1, int y1, int x2, int y2, uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha)

--- a/src/core/base/picture_load_base.h
+++ b/src/core/base/picture_load_base.h
@@ -1,0 +1,61 @@
+/*
+ * TheXTech - A platform game engine ported from old source code for VB6
+ *
+ * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
+ * Copyright (c) 2020-2023 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifndef STD_PICTURE_LOAD_BASE_H
+#define STD_PICTURE_LOAD_BASE_H
+
+#define PICTURE_LOAD_NORMAL
+
+#include <cstdint>
+#include <vector>
+
+/*!
+ * \brief Generic image loading store.
+ *
+ * If needed somehing unusual, please define alternative structure instead of this
+ */
+struct StdPictureLoad
+{
+    //! Is this a lazy-loaded texture?
+    bool lazyLoaded = false;
+
+    //! Original compressed data of the front image
+    std::vector<char> raw;
+    //! Original compressed data of the mask image (if presented)
+    std::vector<char> rawMask;
+    //! Was mask restored from the PNG at default graphics?
+    bool isMaskPng = false;
+
+    // Transparent color for BMP and JPEG
+    bool     colorKey = false;
+    uint8_t  keyRgb[3] = {0 /*R*/, 0 /*G*/, 0 /*B*/};
+
+    /*!
+     * \brief Can a picture be reloaded from this load struct?
+     */
+    inline bool canLoad() const
+    {
+        return lazyLoaded;
+    }
+};
+
+#endif // STD_PICTURE_LOAD_BASE_H

--- a/src/core/base/render_base.cpp
+++ b/src/core/base/render_base.cpp
@@ -148,224 +148,6 @@ void AbstractRender_t::close()
 #endif
 }
 
-StdPicture AbstractRender_t::LoadPicture(const std::string &path,
-                                         const std::string &maskPath,
-                                         const std::string &maskFallbackPath)
-{
-    StdPicture target;
-    FIBITMAP *sourceImage;
-    FIBITMAP *maskImage = nullptr;
-    bool useMask = true;
-
-    if(!GameIsActive)
-        return target; // do nothing when game is closed
-
-    if(path.empty())
-        return target;
-
-#ifdef DEBUG_BUILD
-    target.origPath = path;
-#endif
-
-    sourceImage = GraphicsHelps::loadImage(path);
-
-    // Don't load mask if PNG image is used
-    if(Files::hasSuffix(path, ".png"))
-        useMask = false;
-
-    if(!sourceImage)
-    {
-        pLogWarning("Error loading of image file:\n"
-                    "%s\n"
-                    "Reason: %s.",
-                    path.c_str(),
-                    (Files::fileExists(path) ? "wrong image format" : "file not exist"));
-        // target = g_renderer->getDummyTexture();
-        return target;
-    }
-
-#ifdef DEBUG_BUILD
-    ElapsedTimer totalTime;
-    ElapsedTimer maskMergingTime;
-    ElapsedTimer bindingTime;
-    ElapsedTimer unloadTime;
-    totalTime.start();
-    int64_t maskElapsed = 0;
-    int64_t bindElapsed = 0;
-    int64_t unloadElapsed = 0;
-#endif
-
-    //Apply Alpha mask
-    if(useMask && !maskPath.empty() && Files::fileExists(maskPath))
-    {
-        if(g_render->textureMaskSupported())
-        {
-            maskImage = GraphicsHelps::loadImage(maskPath);
-            FreeImage_FlipVertical(maskImage);
-        }
-        else
-        {
-#ifdef DEBUG_BUILD
-            maskMergingTime.start();
-#endif
-            GraphicsHelps::mergeWithMask(sourceImage, maskPath);
-#ifdef DEBUG_BUILD
-            maskElapsed = maskMergingTime.nanoelapsed();
-#endif
-        }
-    }
-    else if(useMask && !maskFallbackPath.empty())
-    {
-#ifdef DEBUG_BUILD
-        maskMergingTime.start();
-#endif
-        GraphicsHelps::mergeWithMask(sourceImage, "", maskFallbackPath);
-#ifdef DEBUG_BUILD
-        maskElapsed = maskMergingTime.nanoelapsed();
-#endif
-    }
-
-    uint32_t w = static_cast<uint32_t>(FreeImage_GetWidth(sourceImage));
-    uint32_t h = static_cast<uint32_t>(FreeImage_GetHeight(sourceImage));
-    uint32_t pitch = static_cast<uint32_t>(FreeImage_GetPitch(sourceImage));
-
-    if((w == 0) || (h == 0))
-    {
-        FreeImage_Unload(sourceImage);
-        pLogWarning("Error loading of image file:\n"
-                    "%s\n"
-                    "Reason: %s.",
-                    path.c_str(),
-                    "Zero image size!");
-        //target = g_renderer->getDummyTexture();
-        return target;
-    }
-
-#ifdef DEBUG_BUILD
-    bindingTime.start();
-#endif
-
-    RGBQUAD upperColor;
-    FreeImage_GetPixelColor(sourceImage, 0, 0, &upperColor);
-    target.ColorUpper.r = upperColor.rgbRed / 255.0f;
-    target.ColorUpper.g = upperColor.rgbGreen / 255.0f;
-    target.ColorUpper.b = upperColor.rgbBlue / 255.0f;
-
-    RGBQUAD lowerColor;
-    FreeImage_GetPixelColor(sourceImage, 0, static_cast<unsigned int>(h - 1), &lowerColor);
-    target.ColorLower.r = lowerColor.rgbRed / 255.0f;
-    target.ColorLower.b = lowerColor.rgbBlue / 255.0f;
-    target.ColorLower.g = lowerColor.rgbGreen / 255.0f;
-
-    FreeImage_FlipVertical(sourceImage);
-    target.w = static_cast<int>(w);
-    target.h = static_cast<int>(h);
-//    target.frame_w = static_cast<int>(w);
-//    target.frame_h = static_cast<int>(h);
-
-    bool wLimitExcited = m_maxTextureWidth > 0 && w > Uint32(m_maxTextureWidth);
-    bool hLimitExcited = m_maxTextureHeight > 0 && h > Uint32(m_maxTextureHeight);
-
-    if(wLimitExcited || hLimitExcited)
-    {
-        target.l.w_orig = int(w);
-        target.l.h_orig = int(h);
-
-        // WORKAROUND: down-scale too big textures
-        if(wLimitExcited)
-            w = Uint32(m_maxTextureWidth);
-        if(hLimitExcited)
-            h = Uint32(m_maxTextureHeight);
-
-        pLogWarning("Texture [%s] (%dx%d) is too big for a given hardware limit. "
-                    "Shrinking texture to %dx%d, quality may be distorted!",
-                    path.c_str(),
-                    target.l.w_orig, target.l.h_orig,
-                    w, h);
-
-        FIBITMAP *d = FreeImage_Rescale(sourceImage, int(w), int(h), FILTER_BOX);
-        if(d)
-        {
-            GraphicsHelps::closeImage(sourceImage);
-            sourceImage = d;
-        }
-
-        target.l.w_scale = float(w) / float(target.l.w_orig);
-        target.l.h_scale = float(h) / float(target.l.h_orig);
-        pitch = FreeImage_GetPitch(d);
-
-        if(maskImage)
-        {
-            d = FreeImage_Rescale(maskImage, int(w), int(h), FILTER_BOX);
-            if(d)
-            {
-                GraphicsHelps::closeImage(maskImage);
-                maskImage = d;
-            }
-        }
-    }
-
-    uint8_t *textura = reinterpret_cast<uint8_t *>(FreeImage_GetBits(sourceImage));
-    g_render->loadTexture(target, w, h, textura, pitch);
-
-#ifdef DEBUG_BUILD
-    bindElapsed = bindingTime.nanoelapsed();
-    unloadTime.start();
-#endif
-    //SDL_FreeSurface(sourceImage);
-    GraphicsHelps::closeImage(sourceImage);
-
-#ifdef DEBUG_BUILD
-    unloadElapsed = unloadTime.nanoelapsed();
-#endif
-
-    if(maskImage)
-    {
-        uint32_t w_mask = static_cast<uint32_t>(FreeImage_GetWidth(maskImage));
-        uint32_t h_mask = static_cast<uint32_t>(FreeImage_GetHeight(maskImage));
-        uint32_t pitch_mask = static_cast<uint32_t>(FreeImage_GetPitch(maskImage));
-
-        textura = reinterpret_cast<uint8_t *>(FreeImage_GetBits(maskImage));
-        g_render->loadTextureMask(target, w_mask, h_mask, textura, pitch_mask, w, h);
-        GraphicsHelps::closeImage(maskImage);
-    }
-
-#ifdef DEBUG_BUILD
-    pLogDebug("Mask merging of %s passed in %d nanoseconds", path.c_str(), static_cast<int>(maskElapsed));
-    pLogDebug("Binding time of %s passed in %d nanoseconds", path.c_str(), static_cast<int>(bindElapsed));
-    pLogDebug("Unload time of %s passed in %d nanoseconds", path.c_str(), static_cast<int>(unloadElapsed));
-    pLogDebug("Total Loading of texture %s passed in %d nanoseconds (%dx%d)",
-              path.c_str(),
-              static_cast<int>(totalTime.nanoelapsed()),
-              static_cast<int>(w),
-              static_cast<int>(h));
-#endif
-
-    return target;
-}
-
-StdPicture AbstractRender_t::LoadPicture_1x(const std::string &path,
-                                         const std::string &maskPath,
-                                         const std::string &maskFallbackPath)
-{
-    StdPicture target = LoadPicture(path, maskPath, maskFallbackPath);
-
-    if(target.inited)
-    {
-        target.l.w_orig = target.w;
-        target.l.h_orig = target.h;
-        target.l.w_scale /= 2;
-        target.l.h_scale /= 2;
-
-        target.w *= 2;
-        target.h *= 2;
-//        target.frame_w *= 2;
-//        target.frame_h *= 2;
-    }
-
-    return target;
-}
-
 void AbstractRender_t::loadTextureMask(StdPicture &target,
                          uint32_t mask_width,
                          uint32_t mask_height,
@@ -388,27 +170,6 @@ void AbstractRender_t::loadTextureMask(StdPicture &target,
 bool AbstractRender_t::textureMaskSupported()
 {
     return false;
-}
-
-void AbstractRender_t::loadTexture_1x(StdPicture &target,
-                         uint32_t width,
-                         uint32_t height,
-                         uint8_t *RGBApixels,
-                         uint32_t pitch)
-{
-    loadTexture(target, width, height, RGBApixels, pitch);
-//    if(target.inited)
-//    {
-//        target.l.w_orig = target.w;
-//        target.l.h_orig = target.h;
-//        target.l.w_scale /= 2;
-//        target.l.h_scale /= 2;
-
-//        target.w *= 2;
-//        target.h *= 2;
-//        target.frame_w *= 2;
-//        target.frame_h *= 2;
-//    }
 }
 
 static void dumpFullFile(std::vector<char> &dst, const std::string &path)
@@ -435,19 +196,20 @@ static void dumpFullFile(std::vector<char> &dst, const std::string &path)
     SDL_RWclose(f);
 }
 
-StdPicture AbstractRender_t::lazyLoadPicture(const std::string &path,
-                                             const std::string &maskPath,
-                                             const std::string &maskFallbackPath)
+void AbstractRender_t::lazyLoadPicture(StdPicture_Sub& target,
+                                       const std::string &path,
+                                       int scaleFactor,
+                                       const std::string &maskPath,
+                                       const std::string &maskFallbackPath)
 {
-    StdPicture target;
     PGE_Size tSize;
     bool useMask = true;
 
     if(!GameIsActive)
-        return target; // do nothing when game is closed
+        return; // do nothing when game is closed
 
     if(path.empty())
-        return target;
+        return;
 
 #ifdef DEBUG_BUILD
     target.origPath = path;
@@ -465,11 +227,11 @@ StdPicture AbstractRender_t::lazyLoadPicture(const std::string &path,
                     path.c_str(),
                     (Files::fileExists(path) ? "wrong image format" : "file not exist"));
         // target = g_renderer->getDummyTexture();
-        return target;
+        return;
     }
 
-    target.w = tSize.w();
-    target.h = tSize.h();
+    target.w = tSize.w() * scaleFactor;
+    target.h = tSize.h() * scaleFactor;
 
     dumpFullFile(target.l.raw, path);
 
@@ -487,9 +249,8 @@ StdPicture AbstractRender_t::lazyLoadPicture(const std::string &path,
 
     target.inited = true;
     target.l.lazyLoaded = true;
-    target.d.clear();
 
-    return target;
+    return;
 }
 
 void AbstractRender_t::setTransparentColor(StdPicture& target, uint32_t rgb)
@@ -566,10 +327,10 @@ void AbstractRender_t::lazyLoad(StdPicture &target)
     }
 
     FreeImage_FlipVertical(sourceImage);
-    target.w = static_cast<int>(w);
-    target.h = static_cast<int>(h);
-//    target.frame_w = static_cast<int>(w);
-//    target.frame_h = static_cast<int>(h);
+
+    // don't touch texture info, that was set on original load
+    // target.w = static_cast<int>(w);
+    // target.h = static_cast<int>(h);
 
     bool shrink2x;
     switch(g_videoSettings.scaleDownTextures)
@@ -590,8 +351,6 @@ void AbstractRender_t::lazyLoad(StdPicture &target)
 
     if(shrink2x)
     {
-        target.l.w_orig = int(w);
-        target.l.h_orig = int(h);
         w /= 2;
         h /= 2;
     }
@@ -601,12 +360,6 @@ void AbstractRender_t::lazyLoad(StdPicture &target)
 
     if(wLimitExcited || hLimitExcited || shrink2x)
     {
-        if(!shrink2x)
-        {
-            target.l.w_orig = int(w);
-            target.l.h_orig = int(h);
-        }
-
         // WORKAROUND: down-scale too big textures
         if(wLimitExcited)
             w = Uint32(m_maxTextureWidth);
@@ -626,11 +379,8 @@ void AbstractRender_t::lazyLoad(StdPicture &target)
         {
             GraphicsHelps::closeImage(sourceImage);
             sourceImage = d;
+            pitch = FreeImage_GetPitch(d);
         }
-
-        target.l.w_scale = float(w) / float(target.l.w_orig);
-        target.l.h_scale = float(h) / float(target.l.h_orig);
-        pitch = FreeImage_GetPitch(d);
 
         if(maskImage)
         {
@@ -661,13 +411,6 @@ void AbstractRender_t::lazyLoad(StdPicture &target)
 
         GraphicsHelps::closeImage(maskImage);
     }
-}
-
-void AbstractRender_t::lazyUnLoad(StdPicture &target)
-{
-    if(!target.inited || !target.l.lazyLoaded || !target.d.hasTexture())
-        return;
-    XRender::deleteTexture(target, true);
 }
 
 void AbstractRender_t::lazyPreLoad(StdPicture &target)

--- a/src/core/base/render_base.h
+++ b/src/core/base/render_base.h
@@ -164,17 +164,17 @@ public:
 
     // Load and unload textures
 
-    static StdPicture LoadPicture(const std::string &path,
-                                  const std::string &maskPath = std::string(),
-                                  const std::string &maskFallbackPath = std::string());
+    static void LoadPicture(StdPicture& target,
+                            const std::string &path,
+                            int scaleFactor = 1,
+                            const std::string &maskPath = std::string(),
+                            const std::string &maskFallbackPath = std::string());
 
-    static StdPicture LoadPicture_1x(const std::string &path,
-                                  const std::string &maskPath = std::string(),
-                                  const std::string &maskFallbackPath = std::string());
-
-    static StdPicture lazyLoadPicture(const std::string &path,
-                                      const std::string &maskPath = std::string(),
-                                      const std::string &maskFallbackPath = std::string());
+    static void lazyLoadPicture(StdPicture_Sub& target,
+                                const std::string &path,
+                                int scaleFactor = 1,
+                                const std::string &maskPath = std::string(),
+                                const std::string &maskFallbackPath = std::string());
 
     static void setTransparentColor(StdPicture &target, uint32_t rgb);
 
@@ -183,6 +183,8 @@ public:
                              uint32_t height,
                              uint8_t *RGBApixels,
                              uint32_t pitch) = 0;
+
+    virtual void unloadTexture(StdPicture &tx) = 0;
 
     virtual void loadTextureMask(StdPicture &target,
                              uint32_t mask_width,
@@ -194,20 +196,12 @@ public:
 
     virtual bool textureMaskSupported();
 
-    void loadTexture_1x(StdPicture &target,
-                             uint32_t width,
-                             uint32_t height,
-                             uint8_t *RGBApixels,
-                             uint32_t pitch);
-
     static void lazyLoad(StdPicture &target);
-    static void lazyUnLoad(StdPicture &target);
     static void lazyPreLoad(StdPicture &target);
 
     static size_t lazyLoadedBytes();
     static void lazyLoadedBytesReset();
 
-    virtual void deleteTexture(StdPicture &tx, bool lazyUnload = false) = 0;
     virtual void clearAllTextures() = 0;
 
     virtual void clearBuffer() = 0;

--- a/src/core/minport/render_minport_shared.cpp
+++ b/src/core/minport/render_minport_shared.cpp
@@ -294,51 +294,17 @@ void minport_initFrame()
 
     int num_unloaded = 0;
 
-#if 0
-    // future code for when/if TffFont can recover from its textures being de-inited
-
-    StdPicture* cur = g_render_chain_tail;
-    while(cur && g_current_frame - cur->l.last_draw_frame > g_always_unload_after)
-    {
-        StdPicture* next = cur->l.next_texture;
-
-        if(cur->l.lazyLoaded)
-        {
-            // will internally invoke deleteTexture, which invokes minport_unlinkTexture if written properly
-            lazyUnLoad(*cur);
-
-            if(g_render_chain_tail == cur || cur->l.next_texture)
-            {
-                pLogCritical("Failed to unlink texture during lazyUnLoad! Manually unlinking texture. VRAM may be leaked.");
-                minport_unlinkTexture(cur);
-            }
-
-            num_unloaded++;
-        }
-
-        cur = next;
-    }
-#endif
-
-    while(g_render_chain_tail && g_current_frame - g_render_chain_tail->l.last_draw_frame > g_always_unload_after)
+    while(g_render_chain_tail && g_current_frame - g_render_chain_tail->d.last_draw_frame > g_always_unload_after)
     {
         StdPicture* last_tail = g_render_chain_tail;
 
-        // will internally invoke deleteTexture, which invokes minport_unlinkTexture if written properly
-        if(last_tail->l.lazyLoaded)
-        {
-            lazyUnLoad(*last_tail);
-            num_unloaded++;
-        }
-        else
-        {
-            // keeps us from freeing it, because it's not valid to! (can't be re-loaded)
-            minport_unlinkTexture(last_tail);
-        }
+        // will internally invoke minport_unlinkTexture if written properly
+        unloadTexture(*last_tail);
+        num_unloaded++;
 
         if(g_render_chain_tail == last_tail)
         {
-            pLogCritical("Failed to unlink texture during lazyUnLoad! Manually unlinking texture. VRAM may be leaked.");
+            pLogCritical("Failed to unlink texture during unloadTexture! Manually unlinking texture. VRAM may be leaked.");
             minport_unlinkTexture(g_render_chain_tail);
         }
     }
@@ -354,20 +320,20 @@ void minport_unlinkTexture(StdPicture* tx)
 {
     // redirect the tail and head
     if(tx == g_render_chain_tail)
-        g_render_chain_tail = tx->l.next_texture;
+        g_render_chain_tail = tx->d.next_texture;
 
     if(tx == g_render_chain_head)
-        g_render_chain_head = tx->l.last_texture;
+        g_render_chain_head = tx->d.last_texture;
 
     // unlink from its context
-    if(tx->l.last_texture)
-        tx->l.last_texture->l.next_texture = tx->l.next_texture;
+    if(tx->d.last_texture)
+        tx->d.last_texture->d.next_texture = tx->d.next_texture;
 
-    if(tx->l.next_texture)
-        tx->l.next_texture->l.last_texture = tx->l.last_texture;
+    if(tx->d.next_texture)
+        tx->d.next_texture->d.last_texture = tx->d.last_texture;
 
-    tx->l.last_texture = nullptr;
-    tx->l.next_texture = nullptr;
+    tx->d.last_texture = nullptr;
+    tx->d.next_texture = nullptr;
 }
 
 // unload all textures not rendered since g_never_unload_before
@@ -375,51 +341,17 @@ void minport_freeTextureMemory()
 {
     int num_unloaded = 0;
 
-#if 0
-    // future code for when/if TffFont can recover from its textures being de-inited
-
-    while(g_render_chain_tail && g_current_frame - g_render_chain_tail->l.last_draw_frame > g_never_unload_before)
+    while(g_render_chain_tail && g_current_frame - g_render_chain_tail->d.last_draw_frame > g_never_unload_before)
     {
         StdPicture* last_tail = g_render_chain_tail;
 
-        // will internally invoke deleteTexture, which invokes minport_unlinkTexture if written properly
-        if(last_tail->l.lazyLoaded)
-            lazyUnLoad(*g_render_chain_tail);
-        else
-        {
-            deleteTexture(*g_render_chain_tail, false);
-            num_deleted++;
-        }
-
-        if(g_render_chain_tail == last_tail)
-        {
-            pLogCritical("Failed to unlink texture during lazyUnLoad! Manually unlinking texture. VRAM may be leaked.");
-            minport_unlinkTexture(g_render_chain_tail);
-        }
-
+        // will internally invoke minport_unlinkTexture if written properly
+        unloadTexture(*last_tail);
         num_unloaded++;
-    }
-#endif
-
-    while(g_render_chain_tail && g_current_frame - g_render_chain_tail->l.last_draw_frame > g_never_unload_before)
-    {
-        StdPicture* last_tail = g_render_chain_tail;
-
-        // will internally invoke deleteTexture, which invokes minport_unlinkTexture if written properly
-        if(last_tail->l.lazyLoaded)
-        {
-            lazyUnLoad(*last_tail);
-            num_unloaded++;
-        }
-        else
-        {
-            // keeps us from freeing it, because it's not valid to! (can't be re-loaded)
-            minport_unlinkTexture(last_tail);
-        }
 
         if(g_render_chain_tail == last_tail)
         {
-            pLogCritical("Failed to unlink texture during lazyUnLoad! Manually unlinking texture. VRAM may be leaked.");
+            pLogCritical("Failed to unlink texture during unloadTexture! Manually unlinking texture. VRAM may be leaked.");
             minport_unlinkTexture(g_render_chain_tail);
         }
     }
@@ -446,7 +378,7 @@ inline void minport_RenderTexturePrivate_2(int16_t xDst, int16_t yDst, int16_t w
 
     if(tx.inited && tx.l.lazyLoaded && &tx != g_render_chain_head)
     {
-        tx.l.last_draw_frame = g_current_frame;
+        tx.d.last_draw_frame = g_current_frame;
 
         // unlink
         minport_unlinkTexture(&tx);
@@ -454,8 +386,8 @@ inline void minport_RenderTexturePrivate_2(int16_t xDst, int16_t yDst, int16_t w
         // insert at head
         if(g_render_chain_head)
         {
-            g_render_chain_head->l.next_texture = &tx;
-            tx.l.last_texture = g_render_chain_head;
+            g_render_chain_head->d.next_texture = &tx;
+            tx.d.last_texture = g_render_chain_head;
         }
         else
         {

--- a/src/core/null/picture_load_null.h
+++ b/src/core/null/picture_load_null.h
@@ -20,19 +20,35 @@
 
 #pragma once
 
-#ifdef __WII__
-#   define PICTURE_LOAD_WII
-#   include "core/wii/picture_load_wii.h"
-#elif defined(__16M__)
-#   define PICTURE_LOAD_16M
-#   include "core/16m/picture_load_16m.h"
-#elif defined(__3DS__)
-#   define PICTURE_LOAD_3DS
-#   include "core/3ds/picture_load_3ds.h"
-#elif defined(PGE_MIN_PORT) || defined(THEXTECH_CLI_BUILD)
-#   define PICTURE_LOAD_NULL
-#   include "core/null/picture_load_null.h"
-#else
-#   define PICTURE_LOAD_NORMAL
-#   include "core/base/picture_load_base.h"
-#endif
+#ifndef STD_PICTURE_LOAD_NULL_H
+#define STD_PICTURE_LOAD_NULL_H
+
+#include <string>
+
+/*!
+ * \brief Generic image loading store.
+ *
+ * If needed somehing unusual, please define alternative structure instead of this
+ */
+struct StdPictureLoad
+{
+    //! Is this a lazy-loaded texture?
+    bool lazyLoaded = false;
+
+    //! Path to find image
+    std::string path = "";
+
+    //! Path to find mask (if any)
+    std::string mask_path = "";
+
+    // Transparent color for BMP and JPEG
+    bool     colorKey = false;
+    uint8_t  keyRgb[3] = {0 /*R*/, 0 /*G*/, 0 /*B*/};
+
+    inline bool canLoad() const
+    {
+        return lazyLoaded;
+    }
+};
+
+#endif // #ifndef STD_PICTURE_LOAD_NULL_H

--- a/src/core/picture_load.h
+++ b/src/core/picture_load.h
@@ -22,77 +22,17 @@
 
 #ifdef __WII__
 #   define PICTURE_LOAD_WII
-#   include "core/wii/picture_load.h"
+#   include "core/wii/picture_load_wii.h"
 #elif defined(__16M__)
 #   define PICTURE_LOAD_16M
 #   include "core/16m/picture_load_16m.h"
 #elif defined(__3DS__) || defined(PGE_MIN_PORT) || defined(THEXTECH_CLI_BUILD)
 #   define PICTURE_LOAD_3DS
-#   include "core/3ds/picture_load.h"
+#   include "core/3ds/picture_load_3ds.h"
+#elif defined(PGE_MIN_PORT) || defined(THEXTECH_CLI_BUILD)
+#   define PICTURE_LOAD_NULL
+#   include "core/null/picture_load_null.h"
+#else
+#   define PICTURE_LOAD_NORMAL
+#   include "core/base/picture_load_base.h"
 #endif
-
-// each of the above defines STD_PICTURE_LOAD_H so they prevent the rest from running
-
-#ifndef STD_PICTURE_LOAD_H
-#define STD_PICTURE_LOAD_H
-
-#define PICTURE_LOAD_NORMAL
-
-#include <cstdint>
-#include <vector>
-
-/*!
- * \brief Generic image loading store.
- *
- * If needed somehing unusual, please define alternative structure instead of this
- */
-struct StdPictureLoad
-{
-    //! Is this a lazy-loaded texture?
-    bool lazyLoaded = false;
-    //! Original compressed data of the front image
-    std::vector<char> raw;
-    //! Original compressed data of the mask image (if presented)
-    std::vector<char> rawMask;
-    //! Was mask restored from the PNG at default graphics?
-    bool isMaskPng = false;
-
-    // Original size (if texture got scaled while loading)
-    //! Original width
-    int w_orig = 0;
-    //! Original height
-    int h_orig = 0;
-
-    // Difference between original and initial size
-    //! Width scale factor
-    float w_scale = 1.0f;
-    //! Height scale factor
-    float h_scale = 1.0f;
-
-    // Transparent color for BMP and JPEG
-    bool     colorKey = false;
-    uint8_t  keyRgb[3] = {0 /*R*/, 0 /*G*/, 0 /*B*/};
-
-    /*!
-     * \brief Clear all held data
-     *
-     * Must be called by renderer backend after texture deletion
-     */
-    void clear()
-    {
-        raw.clear();
-        rawMask.clear();
-        lazyLoaded = false;
-        isMaskPng = false;
-        w_orig = 0;
-        h_orig = 0;
-        w_scale = 1.f;
-        h_scale = 1.f;
-        colorKey = false;
-        keyRgb[0] = 0;
-        keyRgb[1] = 0;
-        keyRgb[2] = 0;
-    }
-};
-
-#endif // STD_PICTURE_LOAD_H

--- a/src/core/render.h
+++ b/src/core/render.h
@@ -227,10 +227,12 @@ E_INLINE void lazyLoadPicture(StdPicture_Sub &target,
                               const std::string &path,
                               int scaleFactor,
                               const std::string &maskPath = std::string(),
-                              const std::string &maskFallbackPath = std::string())
+                              const std::string &maskFallbackPath = std::string()) TAIL
+#ifndef RENDER_CUSTOM
 {
     AbstractRender_t::lazyLoadPicture(target, path, scaleFactor, maskPath, maskFallbackPath);
 }
+#endif
 
 SDL_FORCE_INLINE void lazyLoadPicture(StdPicture_Sub &target,
                                       const std::string &path,
@@ -270,7 +272,7 @@ SDL_FORCE_INLINE void LoadPicture(StdPicture &target,
 
 
 #if defined(PGE_MIN_PORT) || defined(THEXTECH_CLI_BUILD)
-E_INLINE lazyLoadPictureFromList(StdPicture& target, int scaleFactor, FILE* f, const std::string& dir);
+E_INLINE void lazyLoadPictureFromList(StdPicture_Sub& target, FILE* f, const std::string& dir);
 #endif
 
 E_INLINE void setTransparentColor(StdPicture &target, uint32_t rgb) TAIL

--- a/src/core/render.h
+++ b/src/core/render.h
@@ -25,9 +25,9 @@
 #include <string>
 #include "std_picture.h"
 #include "base/render_types.h"
+#include "sdl_proxy/sdl_stdinc.h"
 
 #ifndef RENDER_CUSTOM
-#   include "sdl_proxy/sdl_stdinc.h"
 #   include "base/render_base.h"
 #   define E_INLINE SDL_FORCE_INLINE
 #   define TAIL
@@ -223,45 +223,22 @@ E_INLINE void setTargetSubScreen() TAIL
 #endif
 
 
-// load a picture whose logical size is the same as its texture size (the texture normally would have 2x2 pixels)
-E_INLINE StdPicture LoadPicture(const std::string &path,
-                                const std::string &maskPath = std::string(),
-                                const std::string &maskFallbackPath = std::string()) TAIL
-#ifndef RENDER_CUSTOM
+E_INLINE void lazyLoadPicture(StdPicture_Sub &target,
+                              const std::string &path,
+                              int scaleFactor,
+                              const std::string &maskPath = std::string(),
+                              const std::string &maskFallbackPath = std::string())
 {
-    return AbstractRender_t::LoadPicture(path, maskPath, maskFallbackPath);
+    AbstractRender_t::lazyLoadPicture(target, path, scaleFactor, maskPath, maskFallbackPath);
 }
-#endif
 
-// load a picture whose logical size is twice its texture size (the texture has 1x1 pixels)
-E_INLINE StdPicture LoadPicture_1x(const std::string &path,
-                                const std::string &maskPath = std::string(),
-                                const std::string &maskFallbackPath = std::string()) TAIL
-#ifndef RENDER_CUSTOM
+SDL_FORCE_INLINE void lazyLoadPicture(StdPicture_Sub &target,
+                                      const std::string &path,
+                                      const std::string &maskPath = std::string(),
+                                      const std::string &maskFallbackPath = std::string())
 {
-    return AbstractRender_t::LoadPicture_1x(path, maskPath, maskFallbackPath);
+    lazyLoadPicture(target, path, 1, maskPath, maskFallbackPath);
 }
-#endif
-
-E_INLINE StdPicture lazyLoadPicture(const std::string &path,
-                                    const std::string &maskPath = std::string(),
-                                    const std::string &maskFallbackPath = std::string()) TAIL
-#ifndef RENDER_CUSTOM
-{
-    return AbstractRender_t::lazyLoadPicture(path, maskPath, maskFallbackPath);
-}
-#endif
-
-#if defined(PGE_MIN_PORT) || defined(THEXTECH_CLI_BUILD)
-E_INLINE StdPicture lazyLoadPictureFromList(FILE* f, const std::string& dir);
-#endif
-
-E_INLINE void setTransparentColor(StdPicture &target, uint32_t rgb) TAIL
-#ifndef RENDER_CUSTOM
-{
-    AbstractRender_t::setTransparentColor(target, rgb);
-}
-#endif
 
 E_INLINE void lazyLoad(StdPicture &target) TAIL
 #ifndef RENDER_CUSTOM
@@ -270,10 +247,36 @@ E_INLINE void lazyLoad(StdPicture &target) TAIL
 }
 #endif
 
-E_INLINE void lazyUnLoad(StdPicture &target) TAIL
+// load a picture whose logical size is some factor times its texture size (the texture has 1x1 pixels)
+SDL_FORCE_INLINE void LoadPicture(StdPicture &target,
+                                  const std::string &path,
+                                  int scaleFactor,
+                                  const std::string &maskPath = std::string(),
+                                  const std::string &maskFallbackPath = std::string())
+{
+    lazyLoadPicture(target, path, scaleFactor, maskPath, maskFallbackPath);
+    lazyLoad(target);
+}
+
+// load a picture whose logical size is the same as its texture size (the texture normally would have 2x2 pixels)
+SDL_FORCE_INLINE void LoadPicture(StdPicture &target,
+                                  const std::string &path,
+                                  const std::string &maskPath = std::string(),
+                                  const std::string &maskFallbackPath = std::string())
+{
+    lazyLoadPicture(target, path, 1, maskPath, maskFallbackPath);
+    lazyLoad(target);
+}
+
+
+#if defined(PGE_MIN_PORT) || defined(THEXTECH_CLI_BUILD)
+E_INLINE lazyLoadPictureFromList(StdPicture& target, int scaleFactor, FILE* f, const std::string& dir);
+#endif
+
+E_INLINE void setTransparentColor(StdPicture &target, uint32_t rgb) TAIL
 #ifndef RENDER_CUSTOM
 {
-    AbstractRender_t::lazyUnLoad(target);
+    AbstractRender_t::setTransparentColor(target, rgb);
 }
 #endif
 
@@ -299,16 +302,15 @@ E_INLINE void lazyLoadedBytesReset() TAIL
 #endif
 
 /*!
- * \brief Load a texture whose logical size is the same as its texture size (the texture normally would have 2x2 pixels)
+ * \brief Load a texture's backing image data (image data may differ from texture's logical size)
  * \param target Destination texture entry
  * \param width Width of the input texture in pixels
  * \param height Height of the input texture in pixels
  * \param RGBApixels Pointer to the RGBA pixel data
  * \param pitch Width of the line in bytes
  *
- * Important note: All internal data of the target texture
- * (such as .w, .h, .frame_w, .frame_h, .l.w_orig, .l.h_orig,
- * .l.w_scale, .l.h_scale) must be filled externally BEFORE loading
+ * Important note: internal size data of the target texture
+ * (such as .w, .h) must be filled externally BEFORE loading
  * the texture.
  */
 E_INLINE void loadTexture(StdPicture &target,
@@ -323,33 +325,14 @@ E_INLINE void loadTexture(StdPicture &target,
 #endif
 
 /*!
- * \brief load an RGBA texture whose logical size is the twice its texture size (the texture has 1x1 pixels)
- * \param target Destination texture entry
- * \param width Width of the input texture in pixels
- * \param height Height of the input texture in pixels
- * \param RGBApixels Pointer to the RGBA pixel data
- * \param pitch Width of the line in bytes
+ * \brief Unload all renderer-specific state of a texture
  *
- * Important note: All internal data of the target texture
- * (such as .w, .h, .frame_w, .frame_h, .l.w_orig, .l.h_orig,
- * .l.w_scale, .l.h_scale) must be filled externally BEFORE loading
- * the texture.
+ * Important note: if the texture does not have loading information, fully de-inits it.
  */
-E_INLINE void loadTexture_1x(StdPicture &target,
-                          uint32_t width,
-                          uint32_t height,
-                          uint8_t *RGBApixels,
-                          uint32_t pitch) TAIL
+E_INLINE void unloadTexture(StdPicture &tx) TAIL
 #ifndef RENDER_CUSTOM
 {
-    g_render->loadTexture_1x(target, width, height, RGBApixels, pitch);
-}
-#endif
-
-E_INLINE void deleteTexture(StdPicture &tx, bool lazyUnload = false) TAIL
-#ifndef RENDER_CUSTOM
-{
-    g_render->deleteTexture(tx, lazyUnload);
+    g_render->unloadTexture(tx);
 }
 #endif
 

--- a/src/core/sdl/picture_data_sdl.h
+++ b/src/core/sdl/picture_data_sdl.h
@@ -36,6 +36,7 @@ struct SDL_Texture;
 struct StdPictureData
 {
 // Compatible backend is only can use these internals
+private:
     friend class RenderSDL;
 
     //! Texture instance pointer for SDL Render
@@ -53,19 +54,20 @@ struct StdPictureData
     //! Number of colors
     GLint       nOfColors = 0;
 
+    //! Width scale factor
+    float w_scale = 1.0f;
+    //! Height scale factor
+    float h_scale = 1.0f;
+
     //! Cached color modifier
     uint8_t     modColor[4] = {255,255,255,255};
 
 // Public API
+public:
 
-    inline bool hasTexture()
+    inline bool hasTexture() const
     {
         return texture != nullptr;
-    }
-
-    inline void clear()
-    {
-        texture = nullptr;
     }
 };
 

--- a/src/core/sdl/render_sdl.cpp
+++ b/src/core/sdl/render_sdl.cpp
@@ -91,6 +91,7 @@ bool RenderSDL::initRender(const CmdLineSetup_t &setup, SDL_Window *window)
         pLogWarning("Failed to initialize V-Synced renderer, trying to create accelerated renderer...");
 
         // fallthrough
+    default:
     case RENDER_ACCELERATED:
         renderFlags = SDL_RENDERER_ACCELERATED;
         g_videoSettings.renderModeObtained = RENDER_ACCELERATED;
@@ -378,9 +379,6 @@ void RenderSDL::loadTexture(StdPicture &target, uint32_t width, uint32_t height,
     SDL_Surface *surface;
     SDL_Texture *texture = nullptr;
 
-    target.d.nOfColors = GL_RGBA;
-    target.d.format = GL_BGRA;
-
     surface = SDL_CreateRGBSurfaceFrom(RGBApixels,
                                        static_cast<int>(width),
                                        static_cast<int>(height),
@@ -398,13 +396,20 @@ void RenderSDL::loadTexture(StdPicture &target, uint32_t width, uint32_t height,
     if(!texture)
     {
         pLogWarning("Render SDL: Failed to load texture! (%s)", SDL_GetError());
-        target.d.clear();
         target.inited = false;
         return;
     }
 
     target.d.texture = texture;
-    m_textureBank.insert(texture);
+
+    target.d.nOfColors = GL_RGBA;
+    target.d.format = GL_BGRA;
+
+    target.d.w_scale = static_cast<float>(width) / target.w;
+    target.d.h_scale = static_cast<float>(height) / target.h;
+
+    m_loadedPictures.insert(&target);
+    D_pLogDebug("RenderSDL: loading texture at %p, new texture count %d...", &tx, (int)m_loadedPictures.size());
 
     target.inited = true;
 
@@ -413,46 +418,41 @@ void RenderSDL::loadTexture(StdPicture &target, uint32_t width, uint32_t height,
 #endif
 }
 
-void RenderSDL::deleteTexture(StdPicture &tx, bool lazyUnload)
+void RenderSDL::unloadTexture(StdPicture &tx)
 {
-    if(!tx.inited || !tx.d.texture)
-    {
-        if(!lazyUnload)
-            tx.inited = false;
-        return;
-    }
+    auto corpseIt = m_loadedPictures.find(&tx);
+    if(corpseIt != m_loadedPictures.end())
+        m_loadedPictures.erase(corpseIt);
 
-    auto corpseIt = m_textureBank.find(tx.d.texture);
-    if(corpseIt == m_textureBank.end())
-    {
+    D_pLogDebug("RenderSDL: unloading texture at %p, new texture count %d...", &tx, (int)m_loadedPictures.size());
+
+    if(tx.d.hasTexture())
         SDL_DestroyTexture(tx.d.texture);
-        tx.d.texture = nullptr;
-        if(!lazyUnload)
-            tx.inited = false;
-        return;
-    }
 
-    SDL_Texture *corpse = *corpseIt;
-    if(corpse)
-        SDL_DestroyTexture(corpse);
-    m_textureBank.erase(corpse);
+    tx.d = StdPictureData();
 
-    tx.d.texture = nullptr;
+    if(!tx.l.canLoad())
+        static_cast<StdPicture_Sub&>(tx) = StdPicture_Sub();
 
-    if(!lazyUnload)
-        tx.resetAll();
-
-    tx.d.format = 0;
-    tx.d.nOfColors = 0;
-
-    tx.resetColors();
+    return;
 }
 
 void RenderSDL::clearAllTextures()
 {
-    for(SDL_Texture *tx : m_textureBank)
-        SDL_DestroyTexture(tx);
-    m_textureBank.clear();
+    for(StdPicture *tx : m_loadedPictures)
+    {
+        D_pLogDebug("RenderSDL: unloading texture at %p on clearAllTextures()", tx);
+
+        if(tx->d.hasTexture())
+            SDL_DestroyTexture(tx->d.texture);
+
+        tx->d = StdPictureData();
+
+        if(!tx->l.canLoad())
+            static_cast<StdPicture_Sub&>(*tx) = StdPicture_Sub();
+    }
+
+    m_loadedPictures.clear();
 }
 
 void RenderSDL::clearBuffer()
@@ -603,7 +603,7 @@ void RenderSDL::renderCircleHole(int cx, int cy, int radius, float red, float gr
 
 
 
-static SDL_INLINE void txColorMod(StdPictureData &tx, float red, float green, float blue, float alpha)
+void RenderSDL::txColorMod(StdPictureData &tx, float red, float green, float blue, float alpha)
 {
     uint8_t modColor[4] = {static_cast<unsigned char>(255.f * red),
                            static_cast<unsigned char>(255.f * green),
@@ -685,11 +685,8 @@ void RenderSDL::renderTextureScaleEx(double xDstD, double yDstD, double wDstD, d
 #endif
 
     SDL_Rect sourceRect;
-    if(tx.l.w_orig == 0 && tx.l.h_orig == 0)
-        sourceRect = {xSrc, ySrc, wSrc, hSrc};
-    else
-        sourceRect = {int(tx.l.w_scale * xSrc), int(tx.l.h_scale * ySrc),
-                      int(tx.l.w_scale * wSrc), int(tx.l.h_scale * hSrc)};
+    sourceRect = {int(tx.d.w_scale * xSrc), int(tx.d.h_scale * ySrc),
+                  int(tx.d.w_scale * wSrc), int(tx.d.h_scale * hSrc)};
 
     txColorMod(tx.d, red, green, blue, alpha);
     SDL_RenderCopyExF(m_gRenderer, tx.d.texture, &sourceRect, &destRect,
@@ -730,10 +727,7 @@ void RenderSDL::renderTextureScale(double xDst, double yDst, double wDst, double
 #endif
 
     SDL_Rect sourceRect;
-    if(tx.l.w_orig == 0 && tx.l.h_orig == 0)
-        sourceRect = {0, 0, tx.w, tx.h};
-    else
-        sourceRect = {0, 0, tx.l.w_orig, tx.l.h_orig};
+    sourceRect = {0, 0, tx.w, tx.h};
 
     txColorMod(tx.d, red, green, blue, alpha);
     SDL_RenderCopyExF(m_gRenderer, tx.d.texture, &sourceRect, &destRect,
@@ -796,11 +790,8 @@ void RenderSDL::renderTexture(double xDstD, double yDstD, double wDstD, double h
 
     SDL_Rect sourceRect;
 
-    if(tx.l.w_orig == 0 && tx.l.h_orig == 0)
-        sourceRect = {xSrc, ySrc, (int)wDst, (int)hDst};
-    else
-        sourceRect = {int(tx.l.w_scale * xSrc), int(tx.l.h_scale * ySrc),
-                      int(tx.l.w_scale * wDst), int(tx.l.h_scale * hDst)};
+    sourceRect = {int(tx.d.w_scale * xSrc), int(tx.d.h_scale * ySrc),
+                  int(tx.d.w_scale * wDst), int(tx.d.h_scale * hDst)};
 
     txColorMod(tx.d, red, green, blue, alpha);
     SDL_RenderCopyF(m_gRenderer, tx.d.texture, &sourceRect, &destRect);
@@ -867,11 +858,8 @@ void RenderSDL::renderTextureFL(double xDstD, double yDstD, double wDstD, double
 
     SDL_Rect sourceRect;
 
-    if(tx.l.w_orig == 0 && tx.l.h_orig == 0)
-        sourceRect = {xSrc, ySrc, (int)wDst, (int)hDst};
-    else
-        sourceRect = {int(tx.l.w_scale * xSrc), int(tx.l.h_scale * ySrc),
-                      int(tx.l.w_scale * wDst), int(tx.l.h_scale * hDst)};
+    sourceRect = {int(tx.d.w_scale * xSrc), int(tx.d.h_scale * ySrc),
+                  int(tx.d.w_scale * wDst), int(tx.d.h_scale * hDst)};
 
     txColorMod(tx.d, red, green, blue, alpha);
     SDL_RenderCopyExF(m_gRenderer, tx.d.texture, &sourceRect, &destRect,
@@ -906,10 +894,7 @@ void RenderSDL::renderTexture(float xDst, float yDst,
 #endif
 
     SDL_Rect sourceRect;
-    if(tx.l.w_orig == 0 && tx.l.h_orig == 0)
-        sourceRect = {0, 0, tx.w, tx.h};
-    else
-        sourceRect = {0, 0, tx.l.w_orig, tx.l.h_orig};
+    sourceRect = {0, 0, tx.w, tx.h};
 
     txColorMod(tx.d, red, green, blue, alpha);
     SDL_RenderCopyExF(m_gRenderer, tx.d.texture, &sourceRect, &destRect,

--- a/src/core/sdl/render_sdl.cpp
+++ b/src/core/sdl/render_sdl.cpp
@@ -409,7 +409,7 @@ void RenderSDL::loadTexture(StdPicture &target, uint32_t width, uint32_t height,
     target.d.h_scale = static_cast<float>(height) / target.h;
 
     m_loadedPictures.insert(&target);
-    D_pLogDebug("RenderSDL: loading texture at %p, new texture count %d...", &tx, (int)m_loadedPictures.size());
+    D_pLogDebug("RenderSDL: loading texture at %p, new texture count %d...", &target, (int)m_loadedPictures.size());
 
     target.inited = true;
 

--- a/src/core/sdl/render_sdl.h
+++ b/src/core/sdl/render_sdl.h
@@ -40,7 +40,7 @@ class RenderSDL final : public AbstractRender_t
     SDL_Texture  *m_tBuffer = nullptr;
     bool          m_tBufferDisabled = false;
     SDL_Texture  *m_recentTarget = nullptr;
-    std::set<SDL_Texture *> m_textureBank;
+    std::set<StdPicture *> m_loadedPictures;
 
     // Scale of virtual and window resolutuins
     float m_scale_x = 1.f;
@@ -69,6 +69,8 @@ class RenderSDL final : public AbstractRender_t
     //Need for HiDPI rendering (number of draw pixels per cursor pixel)
     float m_hidpi_x = 1.0f;
     float m_hidpi_y = 1.0f;
+
+    static void txColorMod(StdPictureData &tx, float red, float green, float blue, float alpha);
 
 public:
     RenderSDL();
@@ -161,7 +163,7 @@ public:
                      uint8_t *RGBApixels,
                      uint32_t pitch) override;
 
-    void deleteTexture(StdPicture &tx, bool lazyUnload = false) override;
+    void unloadTexture(StdPicture &tx) override;
     void clearAllTextures() override;
 
     void clearBuffer() override;

--- a/src/core/wii/picture_data_wii.h
+++ b/src/core/wii/picture_data_wii.h
@@ -31,12 +31,26 @@
 // also, if graphics lists are included, they can force MOST (but not all) assets to be read from TPL
 #define X_IMG_EXT ".tpl"
 
+struct StdPicture;
+
 /*!
  * \brief Platform specific picture data. Fields should not be used directly
  */
 struct StdPictureData
 {
     bool multi_horizontal = false;
+
+    // render chain data to store render sequence
+
+    //! The previous texture in the render chain (nullptr if this is the tail or unloaded)
+    StdPicture* last_texture = nullptr;
+
+    //! The next texture in the render chain (nullptr if this is the head or unloaded)
+    StdPicture* next_texture = nullptr;
+
+    //! The last frame that the texture was rendered (not accessed if not in the render chain)
+    uint32_t last_draw_frame = 0;
+
 
     // possible backing data
     bool texture_file_init[3] = {false, false, false};

--- a/src/core/wii/picture_load_wii.h
+++ b/src/core/wii/picture_load_wii.h
@@ -20,12 +20,10 @@
 
 #pragma once
 
-#ifndef STD_PICTURE_LOAD_H
-#define STD_PICTURE_LOAD_H
+#ifndef STD_PICTURE_LOAD_WII_H
+#define STD_PICTURE_LOAD_WII_H
 
 #include <string>
-
-struct StdPicture;
 
 /*!
  * \brief Generic image loading store.
@@ -37,26 +35,18 @@ struct StdPictureLoad
     //! Is this a lazy-loaded texture?
     bool lazyLoaded = false;
 
-    //! The previous texture in the render chain (nullptr if this is the tail or unloaded)
-    StdPicture* last_texture = nullptr;
-
-    //! The next texture in the render chain (nullptr if this is the head or unloaded)
-    StdPicture* next_texture = nullptr;
-
-    //! The last frame that the texture was rendered (not accessed if not in the render chain)
-    uint32_t last_draw_frame;
-
     //! Path to find image
     std::string path = "";
-
-    //! Path to find mask (if any)
     std::string mask_path = "";
 
     // Transparent color for BMP and JPEG
     bool     colorKey = false;
     uint8_t  keyRgb[3] = {0 /*R*/, 0 /*G*/, 0 /*B*/};
 
-    inline void clear() {}
+    inline bool canLoad() const
+    {
+        return lazyLoaded;
+    }
 };
 
-#endif // #ifndef STD_PICTURE_LOAD_H
+#endif // #ifndef STD_PICTURE_LOAD_WII_H

--- a/src/core/wii/render_wii.cpp
+++ b/src/core/wii/render_wii.cpp
@@ -219,8 +219,11 @@ FIBITMAP* robust_FILoad(const std::string& path, const std::string& maskPath, in
     return sourceImage;
 }
 
-void s_loadTexture(StdPicture& target, void* data, int width, int height, int pitch, bool mask, bool downscale = true)
+void s_loadTexture(StdPicture& target, void* data, int width, int height, int pitch, bool mask)
 {
+    // downscale if logical width matches the actual width of the texture, otherwise don't
+    bool downscale = (width >= target.w);
+
     int max_size = (downscale ? 2048 : 1024);
 
     if(width > max_size && height <= max_size)
@@ -585,108 +588,10 @@ void minport_ApplyViewport()
     // GX_SetScissorBoxOffset(-ox, -oy);
 }
 
-StdPicture LoadPicture(const std::string& path, const std::string& maskPath, const std::string& maskFallbackPath, bool downscale)
+void lazyLoadPictureFromList(StdPicture_Sub& target, FILE* f, const std::string& dir)
 {
-    (void)maskPath;
-    (void)maskFallbackPath;
-
-    StdPicture target;
-
     if(!GameIsActive)
-        return target; // do nothing when game is closed
-
-    target.inited = false;
-    target.l.path = path;
-
-    if(target.l.path.empty())
-        return target;
-
-    if(maskPath.empty() && !maskFallbackPath.empty() && Files::fileExists(maskFallbackPath))
-        target.l.mask_path = maskFallbackPath;
-    else
-        target.l.mask_path = maskPath;
-
-    target.inited = true;
-
-    // must be true to make it safe for the renderer to lazy-unload
-    target.l.lazyLoaded = true;
-
-    if(Files::hasSuffix(target.l.path, ".tpl"))
-    {
-        if(TPL_OpenTPLFromFile(&target.d.texture_file[0], target.l.path.c_str()) == 1)
-        {
-            target.d.texture_file_init[0] = true;
-            s_loadTexture(target, 0);
-            s_num_textures_loaded ++;
-        }
-    }
-    else
-    {
-        FIBITMAP* FI_tex = nullptr;
-        FIBITMAP* FI_mask = nullptr;
-
-        if(Files::hasSuffix(target.l.mask_path, "m.gif"))
-        {
-            FI_tex = robust_FILoad(target.l.path, "", &target.w, &target.h);
-
-            if(FI_tex)
-                FI_mask = robust_FILoad(target.l.mask_path, "");
-        }
-        else
-        {
-            FI_tex = robust_FILoad(target.l.path, target.l.mask_path, &target.w, &target.h);
-        }
-
-        if(!downscale)
-        {
-            target.w *= 2;
-            target.h *= 2;
-        }
-
-        if(!FI_tex)
-        {
-            pLogWarning("Permanently failed to load %s", target.l.path.c_str());
-            pLogWarning("Error: %d (%s)", errno, strerror(errno));
-        }
-        else
-        {
-            s_loadTexture(target, FreeImage_GetBits(FI_tex), FreeImage_GetWidth(FI_tex), FreeImage_GetHeight(FI_tex), FreeImage_GetPitch(FI_tex), false, downscale);
-            FreeImage_Unload(FI_tex);
-
-            if(FI_mask)
-            {
-                s_loadTexture(target, FreeImage_GetBits(FI_mask), FreeImage_GetWidth(FI_mask), FreeImage_GetHeight(FI_mask), FreeImage_GetPitch(FI_mask), true, downscale);
-                FreeImage_Unload(FI_mask);
-            }
-        }
-    }
-
-    if(!target.d.hasTexture())
-    {
-        pLogWarning("FAILED TO LOAD!!! %s", path.c_str());
-        target.d.destroy();
-        target.inited = false;
-    }
-
-    return target;
-}
-
-StdPicture LoadPicture(const std::string& path, const std::string& maskPath, const std::string& maskFallbackPath)
-{
-    return LoadPicture(path, maskPath, maskFallbackPath, true);
-}
-
-StdPicture LoadPicture_1x(const std::string& path, const std::string& maskPath, const std::string& maskFallbackPath)
-{
-    return LoadPicture(path, maskPath, maskFallbackPath, false);
-}
-
-StdPicture lazyLoadPictureFromList(FILE* f, const std::string& dir)
-{
-    StdPicture target;
-
-    if(!GameIsActive)
-        return target; // do nothing when game is closed
+        return; // do nothing when game is closed
 
     int length;
 
@@ -695,13 +600,13 @@ StdPicture lazyLoadPictureFromList(FILE* f, const std::string& dir)
     if(fscanf(f, "%255[^\n]%n%*[^\n]\n", filename, &length) != 1)
     {
         pLogWarning("Could not load image path from load list");
-        return target;
+        return;
     }
 
     if(length == 255)
     {
         pLogWarning("Image path %s was truncated in load list", filename);
-        return target;
+        return;
     }
 
     target.inited = true;
@@ -715,7 +620,7 @@ StdPicture lazyLoadPictureFromList(FILE* f, const std::string& dir)
     {
         pLogWarning("Could not load image %s dimensions from load list", filename);
         target.inited = false;
-        return target;
+        return;
     }
 
     // pLogDebug("Successfully loaded %s (%d %d)", target.l.path.c_str(), w, h);
@@ -723,21 +628,19 @@ StdPicture lazyLoadPictureFromList(FILE* f, const std::string& dir)
     target.w = w;
     target.h = h;
 
-    return target;
+    return;
 }
 
-StdPicture lazyLoadPicture(const std::string& path, const std::string& maskPath, const std::string& maskFallbackPath)
+void lazyLoadPicture(StdPicture_Sub& target, const std::string& path, int scaleFactor, const std::string& maskPath, const std::string& maskFallbackPath)
 {
-    StdPicture target;
-
     if(!GameIsActive)
-        return target; // do nothing when game is closed
+        return; // do nothing when game is closed
 
     target.inited = false;
     target.l.path = path;
 
     if(target.l.path.empty())
-        return target;
+        return;
 
     if(maskPath.empty() && !maskFallbackPath.empty() && Files::fileExists(maskFallbackPath))
         target.l.mask_path = maskFallbackPath;
@@ -784,12 +687,10 @@ StdPicture lazyLoadPicture(const std::string& path, const std::string& maskPath,
         }
         else
         {
-            target.w = tSize.w();
-            target.h = tSize.h();
+            target.w = tSize.w() * scaleFactor;
+            target.h = tSize.h() * scaleFactor;
         }
     }
-
-    return target;
 }
 
 int robust_OpenTPLFromFile(TPLFile* target, const char* path)
@@ -928,41 +829,15 @@ void lazyPreLoad(StdPicture& target)
     lazyLoad(target);
 }
 
-void lazyUnLoad(StdPicture& target)
-{
-    if(!target.inited || !target.l.lazyLoaded || !target.d.hasTexture())
-        return;
-
-    deleteTexture(target, true);
-}
-
 void loadTexture(StdPicture &target, uint32_t width, uint32_t height, uint8_t *RGBApixels, uint32_t pitch)
 {
-    s_loadTexture(target, RGBApixels, width, height, pitch, false, true);
+    s_loadTexture(target, RGBApixels, width, height, pitch, false);
     target.inited = true;
     target.l.lazyLoaded = false;
-    target.w = width;
-    target.h = height;
-//    target.frame_w = width;
-//    target.frame_h = height;
 }
 
-void loadTexture_1x(StdPicture &target, uint32_t width, uint32_t height, uint8_t *RGBApixels, uint32_t pitch)
+void unloadTexture(StdPicture& tx)
 {
-    s_loadTexture(target, RGBApixels, width, height, pitch, false, false);
-    target.inited = true;
-    target.l.lazyLoaded = false;
-    target.w = width * 2;
-    target.h = height * 2;
-//    target.frame_w = width * 2;
-//    target.frame_h = height * 2;
-}
-
-void deleteTexture(StdPicture& tx, bool lazyUnload)
-{
-    if(!tx.inited)
-        return;
-
     minport_unlinkTexture(&tx);
 
     if(tx.d.hasTexture())
@@ -970,15 +845,8 @@ void deleteTexture(StdPicture& tx, bool lazyUnload)
 
     tx.d.destroy();
 
-    if(!lazyUnload)
-    {
-        tx.inited = false;
-        tx.l.lazyLoaded = false;
-        tx.w = 0;
-        tx.h = 0;
-//        tx.frame_w = 0;
-//        tx.frame_h = 0;
-    }
+    if(!tx.l.canLoad())
+        static_cast<StdPicture_Sub&>(tx) = StdPicture_Sub();
 }
 
 inline int ROUNDDIV2(int x)

--- a/src/fontman/raster_font.h
+++ b/src/fontman/raster_font.h
@@ -129,7 +129,7 @@ private:
     CharMap m_charMap;
 
     //! Bank of loaded textures
-    VPtrList<StdPicture > m_texturesBank;
+    VPtrList<StdPicture> m_texturesBank;
 };
 
 #endif // RASTER_FONT_H

--- a/src/fontman/ttf_font.cpp
+++ b/src/fontman/ttf_font.cpp
@@ -661,13 +661,17 @@ const TtfFont::TheGlyph &TtfFont::loadGlyph(StdPicture &texture, uint32_t fontSi
         break;
     }
 
-    texture.w = width;
-    texture.h = height;
-//    texture.frame_w = width;
-//    texture.frame_h = height;
+    if(m_doublePixel)
+    {
+        texture.w = width * 2;
+        texture.h = height * 2;
+    }
+    else
+    {
+        texture.w = width;
+        texture.h = height;
+    }
 
-    // This is accurate for doublePixel, and inaccurate otherwise. But the glyphs are always rendered scaled so it doesn't make a difference.
-    // For now, always mark it as 1x to indicate to XRender that it's not safe to downscale it, but if we tracked doublePixel, it would be fine to specialize here.
     XRender::loadTexture(texture, width, height, image, pitch);
 
     t_glyph.tx      = &texture;

--- a/src/fontman/ttf_font.cpp
+++ b/src/fontman/ttf_font.cpp
@@ -93,10 +93,6 @@ TtfFont::TtfFont() : BaseFontEngine()
 
 TtfFont::~TtfFont()
 {
-    for(StdPicture &t : m_texturesBank)
-        XRender::deleteTexture(t);
-    m_texturesBank.clear();
-
     TTF_MUTEX_LOCK();
     if(m_face)
     {
@@ -472,7 +468,13 @@ const TtfFont::TheGlyph &TtfFont::getGlyph(uint32_t fontSize, char32_t character
     {
         auto rc = fSize->second.find(character);
         if(rc != fSize->second.end())
+        {
+            // reload if the renderer has unloaded the glyph
+            if(rc->second.tx && !rc->second.tx->d.hasTexture())
+                return loadGlyph(*(rc->second.tx), fontSize, character);
+
             return rc->second;
+        }
         return loadGlyph(fontSize, character);
     }
 
@@ -480,6 +482,19 @@ const TtfFont::TheGlyph &TtfFont::getGlyph(uint32_t fontSize, char32_t character
 }
 
 const TtfFont::TheGlyph &TtfFont::loadGlyph(uint32_t fontSize, char32_t character)
+{
+    m_texturesBank.emplace_back();
+    StdPicture &texture = m_texturesBank.back();
+
+    const TtfFont::TheGlyph &ret = loadGlyph(texture, fontSize, character);
+
+    if(ret.tx != &texture)
+        m_texturesBank.pop_back();
+
+    return ret;
+}
+
+const TtfFont::TheGlyph &TtfFont::loadGlyph(StdPicture &texture, uint32_t fontSize, char32_t character)
 {
     FT_Error     error = 0;
     FT_UInt      t_glyphIndex = 0;
@@ -646,22 +661,14 @@ const TtfFont::TheGlyph &TtfFont::loadGlyph(uint32_t fontSize, char32_t characte
         break;
     }
 
-    m_texturesBank.emplace_back();
-    StdPicture &texture = m_texturesBank.back();
     texture.w = width;
     texture.h = height;
 //    texture.frame_w = width;
 //    texture.frame_h = height;
-#ifdef PICTURE_LOAD_NORMAL
-    texture.l.w_orig = 0;
-    texture.l.h_orig = 0;
-    texture.l.w_scale = 1.f;
-    texture.l.h_scale = 1.f;
-#endif
 
     // This is accurate for doublePixel, and inaccurate otherwise. But the glyphs are always rendered scaled so it doesn't make a difference.
     // For now, always mark it as 1x to indicate to XRender that it's not safe to downscale it, but if we tracked doublePixel, it would be fine to specialize here.
-    XRender::loadTexture_1x(texture, width, height, image, pitch);
+    XRender::loadTexture(texture, width, height, image, pitch);
 
     t_glyph.tx      = &texture;
     t_glyph.width   = width;

--- a/src/fontman/ttf_font.h
+++ b/src/fontman/ttf_font.h
@@ -170,7 +170,12 @@ private:
     static const TheGlyph dummyGlyph;
 
     const TheGlyph &getGlyph(uint32_t fontSize, char32_t character);
+
+    // version allocating a new texture
     const TheGlyph &loadGlyph(uint32_t fontSize, char32_t character);
+
+    // version using an existing texture
+    const TheGlyph &loadGlyph(StdPicture &texture, uint32_t fontSize, char32_t character);
 
     typedef std::unordered_map<char32_t, TheGlyph> CharMap;
     typedef std::unordered_map<uint32_t, CharMap>  SizeCharMap;

--- a/src/frm_main.cpp
+++ b/src/frm_main.cpp
@@ -208,3 +208,34 @@ void FrmMain::freeSystem()
     pLogDebug("<Application closed>");
     CloseLog();
 }
+
+bool FrmMain::restartRenderer()
+{
+    pLogDebug("FrmMain: attempting to restart XRender...");
+
+    bool res;
+
+#ifdef RENDER_CUSTOM
+    XRender::quit();
+
+    res = XRender::init();
+#else
+    if(m_render)
+    {
+        m_render->clearAllTextures();
+        m_render->close();
+    }
+
+    m_render.reset();
+    g_render = nullptr;
+
+    RenderUsed *render = new RenderUsed();
+    m_render.reset(render);
+    g_render = m_render.get();
+
+    const CmdLineSetup_t setup;
+    res = render->initRender(setup, reinterpret_cast<WindowUsed*>(g_window)->getWindow());
+#endif
+
+    return res;
+}

--- a/src/frm_main.h
+++ b/src/frm_main.h
@@ -67,6 +67,8 @@ public:
 
     bool initSystem(const CmdLineSetup_t &setup);
     void freeSystem();
+
+    bool restartRenderer();
 };
 
 #endif // FRMMAIN_H

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -58,7 +58,7 @@ void GFX_t::loadImage(StdPicture &img, const std::string &path)
     {
         path_ext = path + ".png";
         pLogDebug("Could not load, trying %s...", path_ext.c_str());
-        img = XRender::LoadPicture(path_ext);
+        XRender::LoadPicture(img, path_ext);
     }
 #endif
 

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -51,7 +51,7 @@ void GFX_t::loadImage(StdPicture &img, const std::string &path)
     std::string path_ext = path + UI_IMG_EXT;
 
     pLogDebug("Loading texture %s...", path_ext.c_str());
-    img = XRender::LoadPicture(path_ext);
+    XRender::LoadPicture(img, path_ext);
 
 #if defined(X_IMG_EXT) && !defined(X_NO_PNG_GIF)
     if(!img.inited)
@@ -186,7 +186,7 @@ bool GFX_t::load()
 void GFX_t::unLoad()
 {
     for(StdPicture *p : m_loadedImages)
-        XRender::deleteTexture(*p);
+        XRender::unloadTexture(*p);
     m_loadedImages.clear();
     SDL_memset(m_isCustom, 0, sizeof(m_loadedImages.size() * sizeof(bool)));
 }

--- a/src/load_gfx.cpp
+++ b/src/load_gfx.cpp
@@ -249,7 +249,8 @@ static void loadImageFromList(FILE* f, const std::string& dir,
                     int *width, int *height, bool &is_custom_loc,
                     bool world = false, bool this_is_custom = false)
 {
-    StdPicture newTexture = XRender::lazyLoadPictureFromList(f, dir);
+    StdPicture_Sub newTexture;
+    XRender::lazyLoadPictureFromList(newTexture, f, dir);
 
     if(!newTexture.inited)
         return;
@@ -261,12 +262,12 @@ static void loadImageFromList(FILE* f, const std::string& dir,
         backup.remote_height = height;
         backup.remote_isCustom = &is_custom_loc;
         backup.remote_texture = &texture;
-        XRender::lazyUnLoad(texture);
+        XRender::unloadTexture(texture);
         if(width)
             backup.width = *width;
         if(height)
             backup.height = *height;
-        backup.texture = texture;
+        backup.texture_backup = static_cast<StdPicture_Sub&>(texture);
 
         if(world)
             g_defaultWorldGfxBackup.push_back(backup);
@@ -280,7 +281,7 @@ static void loadImageFromList(FILE* f, const std::string& dir,
         is_custom_loc = true;
     }
 
-    texture = newTexture;
+    static_cast<StdPicture_Sub&>(texture) = newTexture;
     if(width)
         *width = newTexture.w;
     if(height)

--- a/src/script/luna/lunaimgbox.cpp
+++ b/src/script/luna/lunaimgbox.cpp
@@ -62,6 +62,11 @@ LunaImage::LunaImage(const LunaImage &o)
     operator=(o);
 }
 
+LunaImage::LunaImage(LunaImage &&o)
+{
+    operator=(std::move(o));
+}
+
 LunaImage &LunaImage::operator=(const LunaImage &o)
 {
     m_H = o.m_H;
@@ -74,6 +79,24 @@ LunaImage &LunaImage::operator=(const LunaImage &o)
 
     // initialize load data from other texture
     static_cast<StdPicture_Sub&>(m_image) = static_cast<const StdPicture_Sub&>(o.m_image);
+
+    return *this;
+}
+
+LunaImage &LunaImage::operator=(LunaImage &&o)
+{
+    m_H = o.m_H;
+    m_W = o.m_W;
+    m_uid = o.m_uid;
+    m_TransColor = o.m_TransColor;
+
+    // clear current texture from renderer if it exists
+    m_image.reset();
+
+    // initialize load data from other texture
+    static_cast<StdPicture_Sub&>(m_image) = std::move(static_cast<const StdPicture_Sub&>(o.m_image));
+
+    o.Unload();
 
     return *this;
 }

--- a/src/script/luna/lunaimgbox.cpp
+++ b/src/script/luna/lunaimgbox.cpp
@@ -44,7 +44,7 @@ LunaImage::LunaImage(const std::string &filename)
 
     Init();
 
-    m_image = XRender::lazyLoadPicture(filename);
+    XRender::lazyLoadPicture(m_image, filename);
     if(Files::hasSuffix(filename, ".jpg") || Files::hasSuffix(filename, ".bmp"))
     {
         m_useTransColor = true;
@@ -68,7 +68,13 @@ LunaImage &LunaImage::operator=(const LunaImage &o)
     m_W = o.m_W;
     m_uid = o.m_uid;
     m_TransColor = o.m_TransColor;
-    m_image = o.m_image;
+
+    // clear current texture from renderer if it exists
+    m_image.reset();
+
+    // initialize load data from other texture
+    static_cast<StdPicture_Sub&>(m_image) = static_cast<const StdPicture_Sub&>(o.m_image);
+
     return *this;
 }
 
@@ -82,7 +88,7 @@ void LunaImage::Init()
 
 void LunaImage::Unload()
 {
-    XRender::deleteTexture(m_image);
+    m_image.reset();
     Init();
 }
 

--- a/src/script/luna/lunaimgbox.h
+++ b/src/script/luna/lunaimgbox.h
@@ -49,7 +49,9 @@ public:
 
     LunaImage(const std::string &filename);
     LunaImage(const LunaImage &o);
+    LunaImage(LunaImage &&o);
     LunaImage &operator=(const LunaImage &o);
+    LunaImage &operator=(LunaImage &&o);
 
     void Init();
 

--- a/src/script/luna/lunarender.cpp
+++ b/src/script/luna/lunarender.cpp
@@ -97,7 +97,7 @@ bool Renderer::LoadBitmapResource(const std::string& filename, int resource_code
 
 void Renderer::StoreImage(LunaImage &&bmp, int resource_code)
 {
-    m_legacyResourceCodeImages[resource_code] = bmp;
+    m_legacyResourceCodeImages[resource_code] = std::move(bmp);
 }
 
 bool Renderer::DeleteImage(int resource_code)

--- a/src/std_picture.cpp
+++ b/src/std_picture.cpp
@@ -18,24 +18,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
-#ifndef PICTURE_DATA_H
-#define PICTURE_DATA_H
+#include "std_picture.h"
+#include "core/render.h"
 
-#ifdef __3DS__
-#   define PICTURE_DATA_3DS
-#   include "3ds/picture_data_3ds.h"
-#elif defined(__WII__)
-#   define PICTURE_DATA_WII
-#   include "wii/picture_data_wii.h"
-#elif defined(__16M__)
-#   include "16m/picture_data_16m.h"
-#elif defined(PGE_MIN_PORT) || defined(THEXTECH_CLI_BUILD)
-#   define PICTURE_DATA_NULL
-#   include "null/picture_data_null.h"
-#else
-#   define PICTURE_DATA_NORMAL
-#   include "sdl/picture_data_sdl.h"
-#endif
+StdPicture::~StdPicture()
+{
+    if(d.hasTexture())
+        XRender::unloadTexture(*this);
+}
 
-#endif // PICTURE_DATA_H
+void StdPicture::reset()
+{
+    if(d.hasTexture())
+        XRender::unloadTexture(*this);
+
+    static_cast<StdPicture_Sub&>(*this) = StdPicture_Sub();
+}

--- a/src/std_picture.h
+++ b/src/std_picture.h
@@ -46,9 +46,9 @@ struct PGEColor
 struct SDL_Texture;
 
 /**
- * @brief Handler of a graphical texture
+ * @brief Handler of a graphical texture, excluding renderer-specific data
  */
-struct StdPicture
+struct StdPicture_Sub
 {
 #ifdef STD_PICTURE_HAS_ORIG_PATH
     //! Debug-only file path to the original picture
@@ -94,23 +94,34 @@ struct StdPicture
     //! Loader-related data
     StdPictureLoad l;
 
+};
+
+
+/**
+ * @brief Handler of a graphical texture, including renderer-specific data
+ */
+struct StdPicture : public StdPicture_Sub
+{
+    StdPicture() = default;
+
     //! Platform specific texture data
     StdPictureData d;
 
     /*!
-     * \brief Reset all values into initial state.
-     *
-     * This must be called by renderer backend after texture deletion
+     * \brief Prevent any assignment of textures to preserve renderer references to loaded textures
      */
-    inline void resetAll()
-    {
-        inited = false;
-        l.clear();
-        w = 0;
-        h = 0;
-//        frame_w = 0;
-//        frame_h = 0;
-    }
+    StdPicture& operator=(const StdPicture& o) = delete;
+    StdPicture(const StdPicture& o) = delete;
+
+    /*!
+     * \brief reset operation unloads StdPictureData and also resets the StdPicture_Sub state
+     */
+    void reset();
+
+    /*!
+     * \brief Explicit destructor ensures that renderer unloads StdPictureData
+     */
+    ~StdPicture();
 };
 
 // This macro allows to get the original texture path when debug build is on,


### PR DESCRIPTION
- Destructor of StdPicture now ensures that pictures are unloaded (reduces possible leaks)
- Made it legal to copy the public + load portions of StdPicture (used a base class for these), illegal to copy the StdPictureData portion (reduces possible use-after-free)
- Totally removed the separate loadPicture_1x functions, instead use an optional scaleFactor parameter which is used to multiply the logical w / h members
- Enable the TtfFont class to reload glyphs if their textures have been lost

With all of this, it is now possible to run clearAllTextures() in the middle of the game, and all game state will survive. This will enable hot-swapping between renderers or recovering a lost renderer in future versions.

This is an entirely technical PR and should have no user-facing changes, except for the future features it enables.