### PR TITLE
Quick backport of scale mode feature from multires

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -56,6 +56,7 @@ Changelog for 1.3.6.1
 -Fade out effect occurs during the last 30 frames of the SMBX64 death animation instead of during a pause following the animation (@ds-sloth)
 -Added support for starting a level test from a certain warp (available in editor and command line flag -w / --start-warp) (@ds-sloth)
 -Added support for starting a world with a specific save (--save-slot X) from the command line (@ds-sloth)
+-Added option to control how gameplay is scaled onto physical screen (@ds-sloth)
 
 Changelog for 1.3.6
 -Added an ability to toggle drawing of the HUD and other on-screen meta data using F1 key (@Wohlstand)

--- a/resources/languages/thextech_en.json
+++ b/resources/languages/thextech_en.json
@@ -569,7 +569,13 @@
         "options": {
             "optionsModeFullScreen": "Fullscreen mode",
             "optionsModeWindowed": "Windowed mode",
-            "optionsViewCredits": "View credits"
+            "optionsViewCredits": "View credits",
+            "scale": {
+                "integer": "Integer",
+                "label": "Scale",
+                "linear": "Linear",
+                "nearest": "Nearest"
+            }
         },
         "wordBack": "Back",
         "wordHide": "Hide",

--- a/resources/languages/thextech_zh-cn.json
+++ b/resources/languages/thextech_zh-cn.json
@@ -572,7 +572,7 @@
             "optionsViewCredits": "查看制作团队",
             "scale": {
                 "integer": "整数",
-                "label": "图像插值",
+                "label": "图像缩放",
                 "linear": "双线性",
                 "nearest": "最近邻居"
             }

--- a/resources/languages/thextech_zh-cn.json
+++ b/resources/languages/thextech_zh-cn.json
@@ -569,7 +569,13 @@
         "options": {
             "optionsModeFullScreen": "全屏模式",
             "optionsModeWindowed": "窗口模式",
-            "optionsViewCredits": "查看制作团队"
+            "optionsViewCredits": "查看制作团队",
+            "scale": {
+                "integer": "整数",
+                "label": "图像插值",
+                "linear": "双线性",
+                "nearest": "最近邻居"
+            }
         },
         "wordBack": "返回",
         "wordHide": "隐藏",

--- a/src/change_res.cpp
+++ b/src/change_res.cpp
@@ -19,13 +19,14 @@
  */
 
 #include "globals.h"
+#include "video.h"
 #include "change_res.h"
 #include "load_gfx.h"
 #include "core/window.h"
+#include "core/render.h"
 #ifdef __EMSCRIPTEN__
 #include "core/events.h"
 #endif
-
 
 void SetOrigRes()
 {
@@ -33,7 +34,12 @@ void SetOrigRes()
     resChanged = false;
 
 #ifndef __EMSCRIPTEN__
-    XWindow::setWindowSize(ScreenW, ScreenH);
+    if(g_videoSettings.scaleMode == SCALE_FIXED_05X)
+        XWindow::setWindowSize(ScreenW/2, ScreenH/2);
+    else if(g_videoSettings.scaleMode == SCALE_FIXED_2X)
+        XWindow::setWindowSize(ScreenW*2, ScreenH*2);
+    else
+        XWindow::setWindowSize(ScreenW, ScreenH);
 #endif
 
 #ifdef __EMSCRIPTEN__
@@ -59,3 +65,25 @@ void ChangeRes(int, int, int, int)
 //{
 
 //}
+
+void UpdateInternalRes()
+{
+    XRender::updateViewport();
+}
+
+void UpdateWindowRes()
+{
+    if(resChanged)
+        return;
+
+    int w = ScreenW;
+    int h = ScreenH;
+
+    if(g_videoSettings.scaleMode == SCALE_FIXED_05X)
+        XWindow::setWindowSize(w / 2, h / 2);
+    else if(g_videoSettings.scaleMode == SCALE_FIXED_1X)
+        XWindow::setWindowSize(w, h);
+    else if(g_videoSettings.scaleMode == SCALE_FIXED_2X)
+        XWindow::setWindowSize(w * 2, h * 2);
+}
+

--- a/src/change_res.cpp
+++ b/src/change_res.cpp
@@ -73,7 +73,7 @@ void UpdateInternalRes()
 
 void UpdateWindowRes()
 {
-    if(resChanged)
+    if(XWindow::isFullScreen() || XWindow::isMaximized())
         return;
 
     int w = ScreenW;

--- a/src/change_res.cpp
+++ b/src/change_res.cpp
@@ -35,9 +35,9 @@ void SetOrigRes()
 
 #ifndef __EMSCRIPTEN__
     if(g_videoSettings.scaleMode == SCALE_FIXED_05X)
-        XWindow::setWindowSize(ScreenW/2, ScreenH/2);
+        XWindow::setWindowSize(ScreenW / 2, ScreenH / 2);
     else if(g_videoSettings.scaleMode == SCALE_FIXED_2X)
-        XWindow::setWindowSize(ScreenW*2, ScreenH*2);
+        XWindow::setWindowSize(ScreenW * 2, ScreenH * 2);
     else
         XWindow::setWindowSize(ScreenW, ScreenH);
 #endif

--- a/src/change_res.h
+++ b/src/change_res.h
@@ -26,4 +26,12 @@
 void SetOrigRes();
 void ChangeRes(int ScreenX, int ScreenY, int ScreenColor, int ScreenFreq);
 
+// New: update the internal game resolution and scaling based on game window size and preferences
+// Calls XRender::updateViewport on completion
+void UpdateInternalRes();
+
+// New: update the window size based on internal resolution and scaling factor
+// Only active for windowed mode with 0.5x, 1x, or 2x scaling
+void UpdateWindowRes();
+
 #endif // CHANGE_RES_H

--- a/src/core/16m/window_16m.cpp
+++ b/src/core/16m/window_16m.cpp
@@ -59,6 +59,7 @@ void getWindowSize(int *w, int *h)
 
 bool hasWindowInputFocus() { return true; }
 bool hasWindowMouseFocus() { return true; }
+bool isMaximized() { return false; }
 
 
 }; // namespace XWindow

--- a/src/core/3ds/render_3ds.cpp
+++ b/src/core/3ds/render_3ds.cpp
@@ -733,7 +733,9 @@ void minport_ApplyPhysCoords()
 
     g_screen_swapped = should_swap_screen();
 
-    GPU_TEXTURE_FILTER_PARAM filter =  GPU_LINEAR;
+    GPU_TEXTURE_FILTER_PARAM filter = (g_videoSettings.scaleMode == SCALE_DYNAMIC_LINEAR || g_videoSettings.scaleMode == SCALE_FIXED_05X)
+        ? GPU_LINEAR
+        : GPU_NEAREST;
 
     for(int layer = 0; layer < 4; layer++)
     {

--- a/src/core/3ds/window_3ds.cpp
+++ b/src/core/3ds/window_3ds.cpp
@@ -66,5 +66,6 @@ void getWindowSize(int *w, int *h)
 
 bool hasWindowInputFocus() { return true; }
 bool hasWindowMouseFocus() { return true; }
+bool isMaximized() { return false; }
 
 } // namespace XWindow

--- a/src/core/base/events_base.cpp
+++ b/src/core/base/events_base.cpp
@@ -22,6 +22,7 @@
 #include "../render.h"
 #include "controls.h"
 #include "graphics.h"
+#include "change_res.h"
 
 AbstractEvents_t *g_events = nullptr;
 
@@ -35,7 +36,6 @@ void AbstractEvents_t::init(FrmMain *form)
 
 void AbstractEvents_t::eventResize()
 {
-    XRender::updateViewport();
-    SetupScreens();
+    UpdateInternalRes();
     Controls::UpdateTouchScreenSize();
 }

--- a/src/core/base/render_base.h
+++ b/src/core/base/render_base.h
@@ -287,7 +287,7 @@ public:
     static void toggleGifRecorder();
     static void processRecorder();
 
-private:
+protected:
     static GifRecorder *m_gif;
     static bool recordInProcess();
 #endif // USE_SCREENSHOTS_AND_RECS

--- a/src/core/base/window_base.h
+++ b/src/core/base/window_base.h
@@ -116,6 +116,12 @@ public:
      * \return true if window has a mouse focus
      */
     virtual bool hasWindowMouseFocus() = 0;
+
+    /*!
+     * \brief Is window maximized (resized to fill desktop)?
+     * \return true if window is maximized
+     */
+    virtual bool isMaximized() = 0;
 };
 
 extern AbstractWindow_t *g_window;

--- a/src/core/minport/render_minport_shared.cpp
+++ b/src/core/minport/render_minport_shared.cpp
@@ -76,7 +76,7 @@ void updateViewport()
 
     int ScreenW_Show = ScreenW;
 
-    // if(g_videoSettings.scaleMode == SCALE_DYNAMIC_LINEAR || g_videoSettings.scaleMode == SCALE_DYNAMIC_NEAREST)
+    if(g_videoSettings.scaleMode == SCALE_DYNAMIC_LINEAR || g_videoSettings.scaleMode == SCALE_DYNAMIC_NEAREST)
     {
         int res_h = hardware_h;
         int res_w = ScreenW_Show * hardware_h / ScreenH;
@@ -90,7 +90,6 @@ void updateViewport()
         g_screen_phys_w = res_w;
         g_screen_phys_h = res_h;
     }
-#if 0
     else if(g_videoSettings.scaleMode == SCALE_FIXED_1X)
     {
         g_screen_phys_w = ScreenW_Show / 2;
@@ -121,7 +120,6 @@ void updateViewport()
             g_screen_phys_h -= ScreenH / 2;
         }
     }
-#endif
 
     pLogDebug("Phys screen is %d x %d", g_screen_phys_w, g_screen_phys_h);
 

--- a/src/core/null/window_null.cpp
+++ b/src/core/null/window_null.cpp
@@ -55,6 +55,7 @@ void getWindowSize(int *w, int *h)
 
 bool hasWindowInputFocus() { return true; }
 bool hasWindowMouseFocus() { return true; }
+bool isMaximized() { return false; }
 
 
 } // namespace XWindow

--- a/src/core/sdl/render_sdl.cpp
+++ b/src/core/sdl/render_sdl.cpp
@@ -18,10 +18,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <SDL2/SDL.h>
 #include <SDL2/SDL_version.h>
 #include <SDL2/SDL_render.h>
 #include <SDL2/SDL_opengl.h>
+#include <SDL2/SDL_hints.h>
 
 #include <FreeImageLite.h>
 #include <Logger/logger.h>

--- a/src/core/sdl/render_sdl.cpp
+++ b/src/core/sdl/render_sdl.cpp
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <SDL2/SDL.h>
 #include <SDL2/SDL_version.h>
 #include <SDL2/SDL_render.h>
 #include <SDL2/SDL_opengl.h>
@@ -114,6 +115,8 @@ bool RenderSDL::initRender(const CmdLineSetup_t &setup, SDL_Window *window)
         return false;
     }
 
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
+
     SDL_RendererInfo ri;
     SDL_GetRendererInfo(m_gRenderer, &ri);
     m_maxTextureWidth = ri.max_texture_width;
@@ -168,7 +171,6 @@ void RenderSDL::repaint()
 #endif
 
     int w, h, off_x, off_y, wDst, hDst;
-    float scale_x, scale_y;
 
     setTargetScreen();
 
@@ -191,23 +193,8 @@ void RenderSDL::repaint()
     }
 
     // Calculate the size difference factor
-    scale_x = float(w) / ScaleWidth;
-    scale_y = float(h) / ScaleHeight;
-
-    wDst = w;
-    hDst = h;
-
-    // Keep aspect ratio
-    if(scale_x > scale_y) // Width more than height
-    {
-        wDst = int(scale_y * ScaleWidth);
-        hDst = int(scale_y * ScaleHeight);
-    }
-    else if(scale_x < scale_y) // Height more than width
-    {
-        hDst = int(scale_x * ScaleHeight);
-        wDst = int(scale_x * ScaleWidth);
-    }
+    wDst = int(m_scale_x * ScaleWidth);
+    hDst = int(m_scale_y * ScaleHeight);
 
     // Align the rendering scene to the center of screen
     off_x = (w - wDst) / 2;
@@ -230,28 +217,39 @@ void RenderSDL::repaint()
 
 void RenderSDL::updateViewport()
 {
-    float w, w1, h, h1;
-    int   wi, hi;
+    int   render_w, render_h;
 
-    getRenderSize(&wi, &hi);
+    getRenderSize(&render_w, &render_h);
+
+    D_pLogDebug("Updated render size: %d x %d", render_w, render_h);
 
     // quickly update the HiDPI scaling factor
     int window_w, window_h;
     XWindow::getWindowSize(&window_w, &window_h);
-    m_hidpi_x = (float)wi / (float)window_w;
-    m_hidpi_y = (float)hi / (float)window_h;
+    m_hidpi_x = (float)render_w / (float)window_w;
+    m_hidpi_y = (float)render_h / (float)window_h;
 
-    D_pLogDebug("Updated window size: %d x %d", wi, hi);
+    float scale_x = (float)render_w / ScreenW;
+    float scale_y = (float)render_h / ScreenH;
 
-    w = wi;
-    h = hi;
-    w1 = w;
-    h1 = h;
+    float scale = SDL_min(scale_x, scale_y);
 
-    m_scale_x = w / ScaleWidth;
-    m_scale_y = h / ScaleHeight;
-    m_viewport_scale_x = m_scale_x;
-    m_viewport_scale_y = m_scale_y;
+    if(g_videoSettings.scaleMode == SCALE_FIXED_05X && scale > 0.5f)
+        scale = 0.5f;
+    if(g_videoSettings.scaleMode == SCALE_DYNAMIC_INTEGER && scale > 1.f)
+        scale = std::floor(scale);
+    if(g_videoSettings.scaleMode == SCALE_FIXED_1X && scale > 1.f)
+        scale = 1.f;
+    if(g_videoSettings.scaleMode == SCALE_FIXED_2X && scale > 2.f)
+        scale = 2.f;
+
+    int game_w = scale * ScreenW;
+    int game_h = scale * ScreenH;
+
+    m_scale_x = scale;
+    m_scale_y = scale;
+    m_viewport_scale_x = scale;
+    m_viewport_scale_y = scale;
 
     m_viewport_offset_x = 0;
     m_viewport_offset_y = 0;
@@ -259,24 +257,38 @@ void RenderSDL::updateViewport()
     m_viewport_offset_y_cur = 0;
     m_viewport_offset_ignore = false;
 
-    if(m_scale_x > m_scale_y)
-    {
-        w1 = m_scale_y * ScaleWidth;
-        m_viewport_scale_x = w1 / ScaleWidth;
-    }
-    else if(m_scale_x < m_scale_y)
-    {
-        h1 = m_scale_x * ScaleHeight;
-        m_viewport_scale_y = h1 / ScaleHeight;
-    }
-
-    m_offset_x = (w - w1) / 2;
-    m_offset_y = (h - h1) / 2;
+    m_offset_x = (render_w - game_w) / 2;
+    m_offset_y = (render_h - game_h) / 2;
 
     m_viewport_x = 0;
     m_viewport_y = 0;
-    m_viewport_w = static_cast<int>(w1);
-    m_viewport_h = static_cast<int>(h1);
+    m_viewport_w = ScreenW;
+    m_viewport_h = ScreenH;
+
+    // update render targets
+    if(m_current_scale_mode != g_videoSettings.scaleMode)
+    {
+#ifdef USE_SCREENSHOTS_AND_RECS
+        // invalidates GIF recorder handle
+        if(recordInProcess())
+            toggleGifRecorder();
+#endif
+
+        // update video settings
+        if(g_videoSettings.scaleMode == SCALE_DYNAMIC_LINEAR || scale < 0.5f)
+            SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+        else
+            SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
+
+        SDL_DestroyTexture(m_tBuffer);
+        m_tBuffer = SDL_CreateTexture(m_gRenderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, ScreenW, ScreenH);
+        SDL_SetRenderTarget(m_gRenderer, m_tBuffer);
+
+        // reset scaling setting for images loaded later
+        SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
+
+        m_current_scale_mode = g_videoSettings.scaleMode;
+    }
 }
 
 void RenderSDL::resetViewport()
@@ -288,7 +300,6 @@ void RenderSDL::resetViewport()
     SDL_RenderSetViewport(m_gRenderer, &altViewport);
 //#endif
 
-    updateViewport();
     SDL_RenderSetViewport(m_gRenderer, nullptr);
 }
 

--- a/src/core/sdl/render_sdl.h
+++ b/src/core/sdl/render_sdl.h
@@ -26,7 +26,7 @@
 
 #include "../base/render_base.h"
 #include "cmd_line_setup.h"
-
+#include "video.h"
 
 struct SDL_Renderer;
 struct SDL_Texture;
@@ -57,7 +57,7 @@ class RenderSDL final : public AbstractRender_t
     int m_viewport_offset_x_cur = 0;
     int m_viewport_offset_y_cur = 0;
 
-    //Need to calculate relative viewport position when screen was scaled
+    // Need to calculate relative viewport position when screen was scaled
     float m_viewport_scale_x = 1.0f;
     float m_viewport_scale_y = 1.0f;
 
@@ -65,6 +65,9 @@ class RenderSDL final : public AbstractRender_t
     int m_viewport_y = 0;
     int m_viewport_w = 0;
     int m_viewport_h = 0;
+
+    // Current scaling mode
+    int m_current_scale_mode = SCALE_DYNAMIC_NEAREST;
 
     //Need for HiDPI rendering (number of draw pixels per cursor pixel)
     float m_hidpi_x = 1.0f;

--- a/src/core/sdl/window_sdl.cpp
+++ b/src/core/sdl/window_sdl.cpp
@@ -396,3 +396,11 @@ bool WindowSDL::hasWindowMouseFocus()
     Uint32 flags = SDL_GetWindowFlags(m_window);
     return (flags & SDL_WINDOW_MOUSE_FOCUS) != 0;
 }
+
+bool WindowSDL::isMaximized()
+{
+    if(!m_window)
+        return false;
+    Uint32 flags = SDL_GetWindowFlags(m_window);
+    return (flags & SDL_WINDOW_MAXIMIZED) != 0;
+}

--- a/src/core/sdl/window_sdl.cpp
+++ b/src/core/sdl/window_sdl.cpp
@@ -24,9 +24,12 @@
 #include <Logger/logger.h>
 #include <Graphics/graphics_funcs.h>
 
+#include "globals.h"
 #include "main/game_info.h"
 #include "window_sdl.h"
 #include "../render.h"
+#include "config.h"
+#include "video.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/html5.h>
@@ -153,14 +156,21 @@ bool WindowSDL::initSDL(uint32_t windowInitFlags)
         return false;
     }
 
-#ifdef __EMSCRIPTEN__ //Set canvas be 1/2 size for a faster rendering
-    SDL_SetWindowMinimumSize(m_window, ScreenW / 2, ScreenH / 2);
+    SDL_SetWindowMinimumSize(m_window, 240, 160);
+
+#ifdef __EMSCRIPTEN__ // Set canvas be 1/2 size for a faster rendering
+    SDL_SetWindowSize(m_window, ScreenW / 2, ScreenH / 2);
 #elif defined(__ANDROID__) || defined(__SWITCH__) // Set as small as possible
     SDL_SetWindowMinimumSize(m_window, 200, 150);
 #elif defined(VITA)
-    SDL_SetWindowMinimumSize(m_window, 960, 544);
+    SDL_SetWindowSize(m_window, 960, 544);
 #else
-    SDL_SetWindowMinimumSize(m_window, ScreenW, ScreenH);
+    if(g_videoSettings.scaleMode == SCALE_FIXED_05X)
+        SDL_SetWindowSize(m_window, ScreenW / 2, ScreenH / 2);
+    else if(g_videoSettings.scaleMode == SCALE_FIXED_2X)
+        SDL_SetWindowSize(m_window, ScreenW * 2, ScreenH * 2);
+    else
+        SDL_SetWindowSize(m_window, ScreenW, ScreenH);
 #endif //__EMSCRIPTEN__
 
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");

--- a/src/core/sdl/window_sdl.h
+++ b/src/core/sdl/window_sdl.h
@@ -132,6 +132,12 @@ public:
      * \return true if window has a mouse focus
      */
     bool hasWindowMouseFocus() override;
+
+    /*!
+     * \brief Is window maximized (resized to fill desktop)?
+     * \return true if window is maximized
+     */
+    bool isMaximized() override;
 };
 
 #endif // WINDOWSDL_H

--- a/src/core/wii/window_wii.cpp
+++ b/src/core/wii/window_wii.cpp
@@ -67,6 +67,7 @@ void getWindowSize(int *w, int *h)
 
 bool hasWindowInputFocus() { return true; }
 bool hasWindowMouseFocus() { return true; }
+bool isMaximized() { return false; }
 
 
 } // namespace XWindow

--- a/src/core/window.h
+++ b/src/core/window.h
@@ -195,6 +195,17 @@ E_INLINE bool hasWindowMouseFocus() TAIL
 }
 #endif
 
+/*!
+ * \brief Is window maximized (resized to fill desktop)?
+ * \return true if window is maximized
+ */
+E_INLINE bool isMaximized() TAIL
+#ifndef WINDOW_CUSTOM
+{
+    return g_window->isMaximized();
+}
+#endif
+
 }
 
 #ifndef WINDOW_CUSTOM

--- a/src/main/main_config.cpp
+++ b/src/main/main_config.cpp
@@ -132,10 +132,19 @@ void OpenConfig_preSetup()
         config.read("background-controller-input", g_videoSettings.allowBgControllerInput, false);
         config.read("frame-skip", g_videoSettings.enableFrameSkip, true);
         config.read("show-fps", g_videoSettings.showFrameRate, false);
-
         bool scale_down_all;
         config.read("scale-down-all-textures", scale_down_all, false);
         config.readEnum("scale-down-textures", g_videoSettings.scaleDownTextures, scale_down_all ? (int)VideoSettings_t::SCALE_ALL : (int)VideoSettings_t::SCALE_SAFE, scaleDownTextures);
+        IniProcessing::StrEnumMap scaleModes =
+        {
+            {"linear", SCALE_DYNAMIC_LINEAR},
+            {"integer", SCALE_DYNAMIC_INTEGER},
+            {"nearest", SCALE_DYNAMIC_NEAREST},
+            {"0.5x", SCALE_FIXED_05X},
+            {"1x", SCALE_FIXED_1X},
+            {"2x", SCALE_FIXED_2X},
+        };
+        config.readEnum("scale-mode", g_videoSettings.scaleMode, (int)SCALE_DYNAMIC_NEAREST, scaleModes);
         config.endGroup();
 
 #ifndef THEXTECH_NO_SDL_BUILD
@@ -347,6 +356,7 @@ void SaveConfig()
         config.setValue("battery-status", batteryStatus[g_videoSettings.batteryStatus]);
         config.setValue("osk-fill-screen", g_config.osk_fill_screen);
         config.setValue("show-episode-title", showEpisodeTitle[g_config.show_episode_title]);
+        config.setValue("scale-mode", ScaleMode_strings.at(g_videoSettings.scaleMode));
     }
     config.endGroup();
 

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -57,6 +57,9 @@
 #include "level_file.h"
 #include "world_file.h"
 #include "pge_delay.h"
+#include "video.h"
+#include "change_res.h"
+#include "game_globals.h"
 #include "core/language.h"
 #include "main/translate.h"
 
@@ -1480,11 +1483,11 @@ bool mainMenuUpdate()
         // Options
         else if(MenuMode == MENU_OPTIONS)
         {
+            int optionsMenuLength = 2; // controls, language, credits
 #ifndef RENDER_FULLSCREEN_ALWAYS
-            const int optionsMenuLength = 3;
-#else
-            const int optionsMenuLength = 2;
+            optionsMenuLength++; // FullScreen
 #endif
+            optionsMenuLength ++; // ScaleMode
 
             if(SharedCursor.Move)
             {
@@ -1504,6 +1507,8 @@ bool mainMenuUpdate()
                                 menuLen = 18 * 15; // std::strlen("fullscreen mode")
                         }
 #endif
+                        else if(A == i++)
+                            menuLen = 18 * (7 + ScaleMode_strings.at(g_videoSettings.scaleMode).length());
                         else if(A == i++)
                             menuLen = 18 * 25; // Language: XXXXX (YY)
                         else
@@ -1528,6 +1533,8 @@ bool mainMenuUpdate()
             {
                 if(menuBackPress)
                 {
+                    SaveConfig();
+
                     int optionsIndex = 1;
                     if(!g_gameInfo.disableTwoPlayer)
                         optionsIndex++;
@@ -1559,9 +1566,22 @@ bool mainMenuUpdate()
 #endif
                     else if(MenuCursor == i++)
                     {
+                        PlaySoundMenu(SFX_Do);
+                        if(!leftPressed)
+                            g_videoSettings.scaleMode = g_videoSettings.scaleMode + 1;
+                        else
+                            g_videoSettings.scaleMode = g_videoSettings.scaleMode - 1;
+                        if(g_videoSettings.scaleMode > SCALE_FIXED_2X)
+                            g_videoSettings.scaleMode = SCALE_DYNAMIC_INTEGER;
+                        if(g_videoSettings.scaleMode < SCALE_DYNAMIC_INTEGER)
+                            g_videoSettings.scaleMode = SCALE_FIXED_2X;
+                        UpdateWindowRes();
+                        UpdateInternalRes();
+                    }
+                    else if(MenuCursor == i++)
+                    {
                         XLanguage::rotateLanguage(g_config.language, leftPressed ? -1 : 1);
                         ReloadTranslations();
-                        SaveConfig();
                     }
                     else if(MenuCursor == i++ && (menuDoPress || MenuMouseClick))
                     {
@@ -2032,6 +2052,7 @@ void mainMenuDraw()
         else
             SuperPrint(g_mainMenu.optionsModeFullScreen, 3, MenuX, MenuY + (30 * i++));
 #endif
+        SuperPrint("SCALE: "+ScaleMode_strings.at(g_videoSettings.scaleMode), 3, MenuX, MenuY + (30 * i++));
         SuperPrint(fmt::format_ne("{0}: {1} ({2})", g_mainMenu.wordLanguage, g_mainMenu.languageName, g_config.language), 3, MenuX, MenuY + (30 * i++));
         SuperPrint(g_mainMenu.optionsViewCredits, 3, MenuX, MenuY + (30 * i++));
         XRender::renderTexture(MenuX - 20, MenuY + (MenuCursor * 30),

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -140,6 +140,10 @@ void initMainMenu()
     g_mainMenu.optionsModeFullScreen = "Fullscreen mode";
     g_mainMenu.optionsModeWindowed = "Windowed mode";
     g_mainMenu.optionsViewCredits = "View credits";
+    g_mainMenu.optionsScaleMode = "Scale";
+    g_mainMenu.optionsScaleInteger = "Integer";
+    g_mainMenu.optionsScaleNearest = "Nearest";
+    g_mainMenu.optionsScaleLinear = "Linear";
 
     g_mainMenu.connectCharSelTitle = "Character Select";
     g_mainMenu.connectStartGame = "Start Game";
@@ -2052,7 +2056,15 @@ void mainMenuDraw()
         else
             SuperPrint(g_mainMenu.optionsModeFullScreen, 3, MenuX, MenuY + (30 * i++));
 #endif
-        SuperPrint("SCALE: "+ScaleMode_strings.at(g_videoSettings.scaleMode), 3, MenuX, MenuY + (30 * i++));
+        const std::string* scale_str = &ScaleMode_strings.at(g_videoSettings.scaleMode);
+        if(g_videoSettings.scaleMode == SCALE_DYNAMIC_INTEGER)
+            scale_str = &g_mainMenu.optionsScaleInteger;
+        else if(g_videoSettings.scaleMode == SCALE_DYNAMIC_NEAREST)
+            scale_str = &g_mainMenu.optionsScaleNearest;
+        else if(g_videoSettings.scaleMode == SCALE_DYNAMIC_LINEAR)
+            scale_str = &g_mainMenu.optionsScaleLinear;
+
+        SuperPrint(fmt::format_ne("{0}: {1}", g_mainMenu.optionsScaleMode, *scale_str), 3, MenuX, MenuY + (30 * i++));
         SuperPrint(fmt::format_ne("{0}: {1} ({2})", g_mainMenu.wordLanguage, g_mainMenu.languageName, g_config.language), 3, MenuX, MenuY + (30 * i++));
         SuperPrint(g_mainMenu.optionsViewCredits, 3, MenuX, MenuY + (30 * i++));
         XRender::renderTexture(MenuX - 20, MenuY + (MenuCursor * 30),

--- a/src/main/menu_main.h
+++ b/src/main/menu_main.h
@@ -131,6 +131,10 @@ struct MainMenuContent
     std::string optionsModeFullScreen;
     std::string optionsModeWindowed;
     std::string optionsViewCredits;
+    std::string optionsScaleMode;
+    std::string optionsScaleInteger;
+    std::string optionsScaleNearest;
+    std::string optionsScaleLinear;
 
     // ConnectScreen
     std::string connectCharSelTitle;

--- a/src/main/translate.cpp
+++ b/src/main/translate.cpp
@@ -200,6 +200,10 @@ XTechTranslate::XTechTranslate()
         {"menu.options.optionsModeFullScreen",   &g_mainMenu.optionsModeFullScreen},
         {"menu.options.optionsModeWindowed",     &g_mainMenu.optionsModeWindowed},
         {"menu.options.optionsViewCredits",      &g_mainMenu.optionsViewCredits},
+        {"menu.options.scale.label",             &g_mainMenu.optionsScaleMode},
+        {"menu.options.scale.integer",           &g_mainMenu.optionsScaleInteger},
+        {"menu.options.scale.nearest",           &g_mainMenu.optionsScaleNearest},
+        {"menu.options.scale.linear",            &g_mainMenu.optionsScaleLinear},
 
         {"menu.character.charSelTitle",    &g_mainMenu.connectCharSelTitle},
         {"menu.character.startGame",       &g_mainMenu.connectStartGame},

--- a/src/video.h
+++ b/src/video.h
@@ -22,6 +22,9 @@
 #ifndef VIDEO_H
 #define VIDEO_H
 
+#include <string>
+#include <unordered_map>
+
 enum RenderMode_t
 {
     RENDER_AUTO = -1,
@@ -39,6 +42,26 @@ enum BatteryStatus_t
     BATTERY_STATUS_ALWAYS_ON,
 };
 
+enum ScaleModes
+{
+    SCALE_DYNAMIC_INTEGER = -3,
+    SCALE_DYNAMIC_NEAREST = -2,
+    SCALE_DYNAMIC_LINEAR = -1,
+    SCALE_FIXED_05X = 0,
+    SCALE_FIXED_1X = 1,
+    SCALE_FIXED_2X = 2,
+};
+
+static const std::unordered_map<int, std::string> ScaleMode_strings =
+{
+    {SCALE_DYNAMIC_INTEGER, "integer"},
+    {SCALE_DYNAMIC_NEAREST, "nearest"},
+    {SCALE_DYNAMIC_LINEAR, "linear"},
+    {SCALE_FIXED_05X, "0.5x"},
+    {SCALE_FIXED_1X, "1x"},
+    {SCALE_FIXED_2X, "2x"},
+};
+
 extern struct VideoSettings_t
 {
     enum ScaleDownTextures
@@ -52,6 +75,8 @@ extern struct VideoSettings_t
     int    renderMode = RENDER_ACCELERATED;
     //! The currently running render mode
     int    renderModeObtained = RENDER_AUTO;
+    //! Render scaling mode
+    int    scaleMode = SCALE_DYNAMIC_NEAREST;
     //! Device battery status indicator
     int    batteryStatus = BATTERY_STATUS_OFF;
     //! Allow game to work when window is not active


### PR DESCRIPTION
This PR simply contains the screen scale mode from the multires branch for the main branch. I am trying to simplify the future multires review process by splitting smaller features into their own PRs.

The feature is tested from the multires branch and fully ready for general use. Fine to include in 1.3.6.1.

I quickly added some small additional quality-of-life changes: the scaling mode prompt and string are localizable, and the window doesn't try to resize when fullscreen or maximized.

![Scr_2023-08-12_20-41-40](https://github.com/Wohlstand/TheXTech/assets/72112344/7bf12ecb-d34d-46dd-939f-c03d6f2e612b)
