### PR TITLE
Backport modern section change logic from multires

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,8 @@ Changelog for 1.3.6.1
 -Keyhole framerate fix will be enabled by default (@Wohlstand, @0lhi)
 -Fixed vanilla bug where player could fall through an Instant/Portal warp while performing the "Pound" move. (@ds-sloth)
 -Fixed vanilla bug where held item would not affect a hostile NPC that intersects with an immune NPC (such as an egg container). (@ds-sloth)
+-Fixed vanilla bug where engine would appear to break if an event changed the boundaries of a different section. (@ds-sloth)
+-Added modern animations for section boundary change in multiplayer. (@ds-sloth)
 
 Changelog for 1.3.6
 -Added an ability to toggle drawing of the HUD and other on-screen meta data using F1 key (@Wohlstand)

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -121,6 +121,7 @@ static void compatInit(Compatibility_t &c)
     c.custom_powerup_collect_score = true;
     c.fix_player_crush_death = true;
     c.fix_pound_skip_warp = true;
+    c.modern_section_change = true;
 
 
     if(s_compatLevel >= COMPAT_SMBX2) // Make sure that bugs were same as on SMBX2 Beta 4 on this moment
@@ -167,6 +168,7 @@ static void compatInit(Compatibility_t &c)
         c.custom_powerup_collect_score = false;
         c.fix_player_crush_death = false;
         c.fix_pound_skip_warp = false;
+        c.modern_section_change = false;
     }
 
     if(s_compatLevel >= COMPAT_SMBX13) // Strict vanilla SMBX
@@ -413,6 +415,7 @@ static void loadCompatIni(Compatibility_t &c, const std::string &fileName)
         // compat.read("custom-powerup-collect-score", c.custom_powerup_collect_score, c.custom_powerup_collect_score);
         compat.read("fix-player-crush-death", c.fix_player_crush_death, c.fix_player_crush_death);
         compat.read("fix-pound-skip-warp", c.fix_pound_skip_warp, c.fix_pound_skip_warp);
+        compat.read("modern-section-change", c.modern_section_change, c.modern_section_change);
     }
     // 1.3.4
     compat.read("fix-player-filter-bounce", c.fix_player_filter_bounce, c.fix_player_filter_bounce);

--- a/src/compat.h
+++ b/src/compat.h
@@ -90,6 +90,7 @@ struct Compatibility_t
     bool custom_powerup_collect_score; // collected powerups give score from npc-X.txt
     bool fix_player_crush_death; // player should not be crushed by corners of slopes or by hitting a horizontally moving ceiling
     bool fix_pound_skip_warp; // ground pound state should not skip instant / portal warps
+    bool modern_section_change; // fix glitches and improve animations for section resize
     unsigned int bitblit_background_colour[3];
 
     // SpeedRun section

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -60,10 +60,14 @@ void SetupGraphics();
 //! DUMMY AND USELESS
 void SetupEditorGraphics();
 // Public Sub SetupScreens()
-void SetupScreens();
+void SetupScreens(bool reset = true);
 // Public Sub DynamicScreen() 'for the split screen stuff
 // for the split screen stuff
 void DynamicScreen();
+
+// NEW: moves qScreen towards vScreen, now including the screen size
+bool Update_qScreen(int Z, int camRate = 2, int resizeRate = 2);
+
 // Public Sub SuperPrint(SuperWords As String, Font As Integer, X As Single, Y As Single) 'prints text to the screen
 // prints text to the screen
 int SuperTextPixLen(int SuperN, const char* SuperChars, int Font);

--- a/src/graphics/gfx_update.cpp
+++ b/src/graphics/gfx_update.cpp
@@ -827,6 +827,8 @@ void UpdateGraphics(bool skipRepaint)
 
     g_stats.reset();
 
+    bool continue_qScreen = false;
+
     // prepare to fill this frame's NoReset queue
     std::swap(NPCQueues::NoReset, s_NoReset_NPCs_LastFrame);
     NPCQueues::NoReset.clear();
@@ -855,24 +857,13 @@ void UpdateGraphics(bool skipRepaint)
                 GetvScreen(Z);
         }
 
+        // moved to `graphics/gfx_screen.cpp`
         if(!Do_FrameSkip && qScreen)
-        {
-            if(vScreen[1].X < qScreenLoc[1].X - 2)
-                qScreenLoc[1].X -= 2;
-            else if(vScreen[1].X > qScreenLoc[1].X + 2)
-                qScreenLoc[1].X += 2;
-            if(vScreen[1].Y < qScreenLoc[1].Y - 2)
-                qScreenLoc[1].Y -= 2;
-            else if(vScreen[1].Y > qScreenLoc[1].Y + 2)
-                qScreenLoc[1].Y += 2;
+            continue_qScreen |= Update_qScreen(Z);
 
-            if(qScreenLoc[1].X < vScreen[1].X + 5 && qScreenLoc[1].X > vScreen[1].X - 5 &&
-               qScreenLoc[1].Y < vScreen[1].Y + 5 && qScreenLoc[1].Y > vScreen[1].Y - 5)
-                qScreen = false;
-
-            vScreen[1].X = qScreenLoc[1].X;
-            vScreen[1].Y = qScreenLoc[1].Y;
-        }
+        // the original code was badly written and made THIS happen (always exactly one frame of qScreen in 2P mode)
+        if(Z == 2 && !g_compatibility.modern_section_change)
+            continue_qScreen = false;
 
         // noturningback
         if(!LevelEditor && NoTurnBack[Player[Z].Section])
@@ -995,6 +986,10 @@ void UpdateGraphics(bool skipRepaint)
     // we've now done all the logic that UpdateGraphics can do.
     if(Do_FrameSkip)
         return;
+
+    // only updated on non-frameskip in vanilla
+    qScreen = continue_qScreen;
+
 
     XRender::setTargetTexture();
 

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -865,6 +865,7 @@ void ProcEvent(eventindex_t index, bool NoEffect)
                             SetupScreens(false);
                             DynamicScreen();
                             // CenterScreens();
+
                             if(vScreen[2].Visible)
                             {
                                 for(int Z = 1; Z <= 2; Z++)
@@ -887,7 +888,9 @@ void ProcEvent(eventindex_t index, bool NoEffect)
                                     GetvScreen(Z);
                             }
                             else
+                            {
                                 GetvScreenAverage();
+                            }
 
                             // set the qScreen!
                             qScreen = true;
@@ -895,40 +898,48 @@ void ProcEvent(eventindex_t index, bool NoEffect)
 
                             // set the second qScreen if possible
                             if(vScreen[2].Visible)
-                            {
                                 qScreenLoc[2] = vScreen[2];
-                            }
 
                             // special code to indicate the direction the other player was warped from
                             if(warped_plr && !vScreen[2].Visible)
                             {
+                                // total distance of warp
                                 double dSquare = tX * tX + tY * tY;
 
+                                // project onto the circle: proportion of distance from each axis
                                 double xProp = tX * tX / dSquare;
                                 double yProp = tY * tY / dSquare;
 
                                 if(tX < 0)
                                     xProp *= -1;
+
                                 if(tY < 0)
                                     yProp *= -1;
 
+                                // maximum total shift of 1/4 of the vScreen's size; also limit by 200x150 (SMBX64 amount)
                                 double maxShiftX = vScreen[1].Width / 4;
                                 double maxShiftY = vScreen[1].Height / 4;
+
                                 if(maxShiftX > 200)
                                     maxShiftX = 200;
+
                                 if(maxShiftY > 150)
                                     maxShiftY = 150;
 
+                                // apply the shift
                                 qScreenLoc[1].X += maxShiftX * xProp;
                                 qScreenLoc[1].Y += maxShiftY * yProp;
 
                                 // restrict to old level bounds
                                 if(-qScreenLoc[1].X < level[B].X)
                                     qScreenLoc[1].X = -level[B].X;
+
                                 if(-qScreenLoc[1].X + vScreen[1].Width > level[B].Width)
                                     qScreenLoc[1].X = -(level[B].Width - vScreen[1].Width);
+
                                 if(-qScreenLoc[1].Y < level[B].Y)
                                     qScreenLoc[1].Y = -level[B].Y;
+
                                 if(-qScreenLoc[1].Y + vScreen[1].Height > level[B].Height)
                                     qScreenLoc[1].Y = -(level[B].Height - vScreen[1].Height);
                             }
@@ -965,7 +976,7 @@ void ProcEvent(eventindex_t index, bool NoEffect)
                             qScreen = true;
                             qScreenLoc[1] = vScreen[1];
 
-                            // pan to indicate warped player
+                            // pan to indicate warped player, in the direction the screen was previously split
                             if(int(screenLoc.Width) == 400)
                             {
                                 if(qScreenLoc[1].X < screenLoc.X + screenLoc.Left)
@@ -985,13 +996,17 @@ void ProcEvent(eventindex_t index, bool NoEffect)
                             // restrict to old level bounds
                             if(-qScreenLoc[1].X < level[B].X)
                                 qScreenLoc[1].X = -level[B].X;
+
                             if(-qScreenLoc[1].X + ScreenW /*FrmMain.ScaleWidth*/ > level[B].Width)
                                 qScreenLoc[1].X = -(level[B].Width - ScreenW);
+
                             if(-qScreenLoc[1].Y < level[B].Y)
                                 qScreenLoc[1].Y = -level[B].Y;
+
                             if(-qScreenLoc[1].Y + ScreenH /*FrmMain.ScaleHeight*/ > level[B].Height)
                                 qScreenLoc[1].Y = -(level[B].Height - ScreenH);
 
+                            // restore the new level
                             level[B] = static_cast<Location_t>(s.position);
                         }
                         else


### PR DESCRIPTION
Partial port of the modern section change logic from multires. Does not contain the logic for `vScreen` position (`ScreenTop` / `ScreenLeft`) or for the "quick section change" used for star exits in the Yoshi's Archipelago episode.

This code is all well-tested and should be ready for immediate merge, but I'd like @Wohlstand's quick review before merging.

At 800x600, there will be two visible effects. First, bug #43 will not occur. Second, 2P camera merges / splits will be animated.

Fixes #43.

<img src="https://github.com/Wohlstand/TheXTech/assets/72112344/60f39681-dd7c-4dc2-985a-49dffbc8d25d" width="400" height="300">

<img src="https://github.com/Wohlstand/TheXTech/assets/72112344/516de216-419e-4390-a103-624c7b22957e" width="400" height="300">

[section resize.lvl.zip](https://github.com/Wohlstand/TheXTech/files/12196216/section.resize.lvl.zip)
