### PR TITLE
Fix compilation on newer MSVC versions

### DIFF
--- a/lib/fmt/fmt_format.h
+++ b/lib/fmt/fmt_format.h
@@ -59,7 +59,7 @@
 # define FMT_HAS_STRING_VIEW 0
 #endif
 
-#if defined _SECURE_SCL && _SECURE_SCL
+#if defined _SECURE_SCL && _SECURE_SCL && _MSC_VER < 1938
 # define FMT_SECURE_SCL _SECURE_SCL
 #else
 # define FMT_SECURE_SCL 0

--- a/lib/fmt/fmt_format.h
+++ b/lib/fmt/fmt_format.h
@@ -59,7 +59,7 @@
 # define FMT_HAS_STRING_VIEW 0
 #endif
 
-#if defined _SECURE_SCL && _SECURE_SCL && _MSC_VER < 1938
+#if defined _SECURE_SCL && _SECURE_SCL && defined _MSC_VER && _MSC_VER < 1938
 # define FMT_SECURE_SCL _SECURE_SCL
 #else
 # define FMT_SECURE_SCL 0


### PR DESCRIPTION
Trying to compile TheXTech using newer versions of MSVC (tested with the latest MSVC as of writing) leads to a build failure because of fmt's usage of `stdext::checked_array_iterator`, which was [deprecated in 2023](https://github.com/microsoft/STL/pull/3818) and [removed in 2025](https://github.com/microsoft/STL/pull/5817).

This PR fixes this by disabling the `FMT_SECURE_SCL` macro for versions of MSVC in which this class has been deprecated or removed.