### PR TITLE
Added an option: Don't grab shells from top fall

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ Changelog for 1.3.7-dev
 Changelog for 1.3.6.5-dev
 -Fix TheXTech 1.3.6 bug where auto movement on the world map was not reset when switching episodes (@ds-sloth)
 -Fix TheXTech 1.3.6 bug where dropping a player at the world map removed their mount (@ds-sloth)
+-Added a compat.ini option to disable the grabbing of the shell from the top falling to resolve soft-locking problems in early SMBX episodes (@Wohlstand)
 
 Changelog for 1.3.6.4
 -Use OpenGL as the default renderer on supported platforms ("sdl" may be used in config.ini or at at the command line to request the SDL2 renderer)

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -126,6 +126,8 @@ static void compatInit(Compatibility_t &c)
     c.fix_frame_perfect_despawn = true;
     // 1.3.6.3
     c.pound_by_alt_run = true;
+    // 1.3.6.5
+    c.allow_grab_from_top_fall = true;
     // 1.3.7
     c.modern_npc_camera_logic = true;
     c.allow_multires = true;
@@ -437,6 +439,8 @@ static void loadCompatIni(Compatibility_t &c, const std::string &fileName)
         compat.read("fix-frame-perfect-despawn", c.fix_frame_perfect_despawn, c.fix_frame_perfect_despawn);
         // 1.3.6.3
         // compat.read("pound-by-alt-run", c.pound_by_alt_run, c.pound_by_alt_run); // compat mode only flag
+        // 1.3.6.5
+        compat.read("allow-grab-from-top-fall", c.allow_grab_from_top_fall, c.allow_grab_from_top_fall);
         // 1.3.7 (but these will be changed in the Compat update)
         compat.read("modern-npc-camera-logic", c.modern_npc_camera_logic, c.modern_npc_camera_logic);
         compat.read("allow-multires", c.allow_multires, c.allow_multires);

--- a/src/compat.h
+++ b/src/compat.h
@@ -95,6 +95,8 @@ struct Compatibility_t
     unsigned int bitblit_background_colour[3];
     // 1.3.6.3
     bool pound_by_alt_run; // use alt run for pound action when player is in a purple pet mount
+    // 1.3.6.5
+    bool allow_grab_from_top_fall; // Allows grubbing of shells when jumping on them from the top
     // 1.3.7
     bool modern_npc_camera_logic; // NPCs should support more than two cameras, and consider the event logic camera when activating
     bool allow_multires;

--- a/src/player/player_update.cpp
+++ b/src/player/player_update.cpp
@@ -3913,7 +3913,9 @@ void UpdatePlayer()
                                             {
                                                 if(NPCIsABonus(NPC[B])) // Bonus
                                                     TouchBonus(A, B);
-                                                else if(NPCIsAShell(NPC[B]) && NPC[B].Location.SpeedX == 0 && Player[A].HoldingNPC == 0 && Player[A].Controls.Run)
+                                                else if(NPCIsAShell(NPC[B]) && NPC[B].Location.SpeedX == 0 &&
+                                                        Player[A].HoldingNPC == 0 && Player[A].Controls.Run &&
+                                                        g_compatibility.allow_grab_from_top_fall)
                                                 {
                                                     // grab turtle shells
                                                     //if(nPlay.Online == false || nPlay.MySlot + 1 == A)


### PR DESCRIPTION
This option disables an ability of player to grab a shell while stomping it from the top and holds the RUN button. It's very importand option to prevent soft-locks in ported legacy episodes where player can accidentally destroy a shell hidden in the niche which is required to continue the path.

## Default behaviour:
```ini
[compatibility]
allow-grab-from-top-fall = true
```
![Scr_2024-02-13_23-25-41](https://github.com/Wohlstand/TheXTech/assets/6751442/458eae86-9b0b-4fd9-a609-5caf02b94b07)

## When option is disabled:
```ini
[compatibility]
allow-grab-from-top-fall = false
```
![Scr_2024-02-13_23-25-31](https://github.com/Wohlstand/TheXTech/assets/6751442/fa49f3f2-89ae-4784-a193-f0f84fca7610)

