### PR TITLE
Implemented the fallback for the case when no modern fonts provided

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,7 @@ set(THEXTECH_SRC
     src/fontman/font_manager.cpp
     src/fontman/font_manager_private.cpp
     src/fontman/raster_font.cpp
+    src/fontman/legacy_font.cpp
     src/fontman/utf8_helpers.cpp
 )
 
@@ -1006,7 +1007,8 @@ elseif(NINTENDO_WII OR NINTENDO_3DS OR NINTENDO_DS)
     set_target_properties(thextech PROPERTIES SUFFIX ".elf")
 
 else()
-    add_executable(thextech ${THEXTECH_SRC} ${LIB_SRC})
+    add_executable(thextech ${THEXTECH_SRC} ${LIB_SRC}
+        src/fontman/legacy_font.h src/fontman/legacy_font.cpp)
     pge_set_nopie(thextech)
 endif()
 

--- a/src/control/controls.cpp
+++ b/src/control/controls.cpp
@@ -109,10 +109,6 @@ void Hotkeys::Activate(size_t i, int player)
 #endif
 
 #ifdef DEBUG_BUILD
-    case Buttons::ToggleFontRender:
-        NewFontRender = !NewFontRender;
-        return;
-
     case Buttons::ReloadLanguage:
     {
         ReloadTranslations();

--- a/src/control/keyboard.cpp
+++ b/src/control/keyboard.cpp
@@ -302,10 +302,6 @@ InputMethodProfile_Keyboard::InputMethodProfile_Keyboard()
     this->m_hotkeys[Hotkeys::Buttons::Screenshot] = SDL_SCANCODE_F12;
     this->m_hotkeys2[Hotkeys::Buttons::Screenshot] = SDL_SCANCODE_F2;
 #ifdef DEBUG_BUILD
-    // This is a DEBUG ONLY hot key that can kill the overlook on localized versions
-    // It's primary use is a debugging of the font engine itself, comparing with the
-    // old font engine on the fly
-    this->m_hotkeys[Hotkeys::Buttons::ToggleFontRender] = SDL_SCANCODE_F4;
     this->m_hotkeys[Hotkeys::Buttons::ReloadLanguage] = SDL_SCANCODE_F5;
 #endif
 }

--- a/src/controls.h
+++ b/src/controls.h
@@ -395,7 +395,6 @@ enum Buttons : size_t
     DebugInfo, EnterCheats,
     ToggleHUD, LegacyPause,
 #ifdef DEBUG_BUILD
-    ToggleFontRender,
     ReloadLanguage,
 #endif
     MAX
@@ -422,8 +421,6 @@ inline const char *GetButtonName_INI(size_t i)
     case Buttons::LegacyPause:
         return "legacy-pause";
 #ifdef DEBUG_BUILD
-    case Buttons::ToggleFontRender:
-        return "toggle-font-render";
     case Buttons::ReloadLanguage:
         return "reload-language";
 #endif
@@ -451,8 +448,6 @@ inline const char *GetButtonName_UI_Init(size_t i)
     case Buttons::LegacyPause:
         return "Old Pause";
 #ifdef DEBUG_BUILD
-    case Buttons::ToggleFontRender:
-        return "Old fonts";
     case Buttons::ReloadLanguage:
         return "Reload lang";
 #endif

--- a/src/fontman/font_engine_base.h
+++ b/src/fontman/font_engine_base.h
@@ -32,7 +32,8 @@ public:
     enum FontType
     {
         FONT_RASTER = 0,
-        FONT_TTF
+        FONT_TTF,
+        FONT_LEGACY
     };
 
     /*!

--- a/src/fontman/font_manager.cpp
+++ b/src/fontman/font_manager.cpp
@@ -23,6 +23,7 @@
 #include "font_manager.h"
 #include "font_manager_private.h"
 #include "raster_font.h"
+#include "legacy_font.h"
 #ifdef THEXTECH_ENABLE_TTF_SUPPORT
 #include "ttf_font.h"
 #endif
@@ -53,6 +54,7 @@ BaseFontEngine::~BaseFontEngine()
 
 typedef VPtrList<RasterFont> RasterFontsList;
 typedef VPtrList<TtfFont> TtfFontsList;
+typedef VPtrList<LegacyFont> LegacyFontsList;
 
 //! Complete array of available raster fonts
 static RasterFontsList g_rasterFonts;
@@ -66,6 +68,7 @@ static TtfFontsList    g_ttfFontsCustomLevel;
 #else
 #   define LOADFONTARG(x) false
 #endif
+static LegacyFontsList g_legacyFonts;
 
 typedef VPtrList<BaseFontEngine*> PtrFontsList;
 static PtrFontsList    g_anyFonts;
@@ -74,11 +77,11 @@ static PtrFontsList    g_anyFontsBackup;
 static PtrFontsList    g_anyFontsBackupWorld;
 
 //! Default raster font to render text
-static RasterFont      *g_defaultRasterFont = nullptr;
+static BaseFontEngine  *g_defaultRasterFont = nullptr;
 
 #ifdef THEXTECH_ENABLE_TTF_SUPPORT
 //! Default TTF font to render text
-static TtfFont         *g_defaultTtfFont = nullptr;
+static BaseFontEngine  *g_defaultTtfFont = nullptr;
 #endif
 
 //! Is font manager initialized
@@ -213,7 +216,7 @@ uint32_t FontManager::fontSizeFromSmbxFont(int font)
 TtfFont* FontManager::getDefaultTtfFont()
 {
 #ifdef THEXTECH_ENABLE_TTF_SUPPORT
-    return g_defaultTtfFont;
+    return dynamic_cast<TtfFont*>(g_defaultTtfFont);
 #else
     return nullptr;
 #endif
@@ -239,12 +242,12 @@ TtfFont* FontManager::getTtfFontByName(const std::string& fontName)
 }
 
 #ifdef THEXTECH_ENABLE_TTF_SUPPORT
-static bool s_loadFintsFromDir(DirListCI &fonts_root,
+static bool s_loadFontsFromDir(DirListCI &fonts_root,
                                const std::string &subdir,
                                RasterFontsList &outRasterFonts,
                                TtfFontsList &outTtfFonts)
 #else
-static bool s_loadFintsFromDir(DirListCI &fonts_root,
+static bool s_loadFontsFromDir(DirListCI &fonts_root,
                                const std::string &subdir,
                                RasterFontsList &outRasterFonts,
                                bool)
@@ -383,6 +386,34 @@ static bool s_loadFintsFromDir(DirListCI &fonts_root,
     return true;
 }
 
+static void s_initFontsFallback()
+{
+    for(int i = 1; i <= 4; ++i)
+    {
+        g_legacyFonts.emplace_back(i);
+        LegacyFont& lf = g_legacyFonts.back();
+
+        if(!lf.isLoaded())   //Pop broken font from array
+        {
+            pLogWarning("Failed to load the legacy font %d", i);
+            g_legacyFonts.pop_back();
+        }
+        else   //Register font name in a table
+        {
+            registerFont(&lf);
+            s_smbxFontsMap[i] = FontManager::getFontID(lf.getFontName());
+        }
+    }
+
+    if(!g_legacyFonts.empty())
+        g_defaultRasterFont = &g_legacyFonts.front();
+
+    s_fontMapsDefault = true;
+    s_fontMapsWorld = true;
+    g_fontManagerIsInit = true;
+}
+
+
 void FontManager::initFull()
 {
 #ifdef THEXTECH_ENABLE_TTF_SUPPORT
@@ -405,21 +436,24 @@ void FontManager::initFull()
     const std::string fonts_root = AppPathManager::assetsRoot() + "fonts";
     if(!DirMan::exists(fonts_root))
     {
-        pLogWarning("Can't load fonts as directory %s does not exists", fonts_root.c_str());
+        pLogWarning("Can't load fonts as directory %s does not exists. Built-in fallback fonts will be loaded.", fonts_root.c_str());
+        s_initFontsFallback();
         return;
     }
 
     DirListCI fontsRootCI(fonts_root);
 
-    if(!s_loadFintsFromDir(fontsRootCI, std::string(), g_rasterFonts, LOADFONTARG(g_ttfFonts)))
+    if(!s_loadFontsFromDir(fontsRootCI, std::string(), g_rasterFonts, LOADFONTARG(g_ttfFonts)))
     {
-        pLogWarning("Can't load any font from the directory %s", fonts_root.c_str());
+        pLogWarning("Can't load any font from the directory %s. Built-in fallback fonts will be loaded.", fonts_root.c_str());
+        s_initFontsFallback();
         return;
     }
 
     if(g_anyFonts.empty())
     {
-        pLogWarning("There is no available fonts at the directory %s", fonts_root.c_str());
+        pLogWarning("There is no available fonts at the directory %s. Fallback fonts will be loaded.", fonts_root.c_str());
+        s_initFontsFallback();
         return;
     }
 
@@ -463,7 +497,7 @@ void FontManager::loadCustomFonts()
     else
         pLogDebug("Fonts at %sfonts already loaded", episodeRoot.c_str());
 
-    if(doLoadWorld && s_loadFintsFromDir(g_dirEpisode,
+    if(doLoadWorld && s_loadFontsFromDir(g_dirEpisode,
                                          "fonts",
                                          g_rasterFontsCustom,
                                          LOADFONTARG(g_ttfFontsCustom)))
@@ -486,7 +520,7 @@ void FontManager::loadCustomFonts()
     else
         pLogDebug("Fonts at %sfonts already loaded", dataSubDir.c_str());
 
-    if(doLoadCustom && s_loadFintsFromDir(g_dirCustom,
+    if(doLoadCustom && s_loadFontsFromDir(g_dirCustom,
                                          "fonts",
                                           g_rasterFontsCustomLevel,
                                           LOADFONTARG(g_ttfFontsCustomLevel)))
@@ -611,9 +645,7 @@ void FontManager::printText(const char* text, size_t text_size,
     if((font >= 0) && (static_cast<size_t>(font) < g_anyFonts.size()) && g_anyFonts[font])
     {
         if(g_anyFonts[font]->isLoaded())
-        {
             font_engine = g_anyFonts[font];
-        }
     }
 
     if(!font_engine)
@@ -633,6 +665,12 @@ void FontManager::printText(const char* text, size_t text_size,
                 font_engine = g_defaultTtfFont;
 #endif
             break;
+        }
+
+        if(!font_engine)
+        {
+            pLogWarning("Attempt to print text [%s] without any font being loaded", text);
+            return;
         }
     }
 

--- a/src/fontman/font_manager.cpp
+++ b/src/fontman/font_manager.cpp
@@ -84,8 +84,10 @@ static BaseFontEngine  *g_defaultRasterFont = nullptr;
 static BaseFontEngine  *g_defaultTtfFont = nullptr;
 #endif
 
-//! Is font manager initialized
+//! IS font manager initialized?
 static bool             g_fontManagerIsInit = false;
+//! Does font manager uses legacy fonts fallback?
+static bool             g_fontManagerIsLegacy = false;
 
 #ifdef LOW_MEM
 typedef std::map<std::string, vbint_t> FontsHash;
@@ -411,6 +413,7 @@ static void s_initFontsFallback()
     s_fontMapsDefault = true;
     s_fontMapsWorld = true;
     g_fontManagerIsInit = true;
+    g_fontManagerIsLegacy = true;
 }
 
 
@@ -460,6 +463,7 @@ void FontManager::initFull()
     s_fontMapsDefault = true;
     s_fontMapsWorld = true;
     g_fontManagerIsInit = true;
+    g_fontManagerIsLegacy = false;
 }
 
 void FontManager::quit()
@@ -559,6 +563,11 @@ void FontManager::clearLevelFonts()
 bool FontManager::isInitied()
 {
     return g_fontManagerIsInit;
+}
+
+bool FontManager::isLegacy()
+{
+    return g_fontManagerIsLegacy;
 }
 
 

--- a/src/fontman/font_manager.h
+++ b/src/fontman/font_manager.h
@@ -76,6 +76,12 @@ void clearLevelFonts();
  */
 bool isInitied();
 
+/*!
+ * \brief Checks if font manager uses legacy fonts fallback
+ * \return true when manager uses legacy fonts fallback
+ */
+bool isLegacy();
+
 int fontIdFromSmbxFont(int font);
 uint32_t fontSizeFromSmbxFont(int font);
 

--- a/src/fontman/legacy_font.cpp
+++ b/src/fontman/legacy_font.cpp
@@ -1,0 +1,443 @@
+/*
+ * Moondust, a free game engine for platform game making
+ * Copyright (c) 2014-2023 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This software is licensed under a dual license system (MIT or GPL version 3 or later).
+ * This means you are free to choose with which of both licenses (MIT or GPL version 3 or later)
+ * you want to use this software.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You can see text of MIT license in the LICENSE.mit file you can see in Engine folder,
+ * or see https://mit-license.org/.
+ *
+ * You can see text of GPLv3 license in the LICENSE.gpl3 file you can see in Engine folder,
+ * or see <http://www.gnu.org/licenses/>.
+ */
+
+#include "sdl_proxy/sdl_stdinc.h"
+#include "legacy_font.h"
+#include "gfx.h"
+#include "std_picture.h"
+#include "core/render.h"
+#include "font_manager_private.h"
+
+
+LegacyFont::LegacyFont(int legacyFontId)
+{
+    loadFont(legacyFontId);
+}
+
+LegacyFont::~LegacyFont()
+{
+    m_charMap.clear();
+    SDL_memset(m_textures, 0, sizeof(m_textures));
+}
+
+void LegacyFont::loadFont(int fontId)
+{
+    m_charMap.clear();
+    SDL_memset(m_textures, 0, sizeof(m_textures));
+
+    switch(fontId)
+    {
+    default:
+    case 1: // Numbers font
+        m_glyphWidth = 18;
+        m_glyphHeight = 16;
+
+        for(int i = 0; i < 9; ++i)
+        {
+            char uchar[5] = {static_cast<char>('0' + i), 0, 0, 0, 0};
+            m_textures[i] = &GFX.Font1[i];
+
+            RasChar c;
+            c.texId = i;
+            c.tX = 0;
+            c.tY = 0;
+            c.tW = 16;
+            c.tH = 14;
+            c.width = 18;
+            c.valid = true;
+
+            m_charMap.insert({get_utf8_char(uchar), std::move(c)});
+        }
+
+        m_isReady = true;
+        m_fontName = "numeric";
+        break;
+
+    case 2: // World map level title font
+        m_glyphWidth = 16;
+        m_glyphHeight = 18;
+
+        m_textures[0] = &GFX.Font2[1];
+        m_textures[1] = &GFX.Font2S;
+
+        for(char c = 33; c <= 125; ++c)
+        {
+            char uchar[5] = {c, 0, 0, 0, 0};
+            RasChar cc;
+            cc.texId = 0;
+            cc.tY = 0;
+            cc.tW = 15;
+            cc.tH = 17;
+            cc.width = 16;
+
+            if(c >= 48 && c <= 57)
+            {
+                cc.tX = (c - 48) * 16;
+                cc.texId = 0;
+            }
+            else if(c >= 65 && c <= 90)
+            {
+                cc.tX = (c - 55) * 16;
+                cc.texId = 0;
+            }
+            else if(c >= 97 && c <= 122)
+            {
+                cc.tX = (c - 61) * 16;
+                cc.texId = 0;
+            }
+            else if(c >= 33 && c <= 47)
+            {
+                cc.tX = (c - 33) * 16;
+                cc.texId = 1;
+            }
+            else if(c >= 58 && c <= 64)
+            {
+                cc.tX = (c - 58 + 15) * 16;
+                cc.texId = 1;
+            }
+            else if(c >= 91 && c <= 96)
+            {
+                cc.tX = (c - 91 + 22) * 16;
+                cc.texId = 1;
+            }
+            else if(c >= 123 && c <= 125)
+            {
+                cc.tX = (c - 123 + 28) * 16;
+                cc.texId = 1;
+            }
+
+            cc.valid = true;
+
+            m_charMap.insert({get_utf8_char(uchar), std::move(cc)});
+        }
+
+        m_isReady = true;
+        m_fontName = "font3";
+        break;
+
+    case 3: // Menu font
+        m_glyphWidth = 16;
+        m_glyphHeight = 18;
+
+        m_textures[0] = &GFX.Font2[2];
+
+        for(char c = 33; c <= 126; ++c)
+        {
+            char ucharH[5] = {c, 0, 0, 0, 0};
+            char ucharL[5] = {static_cast<char>(std::tolower(c)), 0, 0, 0, 0};
+
+            RasChar cc;
+            cc.texId = 0;
+            cc.tX = 2;
+            cc.tY = (c - 33) * 32;
+            cc.tW = 18;
+            cc.tH = 16;
+            cc.width = 18;
+
+            if(c == 'M')
+                cc.width += 2;
+
+            cc.valid = true;
+
+            m_charMap.insert({get_utf8_char(ucharH), cc});
+            m_charMap.insert({get_utf8_char(ucharL), std::move(cc)});
+        }
+
+        m_isReady = true;
+        m_fontName = "font1";
+        break;
+
+    case 4: // Message box font
+        m_glyphWidth = 18;
+        m_glyphHeight = 18;
+
+        m_textures[0] = &GFX.Font2[3];
+
+        for(char c = 33; c <= 126; ++c)
+        {
+            char ucharL[5] = {c, 0, 0, 0, 0};
+
+            RasChar cc;
+            cc.texId = 0;
+            cc.tX = 0;
+            cc.tY = (c - 33) * 16;
+            cc.tW = 18;
+            cc.tH = 16;
+            cc.width = 18;
+
+            if(c == 'M')
+                cc.width += 2;
+
+            cc.valid = true;
+
+            m_charMap.insert({get_utf8_char(ucharL), cc});
+        }
+
+        m_isReady = true;
+        m_fontName = "font2";
+        break;
+    }
+}
+
+PGE_Size LegacyFont::textSize(const char* text, size_t text_size,
+                              uint32_t max_line_lenght, bool cut,
+                              uint32_t /*fontSize*/)
+{
+    const char* t = text;
+    size_t t_size = text_size;
+    // TODO: Get rid this string: use integer hints instead of making a modded string copy when performing a cut behaviour
+    std::string modText;
+
+    if(!text || text_size == 0)
+        return PGE_Size(0, 0);
+
+    size_t lastspace = 0; //!< index of last found space character
+    size_t count     = 1; //!< Count of lines
+    uint32_t maxWidth     = 0; //!< detected maximal width of message
+
+    uint32_t widthSumm    = 0;
+    uint32_t widthSummMax = 0;
+
+    if(cut)
+    {
+        modText = std::string(text, text_size);
+        std::string::size_type i = modText.find('\n');
+        if(i != std::string::npos)
+            modText.erase(i, modText.size() - i);
+        t = modText.c_str();
+        t_size = modText.size();
+    }
+
+    /****************Word wrap*********************/
+    uint32_t x = 0;
+    for(size_t i = 0; i < t_size; i++, x++)
+    {
+        const char &cx = t[i];
+        UTF8 uch = static_cast<UTF8>(cx);
+
+        switch(cx)
+        {
+        case '\r':
+            break;
+
+        case '\t':
+        {
+            lastspace = i;
+            size_t spaceSize = m_glyphWidth;
+            if(spaceSize == 0)
+                spaceSize = 1; // Don't divide by zero
+            size_t tabMult = 4 - ((widthSumm / spaceSize) % 4);
+            widthSumm += static_cast<size_t>(m_glyphWidth) * tabMult;
+            if(widthSumm > widthSummMax)
+                widthSummMax = widthSumm;
+            break;
+        }
+
+        case ' ':
+        {
+            lastspace = i;
+            widthSumm += m_glyphWidth;
+            if(widthSumm > widthSummMax)
+                widthSummMax = widthSumm;
+            break;
+        }
+
+        case '\n':
+        {
+            lastspace = 0;
+            if((maxWidth < x) && (maxWidth < max_line_lenght))
+                maxWidth = x;
+            x = 0;
+            widthSumm = 0;
+            count++;
+            break;
+        }
+
+        default:
+        {
+            CharMap::iterator rc = m_charMap.find(get_utf8_char(&cx));
+            if(rc != m_charMap.end())
+            {
+                RasChar &rch = rc->second;
+                widthSumm += rch.valid ? rch.width : m_glyphWidth;
+            }
+            else
+                widthSumm += m_glyphWidth;
+
+            if(widthSumm > widthSummMax)
+                widthSummMax = widthSumm;
+
+            break;
+        }
+
+        }//Switch
+
+        if((max_line_lenght > 0) && (x >= max_line_lenght)) //If lenght more than allowed
+        {
+            maxWidth = x;
+            if(t != modText.c_str())
+            {
+                modText = text;
+                t = modText.c_str();
+                t_size = modText.size();
+            }
+
+            if(lastspace > 0)
+            {
+                modText[lastspace] = '\n';
+                i = lastspace - 1;
+                lastspace = 0;
+            }
+            else
+            {
+                modText.insert(i, 1, '\n');
+                t = modText.c_str();
+                t_size = modText.size();
+                x = 0;
+                count++;
+            }
+        }
+        i += static_cast<size_t>(trailingBytesForUTF8[uch]);
+    }
+
+    // Unused later
+    //    if(count == 1)
+    //        maxWidth = static_cast<uint32_t>(t_size);
+
+    /****************Word wrap*end*****************/
+    return PGE_Size(static_cast<int32_t>(widthSummMax), static_cast<int32_t>(m_glyphHeight * count));
+}
+
+PGE_Size LegacyFont::glyphSize(const char* utf8char, uint32_t charNum, uint32_t /*fontSize*/)
+{
+    PGE_Size ret(0, m_glyphHeight);
+    const char &cx = utf8char[0];
+
+    switch(cx)
+    {
+    case '\n':
+    case '\r':
+        break; // Has no lenght
+
+    case '\t':
+    {
+        size_t spaceSize = m_glyphWidth;
+        if(spaceSize == 0)
+            spaceSize = 1; // Don't divide by zero
+        size_t tabMult = 4 - ((charNum / spaceSize) % 4);
+        ret.setWidth(static_cast<size_t>(m_glyphWidth) * tabMult);
+        break;
+    }
+
+    case ' ':
+    {
+        ret.setWidth(m_glyphWidth);
+        break;
+    }
+
+    default:
+    {
+        CharMap::iterator rc = m_charMap.find(get_utf8_char(&cx));
+        if(rc != m_charMap.end())
+        {
+            RasChar &rch = rc->second;
+            ret.setWidth(rch.valid ? rch.width : m_glyphWidth);
+        }
+        else
+            ret.setWidth(m_glyphWidth);
+
+        break;
+    }
+
+    }//Switch
+
+    return ret;
+}
+
+void LegacyFont::printText(const char* text, size_t text_size, int32_t x, int32_t y,
+                           float Red, float Green, float Blue, float Alpha,
+                           uint32_t /*fontSize*/)
+{
+    if(m_charMap.empty() || !text || text_size == 0)
+        return;
+
+    uint32_t offsetX = 0;
+    uint32_t offsetY = 0;
+
+    const char *strIt  = text;
+    const char *strEnd = strIt + text_size;
+    for(; strIt < strEnd; strIt++)
+    {
+        const char &cx = *strIt;
+        const char *fch = "?";
+        UTF8 ucx = static_cast<unsigned char>(cx);
+
+        switch(cx)
+        {
+        case '\n':
+            offsetX = 0;
+            offsetY += m_glyphHeight;
+            continue;
+
+        case '\t':
+            // Fake tabulation
+            offsetX += offsetX + offsetX % m_glyphWidth;
+            continue;
+
+        case ' ':
+            offsetX += m_glyphWidth;
+            continue;
+        }
+
+        auto rch_f = m_charMap.find(get_utf8_char(strIt));
+        if(rch_f == m_charMap.end())
+            rch_f = m_charMap.find(get_utf8_char(fch));
+
+        if(rch_f != m_charMap.end() && rch_f->second.valid)
+        {
+            const RasChar &rch = rch_f->second;
+            XRender::renderTexture(x + static_cast<int32_t>(offsetX),
+                                   y + static_cast<int32_t>(offsetY),
+                                   rch.tW, rch.tH,
+                                   *m_textures[rch.texId],
+                                   rch.tX, rch.tY,
+                                   Red, Green, Blue, Alpha);
+            offsetX += rch.width;
+        }
+        else
+            offsetX += m_glyphWidth;
+
+        strIt += static_cast<size_t>(trailingBytesForUTF8[ucx]);
+    }
+}
+
+bool LegacyFont::isLoaded() const
+{
+    return m_isReady;
+}
+
+std::string LegacyFont::getFontName() const
+{
+    return m_fontName;
+}
+
+BaseFontEngine::FontType LegacyFont::getFontType() const
+{
+    return FONT_LEGACY;
+}

--- a/src/fontman/legacy_font.cpp
+++ b/src/fontman/legacy_font.cpp
@@ -17,12 +17,21 @@
  * or see <http://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
 #include "sdl_proxy/sdl_stdinc.h"
+
 #include "legacy_font.h"
 #include "gfx.h"
 #include "std_picture.h"
 #include "core/render.h"
 #include "font_manager_private.h"
+
+#if defined(_MSC_VER) && _MSC_VER <= 1900 // Workaround for MSVC 2015
+namespace std
+{
+    using ::toupper;
+}
+#endif
 
 
 LegacyFont::LegacyFont(int legacyFontId)

--- a/src/fontman/legacy_font.h
+++ b/src/fontman/legacy_font.h
@@ -18,36 +18,32 @@
  */
 
 #pragma once
-#ifndef RASTER_FONT_H
-#define RASTER_FONT_H
+#ifndef LEGACYFONT_H
+#define LEGACYFONT_H
 
-#include <string>
 #ifdef LOW_MEM
 #   include <map>
 #else
 #   include <unordered_map>
 #endif
-#include <Utils/vptrlist.h>
-#include "std_picture.h"
-#include <Graphics/size.h>
-
 #include "font_engine_base.h"
 
+struct StdPicture;
+
 /**
- * @brief The raster fonts engine
+ * @brief Implementation of the legacy SMBX font engine as a part of the modern font engine
  */
-class RasterFont final : public BaseFontEngine
+class LegacyFont final : public BaseFontEngine
 {
 public:
-    RasterFont();
-    RasterFont(const RasterFont &rf) = delete;
-    RasterFont &operator=(const RasterFont &tf) = delete;
-    RasterFont(RasterFont &&tf) = default;
+    explicit LegacyFont(int legacyFontId);
+    LegacyFont(const LegacyFont &rf) = delete;
+    LegacyFont &operator=(const LegacyFont &tf) = delete;
+    LegacyFont(LegacyFont &&tf) = default;
 
-    virtual ~RasterFont() override;
+    virtual ~LegacyFont() override;
 
-    void  loadFont(const std::string& font_ini);
-    void  loadFontMap(const std::string &fontmap_ini);
+    void loadFont(int fontId);
 
     /*!
      * \brief Measure the size of the multiline text block in pixels
@@ -96,50 +92,34 @@ public:
 private:
     //! font is fine
     bool m_isReady = false;
-    //! The fallback TTF name to prefer to render a missing character [all unknown characters will be rendered as TTF]
-    std::string m_ttfFallback;
-    //! Enable outline borders on backup ttf font render
-    bool m_ttfOutlines = false;
-    uint32_t m_ttfOutLinesColour = 0x000000FF;
-    float    m_ttfOutlinesColourF[4] = {0.f, 0.f, 0.f, 1.f};
-    //! The fallback TTF size of the glyph to request
-    int  m_ttfSize = -1;
-    //! Width of one letter
-    uint32_t m_letterWidth = 0;
-    //! Height of one letter
-    uint32_t m_letterHeight = 0;
-    //! Space between printing letters
-    uint32_t m_interLetterSpace = 0;
-    //! Width of space symbol
-    uint32_t m_spaceWidth = 0;
-    //! Distance between top of one line and top of next
-    uint32_t m_newlineOffset = 0;
-
-    //! Offset all characters by X
-    int32_t m_glyphOffsetX = 0;
-    //! Offset all characters by Y
-    int32_t m_glyphOffsetY = 0;
-
-    //! Width of font matrix
-    uint32_t m_matrixWidth = 0;
-    //! Width of font matrix
-    uint32_t m_matrixHeight = 0;
 
     //! Handalable name of the font
     std::string m_fontName;
+
+    //! Bank of legacy font textures
+    StdPicture *m_textures[10];
 
     /**
      * @brief Raster font glyph
      */
     struct RasChar
     {
+        uint32_t texId = 0; //!< Texture index in m_textures array
+        uint32_t tX = 0; //!< Horizontal pixel offset on texture
+        uint32_t tY = 0; //!< Vertical pixel offset on texture
+        uint32_t tW = 0; //!< Pixels width of the texture fragment
+        uint32_t tH = 0; //!< Pixels height of the texture fragment
+        uint32_t width = 0; //!< Width of glyph
         bool valid = false; //!< Is a valid glyph
-        StdPicture* tx     = nullptr; //!< Pointer to the texture that contains this glyph
-        uint32_t padding_left    = 0; //!< Crop left
-        uint32_t padding_right   = 0; //!< Crop right
         int32_t x = 0;//!< X pixel offset
         int32_t y = 0;//!< Y pixel offset
     };
+
+    //! Fallback width of glyph
+    uint32_t m_glyphWidth = 0;
+
+    //! Height of glyph
+    uint32_t m_glyphHeight = 0;
 
 #ifdef LOW_MEM
     typedef std::map<char32_t, RasChar > CharMap;
@@ -150,8 +130,6 @@ private:
     //! Table of available characters
     CharMap m_charMap;
 
-    //! Bank of loaded textures
-    VPtrList<StdPicture> m_texturesBank;
 };
 
-#endif // RASTER_FONT_H
+#endif // LEGACYFONT_H

--- a/src/fontman/legacy_font.h
+++ b/src/fontman/legacy_font.h
@@ -104,15 +104,13 @@ private:
      */
     struct RasChar
     {
-        uint32_t texId = 0; //!< Texture index in m_textures array
-        uint32_t tX = 0; //!< Horizontal pixel offset on texture
-        uint32_t tY = 0; //!< Vertical pixel offset on texture
-        uint32_t tW = 0; //!< Pixels width of the texture fragment
-        uint32_t tH = 0; //!< Pixels height of the texture fragment
-        uint32_t width = 0; //!< Width of glyph
-        bool valid = false; //!< Is a valid glyph
-        int32_t x = 0;//!< X pixel offset
-        int32_t y = 0;//!< Y pixel offset
+        uint8_t  texId = 0; //!< Texture index in m_textures array
+        bool     valid = false; //!< Is a valid glyph
+        uint16_t tX = 0; //!< Horizontal pixel offset on texture
+        uint16_t tY = 0; //!< Vertical pixel offset on texture
+        uint8_t  tW = 0; //!< Pixels width of the texture fragment
+        uint8_t  tH = 0; //!< Pixels height of the texture fragment
+        uint8_t  width = 0; //!< Width of glyph
     };
 
     //! Fallback width of glyph

--- a/src/fontman/raster_font.cpp
+++ b/src/fontman/raster_font.cpp
@@ -237,8 +237,8 @@ void RasterFont::loadFontMap(const std::string& fontmap_ini)
             rch.padding_left    = (ucharX.size() > 1) ? char2int(ucharX[1]) : 0;
             rch.padding_right   = (ucharX.size() > 2) ? char2int(ucharX[2]) : 0;
             t                   =  std::stof(charPosX.c_str()) / m_matrixHeight;
-            rch.x               =  static_cast<int32_t>(fontTexture.w * l);
-            rch.y               =  static_cast<int32_t>(fontTexture.h * t);
+            rch.x               =  static_cast<int16_t>(fontTexture.w * l);
+            rch.y               =  static_cast<int16_t>(fontTexture.h * t);
             rch.valid = true;
         }
         catch(std::exception &e)

--- a/src/fontman/raster_font.cpp
+++ b/src/fontman/raster_font.cpp
@@ -47,7 +47,7 @@ RasterFont::RasterFont() : BaseFontEngine()
     m_matrixWidth    = 0;
     m_matrixHeight   = 0;
     m_isReady        = false;
-    m_ttfOutlines     = false;
+    m_ttfOutlines    = false;
     m_fontName       = fmt::format_ne("font{0}", fontNumberCount++);
 }
 

--- a/src/fontman/raster_font.h
+++ b/src/fontman/raster_font.h
@@ -133,12 +133,12 @@ private:
      */
     struct RasChar
     {
-        bool valid = false; //!< Is a valid glyph
+        bool        valid = false; //!< Is a valid glyph
         StdPicture* tx     = nullptr; //!< Pointer to the texture that contains this glyph
-        uint32_t padding_left    = 0; //!< Crop left
-        uint32_t padding_right   = 0; //!< Crop right
-        int32_t x = 0;//!< X pixel offset
-        int32_t y = 0;//!< Y pixel offset
+        uint8_t     padding_left    = 0; //!< Crop left
+        uint8_t     padding_right   = 0; //!< Crop right
+        int16_t     x = 0; //!< X pixel offset
+        int16_t     y = 0; //!< Y pixel offset
     };
 
 #ifdef LOW_MEM

--- a/src/fontman/raster_font.h
+++ b/src/fontman/raster_font.h
@@ -25,12 +25,11 @@
 #include <unordered_map>
 #include <Utils/vptrlist.h>
 #include "std_picture.h"
-#include <Graphics/rect.h>
 #include <Graphics/size.h>
 
 #include "font_engine_base.h"
 
-class RasterFont : public BaseFontEngine
+class RasterFont final : public BaseFontEngine
 {
 public:
     RasterFont();

--- a/src/fontman/raster_font.h
+++ b/src/fontman/raster_font.h
@@ -22,13 +22,20 @@
 #define RASTER_FONT_H
 
 #include <string>
-#include <unordered_map>
+#ifdef LOW_MEM
+#   include <map>
+#else
+#   include <unordered_map>
+#endif
 #include <Utils/vptrlist.h>
 #include "std_picture.h"
 #include <Graphics/size.h>
 
 #include "font_engine_base.h"
 
+/**
+ * @brief The raster fonts engine
+ */
 class RasterFont final : public BaseFontEngine
 {
 public:
@@ -131,7 +138,11 @@ private:
         int32_t y = 0;//!< Y pixel offset
     };
 
+#ifdef LOW_MEM
+    typedef std::map<char32_t, RasChar > CharMap;
+#else
     typedef std::unordered_map<char32_t, RasChar > CharMap;
+#endif
 
     //! Table of available characters
     CharMap m_charMap;

--- a/src/fontman/ttf_font.h
+++ b/src/fontman/ttf_font.h
@@ -43,7 +43,7 @@ extern FT_Library  g_ft;
 extern bool initializeFreeType();
 extern void closeFreeType();
 
-class TtfFont : public BaseFontEngine
+class TtfFont final : public BaseFontEngine
 {
 public:
     TtfFont();

--- a/src/fontman/ttf_font.h
+++ b/src/fontman/ttf_font.h
@@ -22,7 +22,11 @@
 #define TTF_FONT_H
 
 
-#include <unordered_map>
+#ifdef LOW_MEM
+#   include <map>
+#else
+#   include <unordered_map>
+#endif
 #include <Utils/vptrlist.h>
 #include "std_picture.h"
 
@@ -43,6 +47,9 @@ extern FT_Library  g_ft;
 extern bool initializeFreeType();
 extern void closeFreeType();
 
+/**
+ * @brief The FreeType-based font engine
+ */
 class TtfFont final : public BaseFontEngine
 {
 public:
@@ -186,8 +193,13 @@ private:
     // version using an existing texture
     const TheGlyph &loadGlyph(StdPicture &texture, uint32_t fontSize, char32_t character);
 
+#ifdef LOW_MEM
+    typedef std::map<char32_t, TheGlyph> CharMap;
+    typedef std::map<uint32_t, CharMap>  SizeCharMap;
+#else
     typedef std::unordered_map<char32_t, TheGlyph> CharMap;
     typedef std::unordered_map<uint32_t, CharMap>  SizeCharMap;
+#endif
 
     SizeCharMap m_charMap;
     VPtrList<StdPicture > m_texturesBank;

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -49,7 +49,6 @@ uint32_t CommonFrame = 0;
 bool ScrollRelease = false;
 bool TakeScreen = false;
 bool ShowOnScreenHUD = true;
-bool NewFontRender = true;
 std::string LB;
 std::string EoT;
 

--- a/src/graphics/gfx_print.cpp
+++ b/src/graphics/gfx_print.cpp
@@ -44,9 +44,25 @@ int SuperTextPixLen(int SuperN, const char* SuperChars, int Font)
     if(Font == 5)
         Font = 4;
 
-    int len = 0;
-    int dFont = NewFontRender ? FontManager::fontIdFromSmbxFont(Font) : -1;
+    int dFont = FontManager::fontIdFromSmbxFont(Font);
 
+    if(dFont < 0)
+    {
+        int len = 0;
+        pLogWarning("SuperTextPixLen: Invalid font %d is specified", Font);
+
+        for(int i = 0; i < SuperN; ++i)
+        {
+            len += 18;
+            i += static_cast<size_t>(trailingBytesForUTF8[static_cast<UTF8>(SuperChars[i])]);
+        }
+
+        return len;
+    }
+
+    return FontManager::textSize(SuperChars, SuperN, dFont, 0, false, FontManager::fontSizeFromSmbxFont(Font)).w();
+
+#if 0 // Dead code
     if(dFont >= 0)
         return FontManager::textSize(SuperChars, SuperN, dFont, 0, false, FontManager::fontSizeFromSmbxFont(Font)).w();
 
@@ -97,6 +113,7 @@ int SuperTextPixLen(int SuperN, const char* SuperChars, int Font)
     }
 
     return len;
+#endif // Dead code
 }
 
 void SuperPrintRightAlign(int SuperN, const char* SuperChars, int Font, float X, float Y, float r, float g, float b, float a)
@@ -110,7 +127,7 @@ void SuperPrintRightAlign(int SuperN, const char* SuperChars, int Font, float X,
         outline = true;
     }
 
-    int dFont = NewFontRender ? FontManager::fontIdFromSmbxFont(Font) : -1;
+    int dFont = FontManager::fontIdFromSmbxFont(Font);
 
     if(dFont >= 0)
     {
@@ -134,7 +151,7 @@ void SuperPrintCenter(int SuperN, const char* SuperChars, int Font, float X, flo
         outline = true;
     }
 
-    int dFont = NewFontRender ? FontManager::fontIdFromSmbxFont(Font) : -1;
+    int dFont = FontManager::fontIdFromSmbxFont(Font);
 
     if(dFont >= 0)
     {
@@ -158,7 +175,7 @@ void SuperPrintScreenCenter(int SuperN, const char* SuperChars, int Font, float 
         outline = true;
     }
 
-    int dFont = NewFontRender ? FontManager::fontIdFromSmbxFont(Font) : -1;
+    int dFont = FontManager::fontIdFromSmbxFont(Font);
 
     if(dFont >= 0)
     {
@@ -182,7 +199,16 @@ void SuperPrint(int SuperN, const char* SuperChars, int Font, float X, float Y,
         outline = true;
     }
 
-    int dFont = NewFontRender ? FontManager::fontIdFromSmbxFont(Font) : -1;
+    int dFont = FontManager::fontIdFromSmbxFont(Font);
+    if(dFont < 0)
+    {
+        pLogWarning("SuperPrint: Invalid font %d is specified", Font);
+        return; // Invalid font specified
+    }
+
+    FontManager::printText(SuperChars, SuperN, X, Y, dFont, r, g, b, a, FontManager::fontSizeFromSmbxFont(Font), outline);
+
+#if 0 // Dead code
 
     if(dFont >= 0)
     {
@@ -348,6 +374,7 @@ void SuperPrint(int SuperN, const char* SuperChars, int Font, float X, float Y,
         }
 //    End If
     }
+#endif // Dead code
 }
 
 // const char* versions

--- a/src/graphics/gfx_print.cpp
+++ b/src/graphics/gfx_print.cpp
@@ -18,26 +18,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <algorithm>
-
 #include <Logger/logger.h>
-#include "sdl_proxy/sdl_stdinc.h"
-#include "sdl_proxy/sdl_assert.h"
-#include "core/render.h"
 
 #include "globals.h"
 #include "graphics.h"
-#include "gfx.h"
 #include "../fontman/font_manager.h"
 #include "../fontman/font_manager_private.h"
 
-
-#if defined(_MSC_VER) && _MSC_VER <= 1900 // Workaround for MSVC 2015
-namespace std
-{
-    using ::toupper;
-}
-#endif
 
 int SuperTextPixLen(int SuperN, const char* SuperChars, int Font)
 {
@@ -61,59 +48,6 @@ int SuperTextPixLen(int SuperN, const char* SuperChars, int Font)
     }
 
     return FontManager::textSize(SuperChars, SuperN, dFont, 0, false, FontManager::fontSizeFromSmbxFont(Font)).w();
-
-#if 0 // Dead code
-    if(dFont >= 0)
-        return FontManager::textSize(SuperChars, SuperN, dFont, 0, false, FontManager::fontSizeFromSmbxFont(Font)).w();
-
-    switch(Font)
-    {
-    default:
-    case 1:
-    case 4:
-    {
-        //len = SuperN * 18;
-        for(int i = 0; i < SuperN; i++)
-        {
-            len += 18;
-            i += static_cast<size_t>(trailingBytesForUTF8[static_cast<UTF8>(SuperChars[i])]);
-        }
-        break;
-    }
-    case 2:
-    {
-        //len = SuperN * 16;
-        for(int i = 0; i < SuperN; i++)
-        {
-            len += 16;
-            i += static_cast<size_t>(trailingBytesForUTF8[static_cast<UTF8>(SuperChars[i])]);
-        }
-        break;
-    }
-    case 3:
-    {
-        int B = 0;
-        for(int i = 0; i < SuperN; i++)
-        {
-            char c = SuperChars[i];
-            c = std::toupper(c);
-            if(c >= 33 && c <= 126)
-            {
-                B += 18;
-                if(c == 'M')
-                    B += 2;
-            } else {
-                B += 16;
-            }
-            i += static_cast<size_t>(trailingBytesForUTF8[static_cast<UTF8>(c)]);
-        }
-        len = B;
-        break;
-    }
-    }
-
-    return len;
-#endif // Dead code
 }
 
 void SuperPrintRightAlign(int SuperN, const char* SuperChars, int Font, float X, float Y, float r, float g, float b, float a)
@@ -207,174 +141,6 @@ void SuperPrint(int SuperN, const char* SuperChars, int Font, float X, float Y,
     }
 
     FontManager::printText(SuperChars, SuperN, X, Y, dFont, r, g, b, a, FontManager::fontSizeFromSmbxFont(Font), outline);
-
-#if 0 // Dead code
-
-    if(dFont >= 0)
-    {
-        FontManager::printText(SuperChars, SuperN, X, Y, dFont, r, g, b, a, FontManager::fontSizeFromSmbxFont(Font), outline);
-        return;
-    }
-
-    if(outline)
-    {
-        // take square of a to match blend of normal text
-        float outline_a = a * a;
-        SuperPrint(SuperN, SuperChars, Font, X - 2, Y, 0, 0, 0, outline_a);
-        SuperPrint(SuperN, SuperChars, Font, X + 2, Y, 0, 0, 0, outline_a);
-        SuperPrint(SuperN, SuperChars, Font, X, Y - 2, 0, 0, 0, outline_a);
-        SuperPrint(SuperN, SuperChars, Font, X, Y + 2, 0, 0, 0, outline_a);
-    }
-
-//    int A = 0;
-    int B = 0;
-    int C = 0;
-
-    if(Font == 1)
-    {
-        for(int i = 0; i < SuperN; i++)
-        {
-            char c = SuperChars[i];
-            if(c >= '0' && c <= '9')
-                XRender::renderTexture(int(X + B), int(Y), 16, 14, GFX.Font1[c - '0'], 0, 0, r, g, b, a);
-            B += 18;
-            if(c == '\n')
-            {
-                B = 0;
-                Y += 16;
-            }
-            i += static_cast<size_t>(trailingBytesForUTF8[static_cast<UTF8>(c)]);
-        }
-    }
-    else if(Font == 2)
-    {
-        for(int i = 0; i < SuperN; i++)
-        {
-            char c = SuperChars[i];
-            if(c >= 48 && c <= 57) {
-                C = (c - 48) * 16;
-                XRender::renderTexture(int(X + B), int(Y), 15, 17, GFX.Font2[1], C, 0, r, g, b, a);
-                B += 16;
-            } else if(c >= 65 && c <= 90) {
-                C = (c - 55) * 16;
-                XRender::renderTexture(int(X + B), int(Y), 15, 17, GFX.Font2[1], C, 0, r, g, b, a);
-                B += 16;
-            } else if(c >= 97 && c <= 122) {
-                C = (c - 61) * 16;
-                XRender::renderTexture(int(X + B), int(Y), 15, 17, GFX.Font2[1], C, 0, r, g, b, a);
-                B += 16;
-            } else if(c >= 33 && c <= 47) {
-                C = (c - 33) * 16;
-                XRender::renderTexture(int(X + B), int(Y), 15, 17, GFX.Font2S, C, 0, r, g, b, a);
-                B += 16;
-            } else if(c >= 58 && c <= 64) {
-                C = (c - 58 + 15) * 16;
-                XRender::renderTexture(int(X + B), int(Y), 15, 17, GFX.Font2S, C, 0, r, g, b, a);
-                B += 16;
-            } else if(c >= 91 && c <= 96) {
-                C = (c - 91 + 22) * 16;
-                XRender::renderTexture(int(X + B), int(Y), 15, 17, GFX.Font2S, C, 0, r, g, b, a);
-                B += 16;
-            } else if(c >= 123 && c <= 125) {
-                C = (c - 123 + 28) * 16;
-                XRender::renderTexture(int(X + B), int(Y), 15, 17, GFX.Font2S, C, 0, r, g, b, a);
-                B += 16;
-            } else {
-                B += 16;
-            }
-
-            if(c == '\n')
-            {
-                B = 0;
-                Y += 18;
-            }
-
-            i += static_cast<size_t>(trailingBytesForUTF8[static_cast<UTF8>(c)]);
-        }
-
-    }
-    else if(Font == 3)
-    {
-//        Do While Len(Words) > 0
-        for(int i = 0; i < SuperN; i++)
-        {
-            char c = SuperChars[i];
-            c = std::toupper(c);
-//            If Asc(Left(Words, 1)) >= 33 And Asc(Left(Words, 1)) <= 126 Then
-            if(c >= 33 && c <= 126)
-            {
-//                C = (Asc(Left(Words, 1)) - 33) * 32
-                C = (c - 33) * 32;
-//                BitBlt myBackBuffer, X + B, Y, 18, 16, GFX.Font2Mask(2).hdc, 2, C, vbSrcAnd
-//                BitBlt myBackBuffer, X + B, Y, 18, 16, GFX.Font2(2).hdc, 2, C, vbSrcPaint
-                XRender::renderTexture(int(X + B), int(Y), 18, 16, GFX.Font2[2], 2, C, r, g, b, a);
-//                B = B + 18
-                B += 18;
-//                If Left(Words, 1) = "M" Then B = B + 2
-                if(c == 'M')
-                    B += 2;
-//            Else
-            } else {
-//                B = B + 16
-                B += 16;
-            }
-
-            if(c == '\n')
-            {
-                B = 0;
-                Y += 18;
-            }
-
-            i += static_cast<size_t>(trailingBytesForUTF8[static_cast<UTF8>(c)]);
-//            End If
-//            Words = Right(Words, Len(Words) - 1)
-//        Loop
-        }
-//    ElseIf Font = 4 Then
-    }
-    else if(Font == 4)
-    {
-        // D_pLogDebug("Trying to draw: [%s]", SuperChars);
-//        Do While Len(Words) > 0
-        for(int i = 0; i < SuperN; i++)
-        {
-            char c = SuperChars[i];
-            SDL_assert_release(c != 0);
-//            If Asc(Left(Words, 1)) >= 33 And Asc(Left(Words, 1)) <= 126 Then
-            if(c >= 33 && c <= 126)
-            {
-//                C = (Asc(Left(Words, 1)) - 33) * 16
-                C = (c - 33) * 16;
-//                BitBlt myBackBuffer, X + B, Y, 18, 16, GFX.Font2(3).hdc, 2, C, vbSrcPaint
-                XRender::renderTexture(int(X + B), int(Y), 18, 16, GFX.Font2[3], 2, C, r, g, b, a);
-//                B = B + 18
-                B += 18;
-//            Else
-            }
-            else if(c != ' ' && c != '\n' && c != '\0')
-            {
-                C = ('?' - 33) * 16;
-                XRender::renderTexture(int(X + B), int(Y), 18, 16, GFX.Font2[3], 2, C, r, g, b, a);
-//                B = B + 18
-                B += 18;
-//            End If
-            }
-            else
-                B += 18;
-
-            if(c == '\n')
-            {
-                B = 0;
-                Y += 18;
-            }
-
-            i += static_cast<size_t>(trailingBytesForUTF8[static_cast<UTF8>(c)]);
-//            Words = Right(Words, Len(Words) - 1)
-//        Loop
-        }
-//    End If
-    }
-#endif // Dead code
 }
 
 // const char* versions

--- a/src/graphics/gfx_print.cpp
+++ b/src/graphics/gfx_print.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <Logger/logger.h>
+#include "sdl_proxy/sdl_stdinc.h"
 
 #include "globals.h"
 #include "graphics.h"

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -62,6 +62,7 @@
 #include "game_globals.h"
 #include "core/language.h"
 #include "main/translate.h"
+#include "fontman/font_manager.h"
 
 #include "video.h"
 #include "frm_main.h"
@@ -1645,8 +1646,14 @@ bool mainMenuUpdate()
                     }
                     else if(MenuCursor == i++)
                     {
-                        XLanguage::rotateLanguage(g_config.language, leftPressed ? -1 : 1);
-                        ReloadTranslations();
+                        if(!FontManager::isInitied() || FontManager::isLegacy())
+                            PlaySoundMenu(SFX_BlockHit);
+                        else
+                        {
+                            XLanguage::rotateLanguage(g_config.language, leftPressed ? -1 : 1);
+                            ReloadTranslations();
+                            PlaySoundMenu(SFX_Climbing);
+                        }
                     }
                     else if(MenuCursor == i++ && (menuDoPress || MenuMouseClick))
                     {
@@ -2143,8 +2150,14 @@ void mainMenuDraw()
             scale_str = &g_mainMenu.optionsScaleLinear;
 
         SuperPrint(fmt::format_ne("{0}: {1}", g_mainMenu.optionsScaleMode, *scale_str), 3, MenuX, MenuY + (30 * i++));
-        SuperPrint(fmt::format_ne("{0}: {1} ({2})", g_mainMenu.wordLanguage, g_mainMenu.languageName, g_config.language), 3, MenuX, MenuY + (30 * i++));
+
+        if(!FontManager::isInitied() || FontManager::isLegacy())
+            SuperPrint("Language: <missing \"fonts\">", 3, MenuX, MenuY + (30 * i++), 0.5f, 0.5f, 0.5f, 1.0f);
+        else
+            SuperPrint(fmt::format_ne("{0}: {1} ({2})", g_mainMenu.wordLanguage, g_mainMenu.languageName, g_config.language), 3, MenuX, MenuY + (30 * i++));
+
         SuperPrint(g_mainMenu.optionsViewCredits, 3, MenuX, MenuY + (30 * i++));
+
         XRender::renderTexture(MenuX - 20, MenuY + (MenuCursor * 30),
                                GFX.MCursor[0].w, GFX.MCursor[0].h, GFX.MCursor[0], 0, 0);
     }

--- a/src/main/translate.cpp
+++ b/src/main/translate.cpp
@@ -939,7 +939,7 @@ void XTechTranslate::updateLanguages(const std::string &outPath, bool noBlank)
 
 bool XTechTranslate::translate()
 {
-    if(!FontManager::isInitied())
+    if(!FontManager::isInitied() || FontManager::isLegacy())
     {
         pLogWarning("Translations aren't supported without new font engine loaded (the 'fonts' directory is required)");
         return false;

--- a/src/main/translate_episode.cpp
+++ b/src/main/translate_episode.cpp
@@ -32,6 +32,7 @@
 #include "layers.h"
 #endif
 
+#include "fontman/font_manager.h"
 #include "translate_episode.h"
 #define XTECH_TRANSLATE_EPISODE
 #include "translate/tr_title.h"
@@ -141,6 +142,12 @@ TranslateEpisode::TranslateEpisode()
 
 void TranslateEpisode::loadLevelTranslation(const std::string& key)
 {
+    if(!FontManager::isInitied() || FontManager::isLegacy())
+    {
+        pLogWarning("TranslateEpisode: Translations aren't supported without new font engine loaded (the 'fonts' directory is required)");
+        return;
+    }
+
     std::string langFile = getTrFile(FileName);
 
     if(langFile.empty())
@@ -161,6 +168,12 @@ void TranslateEpisode::loadLevelTranslation(const std::string& key)
 
 void TranslateEpisode::loadWorldTranslation(const std::string& key)
 {
+    if(!FontManager::isInitied() || FontManager::isLegacy())
+    {
+        pLogWarning("TranslateEpisode: Translations aren't supported without new font engine loaded (the 'fonts' directory is required)");
+        return;
+    }
+
     std::string langFile = getTrFile(FileNameWorld);
 
     if(langFile.empty())
@@ -183,6 +196,12 @@ void TranslateEpisode::loadLunaScript(const std::string& key)
 {
     m_scriptLines.clear();
     m_scriptTrId.clear();
+
+    if(!FontManager::isInitied() || FontManager::isLegacy())
+    {
+        pLogWarning("TranslateEpisode: Translations aren't supported without new font engine loaded (the 'fonts' directory is required)");
+        return;
+    }
 
     std::string langFile = getTrFile(FileName);
 
@@ -208,6 +227,12 @@ bool TranslateEpisode::tryTranslateTitle(const std::string& episodePath,
                                          const std::string& worldFile,
                                          std::string& output)
 {
+    if(!FontManager::isInitied() || FontManager::isLegacy())
+    {
+        pLogWarning("TranslateEpisode: Translations aren't supported without new font engine loaded (the 'fonts' directory is required)");
+        return false;
+    }
+
     std::string langFile = getTrFile(std::string(), episodePath);
 
     if(langFile.empty())
@@ -231,6 +256,12 @@ bool TranslateEpisode::tryTranslateTitle(const std::string& episodePath,
 
 void TranslateEpisode::trScriptLine(std::string& data, int line)
 {
+    if(!FontManager::isInitied() || FontManager::isLegacy())
+    {
+        pLogWarning("TranslateEpisode: Translations aren't supported without new font engine loaded (the 'fonts' directory is required)");
+        return;
+    }
+
     if(m_scriptLines.empty() && m_scriptTrId.empty())
         return;
 


### PR DESCRIPTION
This thing implements a legacy font engine as a part of modern font engine. So, when modern font fails to load for any reason (for example, when using old assets packages that lacks the `fonts` sub-directory), legacy fonts will take the place of new fonts. The new font manager will work as usually, but it will print using legacy built-in font textures.

Additionally, I made sure that translations won't load if fonts directory is missing. I tweaked the menu to gray out the languages item if fonts are missing.

Fixes #600
