### PR TITLE
Added an ability to load custom fonts at episode or data directory (at "fonts" sub-directories)

### DIFF
--- a/lib/Utils/dir_list_ci.h
+++ b/lib/Utils/dir_list_ci.h
@@ -2,6 +2,7 @@
 #define DIRLISTCI_H
 
 #include <string>
+#include <vector>
 #include <unordered_map>
 #include <memory>
 
@@ -23,6 +24,15 @@ public:
 
     // checks whether a file exists (case-insensitive)
     bool existsCI(const std::string &name);
+
+    // checks whether a directory exists (case-insensitive)
+    bool dirExistsCI(const std::string &name);
+
+    // get a list of files at the selected directory
+    std::vector<std::string> getFilesList(const std::string &subDir,
+                                          const std::vector<std::string> &suffix_filters = std::vector<std::string>());
+
+    std::vector<std::string> getFilesList(const std::vector<std::string> &suffix_filters = std::vector<std::string>());
 
     // resolves the file's case and returns the original string if failed
     std::string resolveFileCase(const std::string &name);

--- a/src/fontman/font_manager.cpp
+++ b/src/fontman/font_manager.cpp
@@ -39,6 +39,11 @@
 #include <fmt_format_ne.h>
 
 #include <vector>
+#ifdef LOW_MEM
+#   include <map>
+#else
+#   include <unordered_map>
+#endif
 
 BaseFontEngine::~BaseFontEngine()
 {}
@@ -56,7 +61,7 @@ static TtfFontsList    g_ttfFontsCustom;
 static TtfFontsList    g_ttfFontsCustomLevel;
 #define LOADFONTARG(x) x
 #else
-#define LOADFONTARG(x) false
+#   define LOADFONTARG(x) false
 #endif
 
 typedef VPtrList<BaseFontEngine*> PtrFontsList;
@@ -76,7 +81,11 @@ static TtfFont         *g_defaultTtfFont = nullptr;
 //! Is font manager initialized
 static bool             g_fontManagerIsInit = false;
 
+#ifdef LOW_MEM
+typedef std::map<std::string, int> FontsHash;
+#else
 typedef std::unordered_map<std::string, int> FontsHash;
+#endif
 //! Database of available fonts
 static FontsHash        g_fontNameToId;
 //! Backup of the database of available fonts

--- a/src/fontman/font_manager.h
+++ b/src/fontman/font_manager.h
@@ -57,10 +57,8 @@ void quit();
 
 /**
  * @brief Attempts to load custom fonts for the episode and for the level
- * @param episodeRoot Episode directory
- * @param dataSubDir Data directory
  */
-void loadCustomFonts(const std::string &episodeRoot, const std::string &dataSubDir);
+void loadCustomFonts();
 
 /**
  * @brief Removes all custom fonts completely

--- a/src/fontman/font_manager.h
+++ b/src/fontman/font_manager.h
@@ -52,13 +52,27 @@ void         utf8_pop_back(std::string &str);
 void         utf8_erase_at(std::string &str, size_t begin);
 void         utf8_erase_before(std::string &str, size_t end);
 
-
-//! Initialize basic support for font rendering withouth config pack
-void initBasic();
 //! Full initialization of font renderith include external fonts
 void initFull();
 //! De-Initialize font manager and clear memory
 void quit();
+
+/**
+ * @brief Attempts to load custom fonts for the episode and for the level
+ * @param episodeRoot Episode directory
+ * @param dataSubDir Data directory
+ */
+void loadCustomFonts(const std::string &episodeRoot, const std::string &dataSubDir);
+
+/**
+ * @brief Removes all custom fonts completely
+ */
+void clearCustomFonts();
+
+/**
+ * @brief Removes all level-wide fonts
+ */
+void clearLevelFonts();
 
 /*!
  * \brief Checks if font manager works

--- a/src/fontman/font_manager.h
+++ b/src/fontman/font_manager.h
@@ -67,10 +67,10 @@ void loadCustomFonts(const std::string &episodeRoot, const std::string &dataSubD
 /**
  * @brief Removes all custom fonts completely
  */
-void clearCustomFonts();
+void clearAllCustomFonts();
 
 /**
- * @brief Removes all level-wide fonts
+ * @brief Removes all level-wide fonts, but keeps episode-wide fonts being loaded
  */
 void clearLevelFonts();
 

--- a/src/fontman/font_manager.h
+++ b/src/fontman/font_manager.h
@@ -26,8 +26,6 @@
 #include <Utils/vptrlist.h>
 
 #include <string>
-#include <vector>
-#include <unordered_map>
 
 #include "font_engine_base.h"
 

--- a/src/fontman/raster_font.cpp
+++ b/src/fontman/raster_font.cpp
@@ -56,7 +56,7 @@ RasterFont::~RasterFont()
     m_texturesBank.clear();
 }
 
-void RasterFont::loadFont(std::string font_ini)
+void RasterFont::loadFont(const std::string &font_ini)
 {
     if(!Files::fileExists(font_ini))
     {
@@ -117,7 +117,7 @@ void RasterFont::loadFont(std::string font_ini)
     pLogDebug("Loaded raster font with name: [%s]", m_fontName.c_str());
 }
 
-void RasterFont::loadFontMap(std::string fontmap_ini)
+void RasterFont::loadFontMap(const std::string& fontmap_ini)
 {
     std::string root = DirMan(Files::dirname(fontmap_ini)).absolutePath() + "/";
 

--- a/src/fontman/raster_font.h
+++ b/src/fontman/raster_font.h
@@ -40,8 +40,8 @@ public:
 
     virtual ~RasterFont() override;
 
-    void  loadFont(std::string font_ini);
-    void  loadFontMap(std::string fontmap_ini);
+    void  loadFont(const std::string& font_ini);
+    void  loadFontMap(const std::string &fontmap_ini);
 
     /*!
      * \brief Measure the size of the multiline text block in pixels

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -768,7 +768,7 @@ int GameMain(const CmdLineSetup_t &setup)
             LoadCustomGFX();
             LoadCustomSound();
             SetupPlayers();
-            FontManager::loadCustomFonts(FileNamePath, FileNamePath + FileName + "/");
+            FontManager::loadCustomFonts();
 
 #ifndef PGE_MIN_PORT
             if(!NoMap)

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -78,6 +78,7 @@
 #include "core/msgbox.h"
 #include "core/language.h"
 #include "script/luna/luna.h"
+#include "fontman/font_manager.h"
 
 #include "pseudo_vb.h"
 
@@ -575,6 +576,7 @@ int GameMain(const CmdLineSetup_t &setup)
             Integrator::clearEpisodeName();
             Integrator::clearLevelName();
             Integrator::clearEditorFile();
+            FontManager::clearCustomFonts();
 
             BattleIntro = 0;
             BattleOutro = 0;
@@ -766,6 +768,8 @@ int GameMain(const CmdLineSetup_t &setup)
             LoadCustomGFX();
             LoadCustomSound();
             SetupPlayers();
+            FontManager::clearLevelFonts();
+            FontManager::loadCustomFonts(FileNamePath, FileNamePath + FileName);
 
 #ifndef PGE_MIN_PORT
             if(!NoMap)
@@ -1817,6 +1821,7 @@ void StartEpisode()
         PGE_Delay(500);
 
     ClearGame();
+    FontManager::clearCustomFonts();
 
     std::string wPath = SelectWorld[selWorld].WorldPath + SelectWorld[selWorld].WorldFile;
 

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -576,7 +576,7 @@ int GameMain(const CmdLineSetup_t &setup)
             Integrator::clearEpisodeName();
             Integrator::clearLevelName();
             Integrator::clearEditorFile();
-            FontManager::clearCustomFonts();
+            FontManager::clearAllCustomFonts();
 
             BattleIntro = 0;
             BattleOutro = 0;
@@ -768,8 +768,7 @@ int GameMain(const CmdLineSetup_t &setup)
             LoadCustomGFX();
             LoadCustomSound();
             SetupPlayers();
-            FontManager::clearLevelFonts();
-            FontManager::loadCustomFonts(FileNamePath, FileNamePath + FileName);
+            FontManager::loadCustomFonts(FileNamePath, FileNamePath + FileName + "/");
 
 #ifndef PGE_MIN_PORT
             if(!NoMap)
@@ -1821,7 +1820,7 @@ void StartEpisode()
         PGE_Delay(500);
 
     ClearGame();
-    FontManager::clearCustomFonts();
+    FontManager::clearAllCustomFonts();
 
     std::string wPath = SelectWorld[selWorld].WorldPath + SelectWorld[selWorld].WorldFile;
 

--- a/src/main/level_file.cpp
+++ b/src/main/level_file.cpp
@@ -196,7 +196,7 @@ bool OpenLevelData(LevelData &lvl, const std::string FilePath)
     FindCustomNPCs();
     LoadCustomGFX();
     LoadCustomSound();
-    FontManager::loadCustomFonts(g_dirEpisode.getCurDir(), g_dirCustom.getCurDir());
+    FontManager::loadCustomFonts();
 
 //    if(DirMan::exists(FileNamePath + FileName)) // Useless now
 //        LoadCustomGFX2(FileNamePath + FileName);

--- a/src/main/level_file.cpp
+++ b/src/main/level_file.cpp
@@ -42,6 +42,7 @@
 #include "npc_special_data.h"
 #include "graphics/gfx_update.h"
 #include "translate_episode.h"
+#include "fontman/font_manager.h"
 
 #include <DirManager/dirman.h>
 #include <Utils/files.h>
@@ -195,6 +196,7 @@ bool OpenLevelData(LevelData &lvl, const std::string FilePath)
     FindCustomNPCs();
     LoadCustomGFX();
     LoadCustomSound();
+    FontManager::loadCustomFonts(g_dirEpisode.getCurDir(), g_dirCustom.getCurDir());
 
 //    if(DirMan::exists(FileNamePath + FileName)) // Useless now
 //        LoadCustomGFX2(FileNamePath + FileName);
@@ -959,6 +961,7 @@ void ClearLevel()
     UnloadCustomGFX();
     doShakeScreenClear();
     treeLevelCleanAll();
+    FontManager::clearLevelFonts();
 
     invalidateDrawBlocks();
     invalidateDrawBGOs();

--- a/src/main/world_file.cpp
+++ b/src/main/world_file.cpp
@@ -107,7 +107,7 @@ bool OpenWorld(std::string FilePath)
     FileNamePathWorld = FileNamePath;
     FileFormatWorld = FileFormat;
 
-    FontManager::loadCustomFonts(g_dirEpisode.getCurDir(), g_dirCustom.getCurDir());
+    FontManager::loadCustomFonts();
 
     if(wld.meta.RecentFormat == LevelData::SMBX64)
         FileRelease = int(wld.meta.RecentFormatVersion);

--- a/src/main/world_file.cpp
+++ b/src/main/world_file.cpp
@@ -36,6 +36,7 @@
 #include "level_file.h"
 #include "world_file.h"
 #include "translate_episode.h"
+#include "fontman/font_manager.h"
 
 #include <Utils/strings.h>
 #include <Utils/files.h>
@@ -105,6 +106,8 @@ bool OpenWorld(std::string FilePath)
     FileNameWorld = FileName;
     FileNamePathWorld = FileNamePath;
     FileFormatWorld = FileFormat;
+
+    FontManager::loadCustomFonts(g_dirEpisode.getCurDir(), g_dirCustom.getCurDir());
 
     if(wld.meta.RecentFormat == LevelData::SMBX64)
         FileRelease = int(wld.meta.RecentFormatVersion);


### PR DESCRIPTION
This update adds an ability to load custom fonts for the new font engine, placed at the episode or at level/world data directories. Additionally, it tracks what current fonts set is loaded, and if needed, it does reloading of requested fonts once the font path becomes different.

Fixes #526
