### PR TITLE
Separated SDL Init/Quit + Timestaps per logger event

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,6 +672,7 @@ if(NINTENDO_3DS)
         src/core/3ds/msgbox_3ds.cpp
         src/core/3ds/events_3ds.cpp
 #        src/core/3ds/3ds-audio-lib.cpp
+        src/core/sdl/sdl_core.cpp
     )
 elseif(NINTENDO_WII)
     add_definitions(-DWINDOW_CUSTOM -DMSGBOX_CUSTOM -DEVENTS_CUSTOM -DRENDER_CUSTOM)
@@ -682,9 +683,10 @@ elseif(NINTENDO_WII)
         src/core/wii/window_wii.cpp
         src/core/wii/msgbox_wii.cpp
         src/core/wii/events_wii.cpp
+        src/core/sdl/sdl_core.cpp
     )
 elseif(NINTENDO_DS)
-    add_definitions(-DWINDOW_CUSTOM -DMSGBOX_CUSTOM -DEVENTS_CUSTOM -DRENDER_CUSTOM)
+    add_definitions(-DWINDOW_CUSTOM -DMSGBOX_CUSTOM -DEVENTS_CUSTOM -DRENDER_CUSTOM -DTHEXTECH_NO_SDL_CORE)
     list(REMOVE_ITEM THEXTECH_SRC src/sound.cpp)
 
     list(APPEND THEXTECH_SRC
@@ -704,9 +706,10 @@ elseif(THEXTECH_CLI_BUILD)
         src/core/null/window_null.cpp
         src/core/null/msgbox_null.cpp
         src/core/null/events_null.cpp
+        src/core/sdl/sdl_core.cpp
     )
 elseif(THEXTECH_NO_SDL_BUILD)
-    add_definitions(-DWINDOW_CUSTOM -DMSGBOX_CUSTOM -DEVENTS_CUSTOM -DRENDER_CUSTOM)
+    add_definitions(-DWINDOW_CUSTOM -DMSGBOX_CUSTOM -DEVENTS_CUSTOM -DRENDER_CUSTOM -DTHEXTECH_NO_SDL_CORE)
     list(APPEND THEXTECH_SRC
         src/core/null/render_null.cpp
         src/core/null/window_null.cpp
@@ -727,6 +730,7 @@ else()
         src/core/sdl/window_sdl.cpp
         src/core/sdl/msgbox_sdl.cpp
         src/core/sdl/events_sdl.cpp
+        src/core/sdl/sdl_core.cpp
     )
 endif()
 

--- a/lib/Logger/private/logger_android.cpp
+++ b/lib/Logger/private/logger_android.cpp
@@ -92,7 +92,7 @@ void LoggerPrivate_pLogConsole(int level, const char *label, const char *format,
 }
 
 #ifndef NO_FILE_LOGGING
-void LoggerPrivate_pLogFile(int level, const char *label, const char *format, va_list arg)
+void LoggerPrivate_pLogFile(int level, const char *label, const char *in_time, const char *format, va_list arg)
 {
     va_list arg_in;
     (void)level;
@@ -104,7 +104,7 @@ void LoggerPrivate_pLogFile(int level, const char *label, const char *format, va
 
     va_copy(arg_in, arg);
 
-    int len = SDL_snprintf(g_outputBuffer, OUT_BUFFER_SIZE, "%s: ", label);
+    int len = SDL_snprintf(g_outputBuffer, OUT_BUFFER_SIZE, "%s [%s]: ", in_time, label);
     if(len > 0)
         SDL_RWwrite(s_logout, g_outputBuffer, 1, (size_t)(len < OUT_BUFFER_STRING_SIZE ? len : OUT_BUFFER_STRING_SIZE));
 

--- a/lib/Logger/private/logger_desktop.cpp
+++ b/lib/Logger/private/logger_desktop.cpp
@@ -99,7 +99,7 @@ void LoggerPrivate_pLogConsole(int level, const char *label, const char *format,
 }
 
 #ifndef NO_FILE_LOGGING
-void LoggerPrivate_pLogFile(int level, const char *label, const char *format, va_list arg)
+void LoggerPrivate_pLogFile(int level, const char *label, const char *in_time, const char *format, va_list arg)
 {
     va_list arg_in;
     (void)level;
@@ -111,7 +111,7 @@ void LoggerPrivate_pLogFile(int level, const char *label, const char *format, va
 
     va_copy(arg_in, arg);
 
-    int len = SDL_snprintf(g_outputBuffer, OUT_BUFFER_SIZE, "%s: ", label);
+    int len = SDL_snprintf(g_outputBuffer, OUT_BUFFER_SIZE, "%s [%s]: ", in_time, label);
     if(len > 0)
         SDL_RWwrite(s_logout, g_outputBuffer, 1, (size_t)(len < OUT_BUFFER_STRING_SIZE ? len : OUT_BUFFER_STRING_SIZE));
 

--- a/lib/Logger/private/logger_dummy.cpp
+++ b/lib/Logger/private/logger_dummy.cpp
@@ -36,10 +36,11 @@ void LoggerPrivate_pLogConsole(int level, const char *label, const char *format,
 }
 
 #ifndef NO_FILE_LOGGING
-void LoggerPrivate_pLogFile(int level, const char *label, const char *format, va_list arg)
+void LoggerPrivate_pLogFile(int level, const char *label, const char *in_time, const char *format, va_list arg)
 {
     (void)level;
     (void)label;
+    (void)in_time;
     (void)format;
     (void)arg;
 }

--- a/lib/Logger/private/logger_emscripten.cpp
+++ b/lib/Logger/private/logger_emscripten.cpp
@@ -70,6 +70,6 @@ void LoggerPrivate_pLogConsole(int level, const char *label, const char *format,
 }
 
 #ifndef NO_FILE_LOGGING
-void LoggerPrivate_pLogFile(int, const char *, const char *, va_list)
+void LoggerPrivate_pLogFile(int, const char *, const char *, const char *, va_list)
 {}
 #endif // NO_FILE_LOGGING

--- a/lib/Logger/private/logger_min.cpp
+++ b/lib/Logger/private/logger_min.cpp
@@ -76,7 +76,7 @@ void LoggerPrivate_pLogConsole(int level, const char *label, const char *format,
 }
 
 #ifndef NO_FILE_LOGGING
-void LoggerPrivate_pLogFile(int level, const char *label, const char *format, va_list arg)
+void LoggerPrivate_pLogFile(int level, const char *label, const char *in_time, const char *format, va_list arg)
 {
     MUTEXLOCK(mutex);
     if(!s_logout)
@@ -86,7 +86,7 @@ void LoggerPrivate_pLogFile(int level, const char *label, const char *format, va
     (void)level;
 
     va_copy(arg_in, arg);
-    std::fprintf(s_logout, "%s: ", label);
+    std::fprintf(s_logout, "%s [%s]: ", in_time, label);
     std::vfprintf(s_logout, format, arg_in);
     std::fprintf(s_logout, OS_NEWLINE);
     std::fflush(s_logout);

--- a/lib/Logger/private/logger_sets.h
+++ b/lib/Logger/private/logger_sets.h
@@ -41,6 +41,8 @@ public:
     //! Verbose logs to stdOut if possible
     static bool       m_enabledVerboseLogs;
 
+    static uint64_t   m_appStartTicks;
+
     static void OpenLogFile();
     static void CloseLog();
 };
@@ -48,7 +50,7 @@ public:
 extern void LoggerPrivate_pLogConsole(int level, const char *label, const char *format, va_list arg);
 
 #ifndef NO_FILE_LOGGING
-extern void LoggerPrivate_pLogFile(int level, const char *label, const char *format, va_list arg);
+extern void LoggerPrivate_pLogFile(int level, const char *label, const char *in_time, const char *format, va_list arg);
 #endif
 
 #endif // LOGGER_SETS_H

--- a/lib/Logger/private/logger_vita.cpp
+++ b/lib/Logger/private/logger_vita.cpp
@@ -85,7 +85,7 @@ void LoggerPrivate_pLogConsole(int level, const char *label, const char *format,
 }
 
 #ifndef NO_FILE_LOGGING
-void LoggerPrivate_pLogFile(int level, const char *label, const char *format, va_list arg)
+void LoggerPrivate_pLogFile(int level, const char *label, const char *in_time, const char *format, va_list arg)
 {
     if(!s_logout)
         return;
@@ -94,7 +94,7 @@ void LoggerPrivate_pLogFile(int level, const char *label, const char *format, va
     (void)level;
 
     va_copy(arg_in, arg);
-    std::fprintf(s_logout, "%s: ", label);
+    std::fprintf(s_logout, "%s [%s]: ", in_time, label);
     std::vfprintf(s_logout, format, arg_in);
     std::fprintf(s_logout, OS_NEWLINE);
     std::fflush(s_logout);

--- a/lib/sdl_proxy/null/std_null.cpp
+++ b/lib/sdl_proxy/null/std_null.cpp
@@ -27,6 +27,11 @@ uint32_t SDL_GetTicks()
    return ++curTime;
 }
 
+uint64_t SDL_GetTicks64()
+{
+   return ++curTime;
+}
+
 uint64_t SDL_GetMicroTicks()
 {
     return curTime * 1000;

--- a/lib/sdl_proxy/sdl_timer.h
+++ b/lib/sdl_proxy/sdl_timer.h
@@ -24,7 +24,16 @@
 
 #ifndef SDLRPOXY_NULL
 
+#include <SDL2/SDL_version.h>
 #include <SDL2/SDL_timer.h>
+
+#if !SDL_VERSION_ATLEAST(2, 0, 18)
+// This call has been introduced in SDL 2.0.18. For the older SDL2, have a fallback!
+inline uint64_t SDL_GetTicks64()
+{
+    return (uint64_t)SDL_GetTicks();
+}
+#endif
 
 #else
 
@@ -36,6 +45,7 @@
 
 #ifndef SDL_timer_h_
 extern uint32_t SDL_GetTicks();
+extern uint64_t SDL_GetTicks64();
 #endif
 
 inline void SDL_Delay(int x)

--- a/lib/sdl_proxy/wii/std_wii.cpp
+++ b/lib/sdl_proxy/wii/std_wii.cpp
@@ -43,9 +43,7 @@ uint64_t startTime = -1;
 uint64_t SDL_GetMicroTicks()
 {
     if(startTime == (uint64_t)-1)
-    {
         startTime = gettime();
-    }
 
     return diff_usec(startTime, gettime());
 }

--- a/src/core/sdl/sdl_core.cpp
+++ b/src/core/sdl/sdl_core.cpp
@@ -53,13 +53,15 @@ bool CoreSDL::init(const CmdLineSetup_t &setup)
 #if !defined(SDL_AUDIO_DISABLED)
     sdlInitFlags |= SDL_INIT_AUDIO;
 #endif
+#if !defined(__WII__) && !defined(__3DS__)
     sdlInitFlags |= SDL_INIT_VIDEO;
     sdlInitFlags |= SDL_INIT_EVENTS;
-#if !defined(SDL_JOYSTICK_DISABLED)
+#endif
+#if !defined(__WII__) && !defined(__3DS__) && !defined(SDL_JOYSTICK_DISABLED)
     sdlInitFlags |= SDL_INIT_JOYSTICK;
     sdlInitFlags |= SDL_INIT_GAMECONTROLLER;
 #endif
-#if !defined(SDL_HAPTIC_DISABLED)
+#if !defined(__WII__) && !defined(__3DS__) && !defined(SDL_HAPTIC_DISABLED)
     sdlInitFlags |= SDL_INIT_HAPTIC;
 #endif
 

--- a/src/core/sdl/sdl_core.cpp
+++ b/src/core/sdl/sdl_core.cpp
@@ -1,0 +1,83 @@
+/*
+ * Moondust, a free game engine for platform game making
+ * Copyright (c) 2014-2023 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This software is licensed under a dual license system (MIT or GPL version 3 or later).
+ * This means you are free to choose with which of both licenses (MIT or GPL version 3 or later)
+ * you want to use this software.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You can see text of MIT license in the LICENSE.mit file you can see in Engine folder,
+ * or see https://mit-license.org/.
+ *
+ * You can see text of GPLv3 license in the LICENSE.gpl3 file you can see in Engine folder,
+ * or see <http://www.gnu.org/licenses/>.
+ */
+
+#include <locale.h>
+#include <SDL2/SDL.h>
+#include <Logger/logger.h>
+
+#include "sdl_core.h"
+
+
+bool CoreSDL::init(const CmdLineSetup_t &setup)
+{
+    bool res;
+
+    if(setup.allowBgInput)
+        SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+
+#if defined(__ANDROID__) || (defined(__APPLE__) && (defined(TARGET_IPHONE_SIMULATOR) || defined(TARGET_OS_IPHONE)))
+    // Restrict the landscape orientation only
+    SDL_SetHint(SDL_HINT_ORIENTATIONS, "LandscapeLeft LandscapeRight");
+#endif
+
+#if defined(__ANDROID__)
+    SDL_setenv("SDL_AUDIODRIVER", "openslES", 1);
+    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
+    SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
+    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 5);
+    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 6);
+    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 5);
+#endif
+
+    Uint32 sdlInitFlags = 0;
+    // Prepare flags for SDL initialization
+#if !defined(__EMSCRIPTEN__) && !defined(SDL_TIMERS_DISABLED)
+    sdlInitFlags |= SDL_INIT_TIMER;
+#endif
+#if !defined(SDL_AUDIO_DISABLED)
+    sdlInitFlags |= SDL_INIT_AUDIO;
+#endif
+    sdlInitFlags |= SDL_INIT_VIDEO;
+    sdlInitFlags |= SDL_INIT_EVENTS;
+#if !defined(SDL_JOYSTICK_DISABLED)
+    sdlInitFlags |= SDL_INIT_JOYSTICK;
+    sdlInitFlags |= SDL_INIT_GAMECONTROLLER;
+#endif
+#if !defined(SDL_HAPTIC_DISABLED)
+    sdlInitFlags |= SDL_INIT_HAPTIC;
+#endif
+
+    // Initialize SDL
+    res = (SDL_Init(sdlInitFlags) >= 0);
+
+    // Workaround: https://discourse.libsdl.org/t/26995
+    setlocale(LC_NUMERIC, "C");
+
+    const char *error = SDL_GetError();
+    if(*error != '\0')
+        pLogWarning("Error while SDL Initialization: %s", error);
+    SDL_ClearError();
+
+    return res;
+}
+
+void CoreSDL::quit()
+{
+    SDL_Quit();
+}

--- a/src/core/sdl/sdl_core.h
+++ b/src/core/sdl/sdl_core.h
@@ -1,0 +1,32 @@
+/*
+ * Moondust, a free game engine for platform game making
+ * Copyright (c) 2014-2023 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This software is licensed under a dual license system (MIT or GPL version 3 or later).
+ * This means you are free to choose with which of both licenses (MIT or GPL version 3 or later)
+ * you want to use this software.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You can see text of MIT license in the LICENSE.mit file you can see in Engine folder,
+ * or see https://mit-license.org/.
+ *
+ * You can see text of GPLv3 license in the LICENSE.gpl3 file you can see in Engine folder,
+ * or see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SDL_CORE_H
+#define SDL_CORE_H
+
+#include "cmd_line_setup.h"
+
+class CoreSDL
+{
+public:
+    static bool init(const CmdLineSetup_t &setup);
+    static void quit();
+};
+
+#endif // SDL_CORE_H

--- a/src/core/sdl/window_sdl.cpp
+++ b/src/core/sdl/window_sdl.cpp
@@ -105,59 +105,11 @@ WindowSDL::WindowSDL() :
 WindowSDL::~WindowSDL()
 {}
 
-bool WindowSDL::initSDL(const CmdLineSetup_t &setup, uint32_t windowInitFlags)
+bool WindowSDL::initSDL(uint32_t windowInitFlags)
 {
     bool res = true;
 
     m_windowTitle = g_gameInfo.titleWindow;
-
-    if(setup.allowBgInput)
-        SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
-
-#if defined(__ANDROID__) || (defined(__APPLE__) && (defined(TARGET_IPHONE_SIMULATOR) || defined(TARGET_OS_IPHONE)))
-    // Restrict the landscape orientation only
-    SDL_SetHint(SDL_HINT_ORIENTATIONS, "LandscapeLeft LandscapeRight");
-#endif
-
-#if defined(__ANDROID__)
-    SDL_setenv("SDL_AUDIODRIVER", "openslES", 1);
-    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
-    SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
-    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 5);
-    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 6);
-    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 5);
-#endif
-
-    Uint32 sdlInitFlags = 0;
-    // Prepare flags for SDL initialization
-#if !defined(__EMSCRIPTEN__) && !defined(SDL_TIMERS_DISABLED)
-    sdlInitFlags |= SDL_INIT_TIMER;
-#endif
-#if !defined(SDL_AUDIO_DISABLED)
-    sdlInitFlags |= SDL_INIT_AUDIO;
-#endif
-    sdlInitFlags |= SDL_INIT_VIDEO;
-    sdlInitFlags |= SDL_INIT_EVENTS;
-#if !defined(SDL_JOYSTICK_DISABLED)
-    sdlInitFlags |= SDL_INIT_JOYSTICK;
-    sdlInitFlags |= SDL_INIT_GAMECONTROLLER;
-#endif
-#if !defined(SDL_HAPTIC_DISABLED)
-    sdlInitFlags |= SDL_INIT_HAPTIC;
-#endif
-
-    // Initialize SDL
-    res = (SDL_Init(sdlInitFlags) >= 0);
-
-    // Workaround: https://discourse.libsdl.org/t/26995
-    setlocale(LC_NUMERIC, "C");
-
-    const char *error = SDL_GetError();
-    if(*error != '\0')
-        pLogWarning("Error while SDL Initialization: %s", error);
-    SDL_ClearError();
-    if(!res)
-        return false;
 
     SDL_GL_ResetAttributes();
 
@@ -272,8 +224,6 @@ void WindowSDL::close()
     if(m_window)
         SDL_DestroyWindow(m_window);
     m_window = nullptr;
-
-    SDL_Quit();
 }
 
 SDL_Window *WindowSDL::getWindow()

--- a/src/core/sdl/window_sdl.h
+++ b/src/core/sdl/window_sdl.h
@@ -43,7 +43,7 @@ public:
     WindowSDL();
     virtual ~WindowSDL();
 
-    bool initSDL(const CmdLineSetup_t &setup, uint32_t windowInitFlags);
+    bool initSDL(uint32_t windowInitFlags);
 
     void close() override;
 

--- a/src/core/wii/window_wii.cpp
+++ b/src/core/wii/window_wii.cpp
@@ -41,13 +41,6 @@ namespace XWindow
 
 bool init()
 {
-    // Mixer is the only component using SDL on Wii
-    if(SDL_Init(SDL_INIT_AUDIO|SDL_INIT_TIMER) < 0)
-    {
-        pLogWarning("Couldn't initialize SDL audio: %s\n", SDL_GetError());
-        return false;
-    }
-
     return true;
 }
 

--- a/src/frm_main.cpp
+++ b/src/frm_main.cpp
@@ -31,6 +31,10 @@
 #include "core/msgbox.h"
 #include "core/events.h"
 
+#ifndef THEXTECH_NO_SDL_CORE
+#   include "core/sdl/sdl_core.h"
+#endif
+
 #ifdef CORE_EVERYTHING_SDL
 #   include "core/sdl/render_sdl.h"
 typedef RenderSDL RenderUsed;
@@ -61,6 +65,12 @@ bool FrmMain::initSystem(const CmdLineSetup_t &setup)
     LoadLogSettings(setup.interprocess, setup.verboseLogging);
     //Write into log the application start event
     pLogDebug("<Application started>");
+
+#ifndef THEXTECH_NO_SDL_CORE
+    res = CoreSDL::init(setup);
+    if(!res)
+        return false;
+#endif
 
 #if defined(__WII__) || defined(__3DS__) || !defined(RENDER_CUSTOM)
     //Initialize FreeImage
@@ -99,7 +109,7 @@ bool FrmMain::initSystem(const CmdLineSetup_t &setup)
     D_pLogDebugNA("FrmMain: Loading XWindow...");
     res = XWindow::init();
 #elif defined(USE_CORE_WINDOW_SDL)
-    res = window->initSDL(setup, render->SDL_InitFlags());
+    res = window->initSDL(render->SDL_InitFlags());
 #else
 #   error "FIXME: Implement supported window initialization here"
 #endif
@@ -207,6 +217,10 @@ void FrmMain::freeSystem()
 
     pLogDebug("<Application closed>");
     CloseLog();
+
+#ifndef THEXTECH_NO_SDL_CORE
+    CoreSDL::quit();
+#endif
 }
 
 bool FrmMain::restartRenderer()


### PR DESCRIPTION
There are two changes made:
- SDL init/quit has been moved into separated thing: SDL is much more than just a window, so, it should be initalized globally before everything, and should be closed after everything got been closed too.
- Added timestamps to every log entry written into the file: the time will show how much time was passed since application startup. This could help to debug the performance at certain points.

Note: if SDL is completely not needed, the `THEXTECH_NO_SDL_CORE` macro should been defined, and the `sdl_core.cpp` should not be included into the build.